### PR TITLE
Add mean() call to fix deferred error.

### DIFF
--- a/m09-estimation/m09-lab.ipynb
+++ b/m09-estimation/m09-lab.ipynb
@@ -868,17 +868,6 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/local/lib/python3.6/site-packages/ipykernel_launcher.py:2: FutureWarning: \n",
-      ".resample() is now a deferred operation\n",
-      "You called head(...) on this deferred object which materialized it into a dataframe\n",
-      "by implicitly taking the mean.  Use .resample(...).mean() instead\n",
-      "  \n"
-     ]
-    },
-    {
      "data": {
       "text/html": [
        "<div>\n",
@@ -1097,7 +1086,7 @@
     }
    ],
    "source": [
-    "upsampled = recent_co2.resample('D')\n",
+    "upsampled = recent_co2.resample('D').mean()\n",
     "upsampled.head(35)"
    ]
   },


### PR DESCRIPTION
The first cell that demonstrates resample() leaves off a call to mean(). In the Python version that was used to create the notebook this only results in a warning written to stderr, but in my version it results in an exception. This update just adds the call the mean() missing from the original.