### PR TITLE
Fixed links to .csv data files

### DIFF
--- a/m06-data/m06-lab.ipynb
+++ b/m06-data/m06-lab.ipynb
@@ -13,9 +13,9 @@
    "source": [
     "## Tidy data\n",
     "\n",
-    "Let's do some tidy exercise first. This is one of the non-tidy dataset assembled by Hadley Wickham (check out [here](https://github.com/tidyverse/tidyr/tree/master/vignettes) for more datasets, explanation, and R code). \n",
+    "Let's do some tidy exercise first. This is one of the non-tidy dataset assembled by Hadley Wickham (check out [here](https://github.com/tidyverse/tidyr/tree/4c0a8d0fdb9372302fcc57ad995d57a43d9e4337/vignettes) for more datasets, explanation, and R code). \n",
     "\n",
-    "Let's take a look at this small dataset: https://raw.githubusercontent.com/tidyverse/tidyr/master/vignettes/pew.csv"
+    "Let's take a look at this small dataset: https://raw.githubusercontent.com/tidyverse/tidyr/4c0a8d0fdb9372302fcc57ad995d57a43d9e4337/vignettes/pew.csv"
    ]
   },
   {


### PR DESCRIPTION
The CSV file referenced in this lab no longer exists. Upon exploring the history of the repository, I discovered that it was replaced with a condensed version in a format specific to R. 
To keep the module intact, I have changed the links to the most recently available version of the CSV file.