### PR TITLE
Removing User Metadata from Notebook

### DIFF
--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -26,5 +26,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate dviz
-          pip install nbmake pytest-xdist
+          jupyter kernelspec list
+          pip install nbmake pytest-xdist nbconvert
+          jupyter nbconvert --ClearMetadataPreprocessor.enabled=True --inplace **/**.ipynb
           pytest --nbmake -n=auto ./


### PR DESCRIPTION
Professor @yy , This PR addresses the below issues:

(1) One of the reasons for failing previous workflows was because of `kernelspec` name changes. For example, whenever I run any notebook in my system, the metadata (`kernelspec` of my system) gets saved in the notebook and if it merges to the original repository, it will create conflict. (Because my `kernelspec` will be different than yours).
(2) Pushing user metadata is anyway a very bad idea.


NOTE:
- User will not need to worry about removing the metadata. The workflow will take care of that.
- The Workflow will not remove **Cell Outputs** and **Execution Count**.
- The workflow will still fail because of placeholder errors in some of the notebooks.