### PR TITLE
[M05] refactor: add remote url for plotted img

### DIFF
--- a/m05-design/lab.ipynb
+++ b/m05-design/lab.ipynb
@@ -506,7 +506,9 @@
         "id": "k97yjBzjy4ty"
       },
       "source": [
-        "img = mpimg.imread('sneakySnake.png')"
+        "img = mpimg.imread('sneakySnake.png')\n",
+        "# Or uncomment the next line if you've only imported the .ipynb into colab for example·\n",
+        "# img = mpimg.imread('https://raw.githubusercontent.com/yy/dviz-course/master/m05-design/sneakySnake.png')"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
For the lazy ones duplicating `.ipynb`files into Colab without the side-files.
Just referencing the `sneakSnake.png` from [github raw](https://raw.githubusercontent.com/yy/dviz-course/master/m05-design/sneakySnake.png) 