### PR TITLE
M08 lab errors

### DIFF
--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -1,7 +1,7 @@
 name: pytest-notebooks
 
 # Run every time a new commit is pushed
-on: pull_request
+on: push
 
 jobs:
   # Set the job key

--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -1,7 +1,7 @@
 name: pytest-notebooks
 
 # Run every time a new commit is pushed
-on: push
+on: pull_request
 
 jobs:
   # Set the job key

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - ipykernel
   - numpy
   - scipy
-  - vega_datasets
+  - vega_datasets==0.9.0
   - matplotlib
   - pandas
   - altair

--- a/m08-histogram/m08-lab.ipynb
+++ b/m08-histogram/m08-lab.ipynb
@@ -1110,7 +1110,11 @@
       "cell_type": "code",
       "execution_count": null,
       "source": [
-        "np.histogram(movies['IMDB_Rating'])"
+        "# TODO: If below code gives ValueError with NaN, then there are still missing values in IMDB_Rating and you must remove it.\n",
+        "try:\n",
+        "    np.histogram(movies['IMDB_Rating'])\n",
+        "except ValueError as e:\n",
+        "    print(\"Resulted in ValueError:\", str(e))"
       ],
       "outputs": [
         {

--- a/m08-histogram/m08-lab.ipynb
+++ b/m08-histogram/m08-lab.ipynb
@@ -1,6 +1,6 @@
 {
   "nbformat": 4,
-  "nbformat_minor": 0,
+  "nbformat_minor": 2,
   "metadata": {
     "anaconda-cloud": {},
     "kernel_info": {
@@ -47,20 +47,18 @@
   "cells": [
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "uJaeks6I_G-4"
-      },
       "source": [
         "# Module 8: Histogram and CDF\n",
         "\n",
         "A deep dive into Histogram and boxplot."
-      ]
+      ],
+      "metadata": {
+        "id": "uJaeks6I_G-4"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "id": "a7PXB9c9_G-5"
-      },
+      "execution_count": null,
       "source": [
         "import matplotlib.pyplot as plt\n",
         "import numpy as np\n",
@@ -68,23 +66,18 @@
         "import altair as alt\n",
         "import pandas as pd"
       ],
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "metadata": {
+        "id": "a7PXB9c9_G-5"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "jupyter": {
-          "outputs_hidden": false
-        },
-        "id": "b05OkVl0_G-6",
-        "outputId": "5f126950-0ded-4241-e1a1-10469535d3ab"
-      },
+      "execution_count": null,
       "source": [
         "import matplotlib\n",
         "matplotlib.__version__"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -98,22 +91,26 @@
           },
           "execution_count": 2
         }
-      ]
+      ],
+      "metadata": {
+        "jupyter": {
+          "outputs_hidden": false
+        },
+        "id": "b05OkVl0_G-6",
+        "outputId": "5f126950-0ded-4241-e1a1-10469535d3ab"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "8_bJgIa-_G-7"
-      },
       "source": [
         "## The tricky histogram with pre-counted data"
-      ]
+      ],
+      "metadata": {
+        "id": "8_bJgIa-_G-7"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "BlKijZi6_G-7"
-      },
       "source": [
         "Let's revisit the table from the class\n",
         "\n",
@@ -124,42 +121,38 @@
         "| 3-5   | 4,900     |\n",
         "| 5-10  | 2,000     |\n",
         "| 10-24 | 2,100     |"
-      ]
+      ],
+      "metadata": {
+        "id": "BlKijZi6_G-7"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "TRqvntvf_G-8"
-      },
       "source": [
         "You can draw a histogram by just providing bins and counts instead of a list of numbers. So, let's try that. "
-      ]
+      ],
+      "metadata": {
+        "id": "TRqvntvf_G-8"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "id": "QZ4VOzrB_G-8"
-      },
+      "execution_count": null,
       "source": [
         "bins = [0, 1, 3, 5, 10, 24]\n",
         "data = {0.5: 4300, 2: 6900, 4: 4900, 7: 2000, 15: 2100} "
       ],
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "metadata": {
+        "id": "QZ4VOzrB_G-8"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "jupyter": {
-          "outputs_hidden": false
-        },
-        "id": "7gP0hDx8_G-8",
-        "outputId": "daaff1d3-a9b4-4ba0-9852-5d28bc591984"
-      },
+      "execution_count": null,
       "source": [
         "data.keys()"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -173,30 +166,30 @@
           },
           "execution_count": 4
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "29jcxJhc_G-9"
-      },
-      "source": [
-        "**Q: Draw histogram using this data.** Useful query: [Google search: matplotlib histogram pre-counted](https://www.google.com/search?client=safari&rls=en&q=matplotlib+histogram+already+counted&ie=UTF-8&oe=UTF-8#q=matplotlib+histogram+pre-counted)"
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "QVvYy95b_G-9",
-        "outputId": "b48aa7c4-f423-45a4-a8c1-32178eda04cb"
-      },
+        "id": "7gP0hDx8_G-8",
+        "outputId": "daaff1d3-a9b4-4ba0-9852-5d28bc591984"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "**Q: Draw histogram using this data.** Useful query: [Google search: matplotlib histogram pre-counted](https://www.google.com/search?client=safari&rls=en&q=matplotlib+histogram+already+counted&ie=UTF-8&oe=UTF-8#q=matplotlib+histogram+pre-counted)"
+      ],
+      "metadata": {
+        "id": "29jcxJhc_G-9"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "# TODO: draw a histogram with weighted data. \n"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -213,7 +206,7 @@
         {
           "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY8AAAEGCAYAAACdJRn3AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAWtElEQVR4nO3dfbRddX3n8fdHI/WhKiCB0oQYrFlW6lSMKdCl7diiPDk1OBUHlmuMDNO4WpzWNbNmBJfTOCgdnLE+MLZMY8k0UBXxkUxlSmPUatcMQlAKCtqkSiFNhqQGQURl0O/8cX63OcT7cHa4+57c3PdrrbvO3t/z2/t8N2fBh/1w9k5VIUlSF48bdwOSpPnH8JAkdWZ4SJI6MzwkSZ0ZHpKkzhaNu4E+HHXUUbV8+fJxtyFJ88ott9zyD1W1eJSxh2R4LF++nK1bt467DUmaV5L83ahjPWwlSerM8JAkdWZ4SJI66y08kjwnya1Dfw8keWOSI5NsTrKtvR7RxifJ5Um2J7ktycqhda1p47clWdNXz5Kk0fQWHlX19ao6sapOBF4IPAR8ArgI2FJVK4AtbR7gTGBF+1sLXAGQ5EhgHXAycBKwbiJwJEnjMVeHrU4F/raq/g5YDWxs9Y3A2W16NXBVDdwIHJ7kWOB0YHNV7a2q+4DNwBlz1LckaRJzFR7nAh9q08dU1S6A9np0qy8B7hlaZkerTVV/lCRrk2xNsnXPnj2z3L4kaVjv4ZHkMOAVwEdmGjpJraapP7pQtb6qVlXVqsWLR/qNiyTpAM3FnseZwJeq6t42f287HEV73d3qO4DjhpZbCuycpi5JGpO5+IX5eew7ZAWwCVgDXNZerxuqvyHJNQxOjt9fVbuS3AD83tBJ8tOAi+eg75Etv+hTc/I5d1328jn5HEmaSa/hkeTJwMuA1w+VLwOuTXIBcDdwTqtfD5wFbGdwZdb5AFW1N8nbgJvbuEuqam+ffUuSptdreFTVQ8Az9qt9i8HVV/uPLeDCKdazAdjQR4+SpO78hbkkqTPDQ5LUmeEhSerM8JAkdWZ4SJI6MzwkSZ0ZHpKkzgwPSVJnhockqTPDQ5LUmeEhSerM8JAkdWZ4SJI6MzwkSZ0ZHpKkzgwPSVJnhockqTPDQ5LUmeEhSerM8JAkdWZ4SJI66zU8khye5KNJvpbkziS/mOTIJJuTbGuvR7SxSXJ5ku1Jbkuycmg9a9r4bUnW9NmzJGlmfe95vBf486r6WeD5wJ3ARcCWqloBbGnzAGcCK9rfWuAKgCRHAuuAk4GTgHUTgSNJGo/ewiPJ04BfBq4EqKqHq+rbwGpgYxu2ETi7Ta8GrqqBG4HDkxwLnA5srqq9VXUfsBk4o6++JUkz63PP41nAHuB/JPlykj9O8hTgmKraBdBej27jlwD3DC2/o9Wmqj9KkrVJtibZumfPntnfGknSP+ozPBYBK4ErquoFwHfZd4hqMpmkVtPUH12oWl9Vq6pq1eLFiw+kX0nSiPoMjx3Ajqr6Ypv/KIMwubcdjqK97h4af9zQ8kuBndPUJUlj0lt4VNX/Be5J8pxWOhW4A9gETFwxtQa4rk1vAl7brro6Bbi/Hda6ATgtyRHtRPlprSZJGpNFPa//3wAfSHIY8A3gfAaBdW2SC4C7gXPa2OuBs4DtwENtLFW1N8nbgJvbuEuqam/PfUuSptFreFTVrcCqSd46dZKxBVw4xXo2ABtmtztJ0oHyF+aSpM4MD0lSZ4aHJKkzw0OS1JnhIUnqzPCQJHVmeEiSOjM8JEmdGR6SpM4MD0lSZ4aHJKkzw0OS1JnhIUnqzPCQJHVmeEiSOjM8JEmdGR6SpM4MD0lSZ4aHJKkzw0OS1JnhIUnqrNfwSHJXktuT3Jpka6sdmWRzkm3t9YhWT5LLk2xPcluSlUPrWdPGb0uyps+eJUkzm4s9j1+pqhOralWbvwjYUlUrgC1tHuBMYEX7WwtcAYOwAdYBJwMnAesmAkeSNB7jOGy1GtjYpjcCZw/Vr6qBG4HDkxwLnA5srqq9VXUfsBk4Y66bliTt03d4FPAXSW5JsrbVjqmqXQDt9ehWXwLcM7Tsjlabqv4oSdYm2Zpk6549e2Z5MyRJwxb1vP4XVdXOJEcDm5N8bZqxmaRW09QfXahaD6wHWLVq1Y+9L0maPb3ueVTVzva6G/gEg3MW97bDUbTX3W34DuC4ocWXAjunqUuSxqS3PY8kTwEeV1XfadOnAZcAm4A1wGXt9bq2yCbgDUmuYXBy/P6q2pXkBuD3hk6SnwZc3FffB7PlF32q98+467KX9/4Zkua/Pg9bHQN8IsnE53ywqv48yc3AtUkuAO4GzmnjrwfOArYDDwHnA1TV3iRvA25u4y6pqr099i1JmkFv4VFV3wCeP0n9W8Cpk9QLuHCKdW0ANsx2j5KkA+MvzCVJnRkekqTODA9JUmeGhySpM8NDktSZ4SFJ6szwkCR1ZnhIkjozPCRJnRkekqTODA9JUmcjhUeS5/XdiCRp/hh1z+O/J7kpyW8lObzXjiRJB72RwqOqXgy8hsFDmbYm+WCSl/XamSTpoDXyOY+q2ga8BXgT8E+By5N8Lck/76s5SdLBaaTneST5eQYPZ3o5sBn4tar6UpKfBv4P8PH+Wpx7c/HEPkmaz0Z9GNT7gPcDb66q700Uq2pnkrf00pkk6aA1anicBXyvqn4IkORxwBOr6qGqurq37iRJB6VRz3l8GnjS0PyTW02StACNGh5PrKoHJ2ba9JP7aUmSdLAbNTy+m2TlxEySFwLfm2a8JOkQNmp4vBH4SJIvJPkC8GHgDaMsmOTxSb6c5M/a/PFJvphkW5IPJzms1X+izW9v7y8fWsfFrf71JKd32UBJ0uwb9UeCNwM/C/wm8FvAc6vqlhE/43eAO4fm3wG8u6pWAPcBF7T6BcB9VfVs4N1tHElOAM4Ffg44A/jDJI8f8bMlST3ocmPEXwB+HngBcF6S1860QJKlDH4b8sdtPsCvAh9tQzYCZ7fp1W2e9v6pbfxq4Jqq+kFVfRPYDpzUoW9J0iwb9UeCVwM/A9wK/LCVC7hqhkXfA/wH4Klt/hnAt6vqkTa/A1jSppcA9wBU1SNJ7m/jlwA3Dq1zeJnhHtcCawGWLVs2ymZJkg7QqL/zWAWcUFU16oqT/DNgd1XdkuQlE+VJhtYM7023zL5C1XpgPcCqVatG7lOS1N2o4fEV4KeAXR3W/SLgFUnOAp4IPI3BnsjhSRa1vY+lwM42fgeDGy/uSLIIeDqwd6g+YXgZSdIYjHrO4yjgjiQ3JNk08TfdAlV1cVUtrarlDE54f6aqXgN8FnhVG7YGuK5Nb2rztPc/0/Z0NgHntquxjgdWADeN2LckqQej7nm8dRY/803ANUneDnwZuLLVrwSuTrKdwR7HuQBV9dUk1wJ3AI8AF07cJkWSNB4jhUdV/WWSZwIrqurTSZ4MjHy5bFV9Dvhcm/4Gk1wtVVXfB86ZYvlLgUtH/TxJUr9GfQztbzC4fPaPWmkJ8Mm+mpIkHdxGPedxIYMT4A/APz4Y6ui+mpIkHdxGDY8fVNXDEzPtaigvh5WkBWrU8PjLJG8GntSeXf4R4H/215Yk6WA2anhcBOwBbgdeD1zP4HnmkqQFaNSrrX7E4DG07++3HUnSfDDqva2+yeS3BHnWrHckSTrodbm31YQnMvg9xpGz344kaT4Y9Xke3xr6+/uqeg+DW6tLkhagUQ9brRyafRyDPZGnTjFcknSIG/Ww1e8PTT8C3AW8eta7kSTNC6NebfUrfTciSZo/Rj1s9W+ne7+q3jU77UiS5oMuV1v9AoNnawD8GvB52mNjJUkLy6jhcRSwsqq+A5DkrcBHqupf99WYJOngNertSZYBDw/NPwwsn/VuJEnzwqh7HlcDNyX5BINfmr8SuKq3riRJB7VRr7a6NMn/An6plc6vqi/315Yk6WA26mErgCcDD1TVe4EdSY7vqSdJ0kFu1MfQrgPeBFzcSk8A/rSvpiRJB7dR9zxeCbwC+C5AVe3E25NI0oI1ang8XFVFuy17kqfMtECSJya5KclfJ/lqkv/U6scn+WKSbUk+nOSwVv+JNr+9vb98aF0Xt/rXk5zedSMlSbNr1PC4NskfAYcn+Q3g08z8YKgfAL9aVc8HTgTOSHIK8A7g3VW1ArgPuKCNvwC4r6qeDby7jSPJCcC5wM8BZwB/mOTxo26gJGn2jXpL9ncCHwU+BjwH+N2q+m8zLFNV9WCbfUL7Kwa3cv9oq28Ezm7Tq9s87f1Tk6TVr6mqH1TVN4HtwEmj9C1J6seMl+q2/8u/oapeCmzusvK27C3As4E/AP4W+HZVPdKG7ACWtOkltNudVNUjSe4HntHqNw6tdniZ4c9aC6wFWLZsWZc2JUkdzbjnUVU/BB5K8vSuK6+qH1bVicBSBnsLz51sWHvNFO9NVd//s9ZX1aqqWrV48eKurUqSOhj1F+bfB25Pspl2xRVAVf32KAtX1beTfA44hcF5k0Vt72MpsLMN2wEcx+A3JIuApwN7h+oThpeRJI3BqCfMPwX8RwZ30r1l6G9KSRYnObxNPwl4KXAn8FngVW3YGuC6Nr2pzdPe/0y7wmsTcG67Gut4YAVw04h9S5J6MO2eR5JlVXV3VW2cbtwUjgU2tvMejwOurao/S3IHcE2StwNfBq5s468Erk6yncEex7kAVfXVJNcCdzB4iuGF7VCaJGlMZjps9UlgJUCSj1XVr4+64qq6DXjBJPVvMMnVUlX1feCcKdZ1KXDpqJ8tSerXTIethk9WP6vPRiRJ88dM4VFTTEuSFrCZDls9P8kDDPZAntSmafNVVU/rtTtJ0kFp2vCoKm8DIkn6MV2e5yFJEmB4SJIOgOEhSerM8JAkdWZ4SJI6MzwkSZ0ZHpKkzgwPSVJnhockqTPDQ5LUmeEhSerM8JAkdWZ4SJI6MzwkSZ0ZHpKkzgwPSVJnhockqbOZHkN7wJIcB1wF/BTwI2B9Vb03yZHAh4HlwF3Aq6vqviQB3gucBTwEvK6qvtTWtQZ4S1v126tqY199a+FaftGnxt2C9JjdddnL5+Rz+tzzeAT4d1X1XOAU4MIkJwAXAVuqagWwpc0DnAmsaH9rgSsAWtisA04GTgLWJTmix74lSTPoLTyqatfEnkNVfQe4E1gCrAYm9hw2Ame36dXAVTVwI3B4kmOB04HNVbW3qu4DNgNn9NW3JGlmvR22GpZkOfAC4IvAMVW1CwYBk+ToNmwJcM/QYjtabar6/p+xlsEeC8uWLZvdDVhAPHQjaRS9nzBP8pPAx4A3VtUD0w2dpFbT1B9dqFpfVauqatXixYsPrFlJ0kh6DY8kT2AQHB+oqo+38r3tcBTtdXer7wCOG1p8KbBzmrokaUx6C4929dSVwJ1V9a6htzYBa9r0GuC6ofprM3AKcH87vHUDcFqSI9qJ8tNaTZI0Jn2e83gR8C+B25Pc2mpvBi4Drk1yAXA3cE5773oGl+luZ3Cp7vkAVbU3yduAm9u4S6pqb499S5Jm0Ft4VNVfMfn5CoBTJxlfwIVTrGsDsGH2upMkPRb+wlyS1JnhIUnqzPCQJHVmeEiSOjM8JEmdGR6SpM4MD0lSZ4aHJKkzw0OS1JnhIUnqzPCQJHVmeEiSOjM8JEmdGR6SpM4MD0lSZ4aHJKkzw0OS1JnhIUnqzPCQJHVmeEiSOjM8JEmd9RYeSTYk2Z3kK0O1I5NsTrKtvR7R6klyeZLtSW5LsnJomTVt/LYka/rqV5I0uj73PP4EOGO/2kXAlqpaAWxp8wBnAiva31rgChiEDbAOOBk4CVg3ETiSpPHpLTyq6vPA3v3Kq4GNbXojcPZQ/aoauBE4PMmxwOnA5qraW1X3AZv58UCSJM2xuT7ncUxV7QJor0e3+hLgnqFxO1ptqvqPSbI2ydYkW/fs2TPrjUuS9jlYTphnklpNU//xYtX6qlpVVasWL148q81Jkh5trsPj3nY4iva6u9V3AMcNjVsK7JymLkkao7kOj03AxBVTa4DrhuqvbVddnQLc3w5r3QCcluSIdqL8tFaTJI3Ror5WnORDwEuAo5LsYHDV1GXAtUkuAO4GzmnDrwfOArYDDwHnA1TV3iRvA25u4y6pqv1PwkuS5lhv4VFV503x1qmTjC3gwinWswHYMIutSZIeo4PlhLkkaR4xPCRJnRkekqTODA9JUmeGhySpM8NDktSZ4SFJ6szwkCR1ZnhIkjozPCRJnRkekqTODA9JUmeGhySpM8NDktSZ4SFJ6szwkCR1ZnhIkjozPCRJnRkekqTODA9JUmeGhySps3kTHknOSPL1JNuTXDTufiRpIZsX4ZHk8cAfAGcCJwDnJTlhvF1J0sI1L8IDOAnYXlXfqKqHgWuA1WPuSZIWrEXjbmBES4B7huZ3ACcPD0iyFljbZh9M8vXH8HlHAf/wGJafz9z2hWshb/8hs+15xwEtNrH9zxx1gfkSHpmkVo+aqVoPrJ+VD0u2VtWq2VjXfOO2L8xth4W9/Qt52+HAtn++HLbaARw3NL8U2DmmXiRpwZsv4XEzsCLJ8UkOA84FNo25J0lasObFYauqeiTJG4AbgMcDG6rqqz1+5Kwc/pqn3PaFayFv/0LedjiA7U9VzTxKkqQh8+WwlSTpIGJ4SJI6MzyGLPRboCS5K8ntSW5NsnXc/fQpyYYku5N8Zah2ZJLNSba11yPG2WOfptj+tyb5+/b935rkrHH22JckxyX5bJI7k3w1ye+0+iH//U+z7Z2/e895NO0WKH8DvIzBpcE3A+dV1R1jbWwOJbkLWFVVh8SPpaaT5JeBB4Grqup5rfZfgL1VdVn7n4cjqupN4+yzL1Ns/1uBB6vqnePsrW9JjgWOraovJXkqcAtwNvA6DvHvf5ptfzUdv3v3PPbxFigLSFV9Hti7X3k1sLFNb2TwL9UhaYrtXxCqaldVfalNfwe4k8FdLA7573+abe/M8NhnslugHNA/1HmsgL9Icku73ctCc0xV7YLBv2TA0WPuZxzekOS2dljrkDtss78ky4EXAF9kgX3/+207dPzuDY99ZrwFygLwoqpayeDuxRe2QxtaOK4AfgY4EdgF/P542+lXkp8EPga8saoeGHc/c2mSbe/83Rse+yz4W6BU1c72uhv4BINDeQvJve2Y8MSx4d1j7mdOVdW9VfXDqvoR8H4O4e8/yRMY/MfzA1X18VZeEN//ZNt+IN+94bHPgr4FSpKntBNoJHkKcBrwlemXOuRsAta06TXAdWPsZc5N/IezeSWH6PefJMCVwJ1V9a6htw7573+qbT+Q796rrYa0y9Pew75boFw65pbmTJJnMdjbgMFtaz54KG9/kg8BL2FwK+p7gXXAJ4FrgWXA3cA5VXVInlSeYvtfwuCwRQF3Aa+fOAdwKEnyYuALwO3Aj1r5zQyO/R/S3/80234eHb97w0OS1JmHrSRJnRkekqTODA9JUmeGhySpM8NDktSZ4SEdoCQP7jf/uiTvG1c/0lwyPKSDTLvDs3RQMzykHiR5ZpIt7UZzW5Isa/U/SfKqoXEPtteXtOcsfBC4vf3i/1NJ/jrJV5L8izFtijSpReNuQJrHnpTk1qH5I9l3S5v3MXhWxsYk/wq4nJlv8X0S8Lyq+maSXwd2VtXLAZI8fZZ7lx4T9zykA/e9qjpx4g/43aH3fhH4YJu+GnjxCOu7qaq+2aZvB16a5B1Jfqmq7p+9tqXHzvCQ5sbEfYAeof17125Sd9jQmO/+4+CqvwFeyCBE/nOS4WCSxs7wkPrxvxncmRngNcBftem7GIQCDJ5c94TJFk7y08BDVfWnwDuBlb11Kh0Az3lI/fhtYEOSfw/sAc5v9fcD1yW5CdjC0N7Gfv4J8F+T/Aj4f8Bv9tyv1Il31ZUkdeZhK0lSZ4aHJKkzw0OS1JnhIUnqzPCQJHVmeEiSOjM8JEmd/X/2mOv7GfAvCgAAAABJRU5ErkJggg==\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY8AAAEGCAYAAACdJRn3AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAWtElEQVR4nO3dfbRddX3n8fdHI/WhKiCB0oQYrFlW6lSMKdCl7diiPDk1OBUHlmuMDNO4WpzWNbNmBJfTOCgdnLE+MLZMY8k0UBXxkUxlSmPUatcMQlAKCtqkSiFNhqQGQURl0O/8cX63OcT7cHa4+57c3PdrrbvO3t/z2/t8N2fBh/1w9k5VIUlSF48bdwOSpPnH8JAkdWZ4SJI6MzwkSZ0ZHpKkzhaNu4E+HHXUUbV8+fJxtyFJ88ott9zyD1W1eJSxh2R4LF++nK1bt467DUmaV5L83ahjPWwlSerM8JAkdWZ4SJI66y08kjwnya1Dfw8keWOSI5NsTrKtvR7RxifJ5Um2J7ktycqhda1p47clWdNXz5Kk0fQWHlX19ao6sapOBF4IPAR8ArgI2FJVK4AtbR7gTGBF+1sLXAGQ5EhgHXAycBKwbiJwJEnjMVeHrU4F/raq/g5YDWxs9Y3A2W16NXBVDdwIHJ7kWOB0YHNV7a2q+4DNwBlz1LckaRJzFR7nAh9q08dU1S6A9np0qy8B7hlaZkerTVV/lCRrk2xNsnXPnj2z3L4kaVjv4ZHkMOAVwEdmGjpJraapP7pQtb6qVlXVqsWLR/qNiyTpAM3FnseZwJeq6t42f287HEV73d3qO4DjhpZbCuycpi5JGpO5+IX5eew7ZAWwCVgDXNZerxuqvyHJNQxOjt9fVbuS3AD83tBJ8tOAi+eg75Etv+hTc/I5d1328jn5HEmaSa/hkeTJwMuA1w+VLwOuTXIBcDdwTqtfD5wFbGdwZdb5AFW1N8nbgJvbuEuqam+ffUuSptdreFTVQ8Az9qt9i8HVV/uPLeDCKdazAdjQR4+SpO78hbkkqTPDQ5LUmeEhSerM8JAkdWZ4SJI6MzwkSZ0ZHpKkzgwPSVJnhockqTPDQ5LUmeEhSerM8JAkdWZ4SJI6MzwkSZ0ZHpKkzgwPSVJnhockqTPDQ5LUmeEhSerM8JAkdWZ4SJI66zU8khye5KNJvpbkziS/mOTIJJuTbGuvR7SxSXJ5ku1Jbkuycmg9a9r4bUnW9NmzJGlmfe95vBf486r6WeD5wJ3ARcCWqloBbGnzAGcCK9rfWuAKgCRHAuuAk4GTgHUTgSNJGo/ewiPJ04BfBq4EqKqHq+rbwGpgYxu2ETi7Ta8GrqqBG4HDkxwLnA5srqq9VXUfsBk4o6++JUkz63PP41nAHuB/JPlykj9O8hTgmKraBdBej27jlwD3DC2/o9Wmqj9KkrVJtibZumfPntnfGknSP+ozPBYBK4ErquoFwHfZd4hqMpmkVtPUH12oWl9Vq6pq1eLFiw+kX0nSiPoMjx3Ajqr6Ypv/KIMwubcdjqK97h4af9zQ8kuBndPUJUlj0lt4VNX/Be5J8pxWOhW4A9gETFwxtQa4rk1vAl7brro6Bbi/Hda6ATgtyRHtRPlprSZJGpNFPa//3wAfSHIY8A3gfAaBdW2SC4C7gXPa2OuBs4DtwENtLFW1N8nbgJvbuEuqam/PfUuSptFreFTVrcCqSd46dZKxBVw4xXo2ABtmtztJ0oHyF+aSpM4MD0lSZ4aHJKkzw0OS1JnhIUnqzPCQJHVmeEiSOjM8JEmdGR6SpM4MD0lSZ4aHJKkzw0OS1JnhIUnqzPCQJHVmeEiSOjM8JEmdGR6SpM4MD0lSZ4aHJKkzw0OS1JnhIUnqrNfwSHJXktuT3Jpka6sdmWRzkm3t9YhWT5LLk2xPcluSlUPrWdPGb0uyps+eJUkzm4s9j1+pqhOralWbvwjYUlUrgC1tHuBMYEX7WwtcAYOwAdYBJwMnAesmAkeSNB7jOGy1GtjYpjcCZw/Vr6qBG4HDkxwLnA5srqq9VXUfsBk4Y66bliTt03d4FPAXSW5JsrbVjqmqXQDt9ehWXwLcM7Tsjlabqv4oSdYm2Zpk6549e2Z5MyRJwxb1vP4XVdXOJEcDm5N8bZqxmaRW09QfXahaD6wHWLVq1Y+9L0maPb3ueVTVzva6G/gEg3MW97bDUbTX3W34DuC4ocWXAjunqUuSxqS3PY8kTwEeV1XfadOnAZcAm4A1wGXt9bq2yCbgDUmuYXBy/P6q2pXkBuD3hk6SnwZc3FffB7PlF32q98+467KX9/4Zkua/Pg9bHQN8IsnE53ywqv48yc3AtUkuAO4GzmnjrwfOArYDDwHnA1TV3iRvA25u4y6pqr099i1JmkFv4VFV3wCeP0n9W8Cpk9QLuHCKdW0ANsx2j5KkA+MvzCVJnRkekqTODA9JUmeGhySpM8NDktSZ4SFJ6szwkCR1ZnhIkjozPCRJnRkekqTODA9JUmcjhUeS5/XdiCRp/hh1z+O/J7kpyW8lObzXjiRJB72RwqOqXgy8hsFDmbYm+WCSl/XamSTpoDXyOY+q2ga8BXgT8E+By5N8Lck/76s5SdLBaaTneST5eQYPZ3o5sBn4tar6UpKfBv4P8PH+Wpx7c/HEPkmaz0Z9GNT7gPcDb66q700Uq2pnkrf00pkk6aA1anicBXyvqn4IkORxwBOr6qGqurq37iRJB6VRz3l8GnjS0PyTW02StACNGh5PrKoHJ2ba9JP7aUmSdLAbNTy+m2TlxEySFwLfm2a8JOkQNmp4vBH4SJIvJPkC8GHgDaMsmOTxSb6c5M/a/PFJvphkW5IPJzms1X+izW9v7y8fWsfFrf71JKd32UBJ0uwb9UeCNwM/C/wm8FvAc6vqlhE/43eAO4fm3wG8u6pWAPcBF7T6BcB9VfVs4N1tHElOAM4Ffg44A/jDJI8f8bMlST3ocmPEXwB+HngBcF6S1860QJKlDH4b8sdtPsCvAh9tQzYCZ7fp1W2e9v6pbfxq4Jqq+kFVfRPYDpzUoW9J0iwb9UeCVwM/A9wK/LCVC7hqhkXfA/wH4Klt/hnAt6vqkTa/A1jSppcA9wBU1SNJ7m/jlwA3Dq1zeJnhHtcCawGWLVs2ymZJkg7QqL/zWAWcUFU16oqT/DNgd1XdkuQlE+VJhtYM7023zL5C1XpgPcCqVatG7lOS1N2o4fEV4KeAXR3W/SLgFUnOAp4IPI3BnsjhSRa1vY+lwM42fgeDGy/uSLIIeDqwd6g+YXgZSdIYjHrO4yjgjiQ3JNk08TfdAlV1cVUtrarlDE54f6aqXgN8FnhVG7YGuK5Nb2rztPc/0/Z0NgHntquxjgdWADeN2LckqQej7nm8dRY/803ANUneDnwZuLLVrwSuTrKdwR7HuQBV9dUk1wJ3AI8AF07cJkWSNB4jhUdV/WWSZwIrqurTSZ4MjHy5bFV9Dvhcm/4Gk1wtVVXfB86ZYvlLgUtH/TxJUr9GfQztbzC4fPaPWmkJ8Mm+mpIkHdxGPedxIYMT4A/APz4Y6ui+mpIkHdxGDY8fVNXDEzPtaigvh5WkBWrU8PjLJG8GntSeXf4R4H/215Yk6WA2anhcBOwBbgdeD1zP4HnmkqQFaNSrrX7E4DG07++3HUnSfDDqva2+yeS3BHnWrHckSTrodbm31YQnMvg9xpGz344kaT4Y9Xke3xr6+/uqeg+DW6tLkhagUQ9brRyafRyDPZGnTjFcknSIG/Ww1e8PTT8C3AW8eta7kSTNC6NebfUrfTciSZo/Rj1s9W+ne7+q3jU77UiS5oMuV1v9AoNnawD8GvB52mNjJUkLy6jhcRSwsqq+A5DkrcBHqupf99WYJOngNertSZYBDw/NPwwsn/VuJEnzwqh7HlcDNyX5BINfmr8SuKq3riRJB7VRr7a6NMn/An6plc6vqi/315Yk6WA26mErgCcDD1TVe4EdSY7vqSdJ0kFu1MfQrgPeBFzcSk8A/rSvpiRJB7dR9zxeCbwC+C5AVe3E25NI0oI1ang8XFVFuy17kqfMtECSJya5KclfJ/lqkv/U6scn+WKSbUk+nOSwVv+JNr+9vb98aF0Xt/rXk5zedSMlSbNr1PC4NskfAYcn+Q3g08z8YKgfAL9aVc8HTgTOSHIK8A7g3VW1ArgPuKCNvwC4r6qeDby7jSPJCcC5wM8BZwB/mOTxo26gJGn2jXpL9ncCHwU+BjwH+N2q+m8zLFNV9WCbfUL7Kwa3cv9oq28Ezm7Tq9s87f1Tk6TVr6mqH1TVN4HtwEmj9C1J6seMl+q2/8u/oapeCmzusvK27C3As4E/AP4W+HZVPdKG7ACWtOkltNudVNUjSe4HntHqNw6tdniZ4c9aC6wFWLZsWZc2JUkdzbjnUVU/BB5K8vSuK6+qH1bVicBSBnsLz51sWHvNFO9NVd//s9ZX1aqqWrV48eKurUqSOhj1F+bfB25Pspl2xRVAVf32KAtX1beTfA44hcF5k0Vt72MpsLMN2wEcx+A3JIuApwN7h+oThpeRJI3BqCfMPwX8RwZ30r1l6G9KSRYnObxNPwl4KXAn8FngVW3YGuC6Nr2pzdPe/0y7wmsTcG67Gut4YAVw04h9S5J6MO2eR5JlVXV3VW2cbtwUjgU2tvMejwOurao/S3IHcE2StwNfBq5s468Erk6yncEex7kAVfXVJNcCdzB4iuGF7VCaJGlMZjps9UlgJUCSj1XVr4+64qq6DXjBJPVvMMnVUlX1feCcKdZ1KXDpqJ8tSerXTIethk9WP6vPRiRJ88dM4VFTTEuSFrCZDls9P8kDDPZAntSmafNVVU/rtTtJ0kFp2vCoKm8DIkn6MV2e5yFJEmB4SJIOgOEhSerM8JAkdWZ4SJI6MzwkSZ0ZHpKkzgwPSVJnhockqTPDQ5LUmeEhSerM8JAkdWZ4SJI6MzwkSZ0ZHpKkzgwPSVJnhockqbOZHkN7wJIcB1wF/BTwI2B9Vb03yZHAh4HlwF3Aq6vqviQB3gucBTwEvK6qvtTWtQZ4S1v126tqY199a+FaftGnxt2C9JjdddnL5+Rz+tzzeAT4d1X1XOAU4MIkJwAXAVuqagWwpc0DnAmsaH9rgSsAWtisA04GTgLWJTmix74lSTPoLTyqatfEnkNVfQe4E1gCrAYm9hw2Ame36dXAVTVwI3B4kmOB04HNVbW3qu4DNgNn9NW3JGlmvR22GpZkOfAC4IvAMVW1CwYBk+ToNmwJcM/QYjtabar6/p+xlsEeC8uWLZvdDVhAPHQjaRS9nzBP8pPAx4A3VtUD0w2dpFbT1B9dqFpfVauqatXixYsPrFlJ0kh6DY8kT2AQHB+oqo+38r3tcBTtdXer7wCOG1p8KbBzmrokaUx6C4929dSVwJ1V9a6htzYBa9r0GuC6ofprM3AKcH87vHUDcFqSI9qJ8tNaTZI0Jn2e83gR8C+B25Pc2mpvBi4Drk1yAXA3cE5773oGl+luZ3Cp7vkAVbU3yduAm9u4S6pqb499S5Jm0Ft4VNVfMfn5CoBTJxlfwIVTrGsDsGH2upMkPRb+wlyS1JnhIUnqzPCQJHVmeEiSOjM8JEmdGR6SpM4MD0lSZ4aHJKkzw0OS1JnhIUnqzPCQJHVmeEiSOjM8JEmdGR6SpM4MD0lSZ4aHJKkzw0OS1JnhIUnqzPCQJHVmeEiSOjM8JEmd9RYeSTYk2Z3kK0O1I5NsTrKtvR7R6klyeZLtSW5LsnJomTVt/LYka/rqV5I0uj73PP4EOGO/2kXAlqpaAWxp8wBnAiva31rgChiEDbAOOBk4CVg3ETiSpPHpLTyq6vPA3v3Kq4GNbXojcPZQ/aoauBE4PMmxwOnA5qraW1X3AZv58UCSJM2xuT7ncUxV7QJor0e3+hLgnqFxO1ptqvqPSbI2ydYkW/fs2TPrjUuS9jlYTphnklpNU//xYtX6qlpVVasWL148q81Jkh5trsPj3nY4iva6u9V3AMcNjVsK7JymLkkao7kOj03AxBVTa4DrhuqvbVddnQLc3w5r3QCcluSIdqL8tFaTJI3Ror5WnORDwEuAo5LsYHDV1GXAtUkuAO4GzmnDrwfOArYDDwHnA1TV3iRvA25u4y6pqv1PwkuS5lhv4VFV503x1qmTjC3gwinWswHYMIutSZIeo4PlhLkkaR4xPCRJnRkekqTODA9JUmeGhySpM8NDktSZ4SFJ6szwkCR1ZnhIkjozPCRJnRkekqTODA9JUmeGhySpM8NDktSZ4SFJ6szwkCR1ZnhIkjozPCRJnRkekqTODA9JUmeGhySps3kTHknOSPL1JNuTXDTufiRpIZsX4ZHk8cAfAGcCJwDnJTlhvF1J0sI1L8IDOAnYXlXfqKqHgWuA1WPuSZIWrEXjbmBES4B7huZ3ACcPD0iyFljbZh9M8vXH8HlHAf/wGJafz9z2hWshb/8hs+15xwEtNrH9zxx1gfkSHpmkVo+aqVoPrJ+VD0u2VtWq2VjXfOO2L8xth4W9/Qt52+HAtn++HLbaARw3NL8U2DmmXiRpwZsv4XEzsCLJ8UkOA84FNo25J0lasObFYauqeiTJG4AbgMcDG6rqqz1+5Kwc/pqn3PaFayFv/0LedjiA7U9VzTxKkqQh8+WwlSTpIGJ4SJI6MzyGLPRboCS5K8ntSW5NsnXc/fQpyYYku5N8Zah2ZJLNSba11yPG2WOfptj+tyb5+/b935rkrHH22JckxyX5bJI7k3w1ye+0+iH//U+z7Z2/e895NO0WKH8DvIzBpcE3A+dV1R1jbWwOJbkLWFVVh8SPpaaT5JeBB4Grqup5rfZfgL1VdVn7n4cjqupN4+yzL1Ns/1uBB6vqnePsrW9JjgWOraovJXkqcAtwNvA6DvHvf5ptfzUdv3v3PPbxFigLSFV9Hti7X3k1sLFNb2TwL9UhaYrtXxCqaldVfalNfwe4k8FdLA7573+abe/M8NhnslugHNA/1HmsgL9Icku73ctCc0xV7YLBv2TA0WPuZxzekOS2dljrkDtss78ky4EXAF9kgX3/+207dPzuDY99ZrwFygLwoqpayeDuxRe2QxtaOK4AfgY4EdgF/P542+lXkp8EPga8saoeGHc/c2mSbe/83Rse+yz4W6BU1c72uhv4BINDeQvJve2Y8MSx4d1j7mdOVdW9VfXDqvoR8H4O4e8/yRMY/MfzA1X18VZeEN//ZNt+IN+94bHPgr4FSpKntBNoJHkKcBrwlemXOuRsAta06TXAdWPsZc5N/IezeSWH6PefJMCVwJ1V9a6htw7573+qbT+Q796rrYa0y9Pew75boFw65pbmTJJnMdjbgMFtaz54KG9/kg8BL2FwK+p7gXXAJ4FrgWXA3cA5VXVInlSeYvtfwuCwRQF3Aa+fOAdwKEnyYuALwO3Aj1r5zQyO/R/S3/80234eHb97w0OS1JmHrSRJnRkekqTODA9JUmeGhySpM8NDktSZ4SEdoCQP7jf/uiTvG1c/0lwyPKSDTLvDs3RQMzykHiR5ZpIt7UZzW5Isa/U/SfKqoXEPtteXtOcsfBC4vf3i/1NJ/jrJV5L8izFtijSpReNuQJrHnpTk1qH5I9l3S5v3MXhWxsYk/wq4nJlv8X0S8Lyq+maSXwd2VtXLAZI8fZZ7lx4T9zykA/e9qjpx4g/43aH3fhH4YJu+GnjxCOu7qaq+2aZvB16a5B1Jfqmq7p+9tqXHzvCQ5sbEfYAeof17125Sd9jQmO/+4+CqvwFeyCBE/nOS4WCSxs7wkPrxvxncmRngNcBftem7GIQCDJ5c94TJFk7y08BDVfWnwDuBlb11Kh0Az3lI/fhtYEOSfw/sAc5v9fcD1yW5CdjC0N7Gfv4J8F+T/Aj4f8Bv9tyv1Il31ZUkdeZhK0lSZ4aHJKkzw0OS1JnhIUnqzPCQJHVmeEiSOjM8JEmd/X/2mOv7GfAvCgAAAABJRU5ErkJggg==",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
@@ -223,32 +216,32 @@
             "needs_background": "light"
           }
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "4upYTxA__G--"
-      },
-      "source": [
-        "As you can see, the **default histogram does not normalize with binwidth and simply shows the counts**! This can be very misleading if you are working with variable bin width (e.g. logarithmic bins). So please be mindful about histograms when you work with variable bins. \n",
-        "\n",
-        "**Q: You can fix this by using the `density` option.**"
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "scqFe0gC_G-_",
-        "outputId": "5e311534-9f21-443e-9d9b-7ce214888274"
-      },
+        "id": "QVvYy95b_G-9",
+        "outputId": "b48aa7c4-f423-45a4-a8c1-32178eda04cb"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "As you can see, the **default histogram does not normalize with binwidth and simply shows the counts**! This can be very misleading if you are working with variable bin width (e.g. logarithmic bins). So please be mindful about histograms when you work with variable bins. \n",
+        "\n",
+        "**Q: You can fix this by using the `density` option.**"
+      ],
+      "metadata": {
+        "id": "4upYTxA__G--"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "# TODO: fix it with density option. \n"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -265,7 +258,7 @@
         {
           "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZIAAAEGCAYAAABPdROvAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAYqUlEQVR4nO3df7RdZZ3f8fdnwg+tFuVH7NAEDY6Z5URso1yisxxZ1p9hUEKXoMmggKWNWmk7dY3LaEd0MjoFZypTO5SCAwooAuKomUVcDOOvTqtiLpghBCZyDSlcw5JLQxV/gZFv/zg745njvbnnZmffa3Lfr7XOOns/+3me8zyclfth/zh7p6qQJGlf/cpcD0CSdGAzSCRJrRgkkqRWDBJJUisGiSSplUPmegCz4ZhjjqklS5bM9TAk6YBy2223PVRVC6erNy+CZMmSJYyOjs71MCTpgJLk/wxTz0NbkqRWDBJJUisGiSSpFYNEktSKQSJJasUgkSS1YpBIkloxSCRJrRgkkqRW5sUv29tYsu6mGbfZceGpHYxEkn45uUciSWrFIJEktWKQSJJaMUgkSa0YJJKkVgwSSVIrBokkqRWDRJLUSqdBkmRlkm1JxpKsm2T725PcleSOJF9I8oy+beckuad5ndNXfmKSLU2fH06SLucgSdq7zoIkyQLgEuAUYBmwJsmygWrfBEaq6p8BNwIfbNoeBbwXeAGwAnhvkiObNpcCa4GlzWtlV3OQJE2vyz2SFcBYVW2vqseA64BV/RWq6ktV9aNm9evA4mb5VcAtVbWrqh4GbgFWJjkWOKKqvlZVBVwNnN7hHCRJ0+gySBYB9/etjzdlUzkP+Pw0bRc1y9P2mWRtktEkoxMTEzMcuiRpWF0GyWTnLmrSiskbgBHgj6dpO3SfVXV5VY1U1cjChQuHGK4kaV90GSTjwHF964uBnYOVkrwc+E/AaVX16DRtx/n54a8p+5QkzZ4ug2QTsDTJ8UkOA1YDG/orJHkecBm9EHmwb9PNwCuTHNmcZH8lcHNVPQA8kuSFzdVaZwOf63AOkqRpdPY8kqraneR8eqGwALiyqrYmWQ+MVtUGeoeyngx8qrmK976qOq2qdiX5Q3phBLC+qnY1y28FPgY8kd45lc8jSZoznT7Yqqo2AhsHyi7oW375XtpeCVw5SfkocMJ+HKYkqQV/2S5JasUgkSS1YpBIkloxSCRJrRgkkqRWDBJJUisGiSSpFYNEktSKQSJJasUgkSS1YpBIkloxSCRJrRgkkqRWDBJJUisGiSSplU6DJMnKJNuSjCVZN8n2k5PcnmR3kjP6yv9Fks19r58kOb3Z9rEk9/ZtW97lHCRJe9fZg62SLAAuAV5B71nrm5JsqKq7+qrdB5wL/F5/26r6ErC86ecoYAz4q74q76iqG7sauyRpeF0+IXEFMFZV2wGSXAesAv4+SKpqR7Pt8b30cwbw+ar6UXdDlSTtqy4PbS0C7u9bH2/KZmo18MmBsg8kuSPJxUkO39cBSpLa6zJIMklZzaiD5FjgucDNfcXvAp4NnAQcBbxzirZrk4wmGZ2YmJjJx0qSZqDLIBkHjutbXwzsnGEfrwM+U1U/3VNQVQ9Uz6PAR+kdQvsFVXV5VY1U1cjChQtn+LGSpGF1GSSbgKVJjk9yGL1DVBtm2McaBg5rNXspJAlwOnDnfhirJGkfdRYkVbUbOJ/eYam7gRuqamuS9UlOA0hyUpJx4EzgsiRb97RPsoTeHs1XBrr+RJItwBbgGOD9Xc1BkjS9VM3otMUBaWRkpEZHR/ep7ZJ1N+3n0ewfOy48da6HIOkgl+S2qhqZrp6/bJcktWKQSJJaMUgkSa0YJJKkVgwSSVIrBokkqRWDRJLUikEiSWrFIJEktWKQSJJaMUgkSa0YJJKkVgwSSVIrBokkqRWDRJLUikEiSWql0yBJsjLJtiRjSdZNsv3kJLcn2Z3kjIFtP0uyuXlt6Cs/PsmtSe5Jcn3zGF9J0hzpLEiSLAAuAU4BlgFrkiwbqHYfcC5w7SRd/Liqljev0/rKLwIurqqlwMPAeft98JKkoXW5R7ICGKuq7VX1GHAdsKq/QlXtqKo7gMeH6TBJgJcCNzZFVwGn778hS5JmqssgWQTc37c+3pQN6wlJRpN8PcmesDga+H9VtXu6PpOsbdqPTkxMzHTskqQhHdJh35mkrGbQ/ulVtTPJM4EvJtkCfH/YPqvqcuBygJGRkZl8riRpBrrcIxkHjutbXwzsHLZxVe1s3rcDXwaeBzwEPDXJngCcUZ+SpP2vyyDZBCxtrrI6DFgNbJimDQBJjkxyeLN8DPAi4K6qKuBLwJ4rvM4BPrffRy5JGlpnQdKcxzgfuBm4G7ihqrYmWZ/kNIAkJyUZB84ELkuytWn+G8Bokr+lFxwXVtVdzbZ3Am9PMkbvnMkVXc1BkjS9Ls+RUFUbgY0DZRf0LW+id3hqsN1XgedO0ed2eleESZJ+CfjLdklSKwaJJKkVg0SS1IpBIklqxSCRJLVikEiSWjFIJEmtGCSSpFYMEklSKwaJJKkVg0SS1IpBIklqxSCRJLVikEiSWjFIJEmtDBUkST6d5NQkMwqeJCuTbEsylmTdJNtPTnJ7kt1JzugrX57ka0m2Jrkjyev7tn0syb1JNjev5TMZkyRp/xo2GC4Ffge4J8mFSZ49XYMkC4BLgFOAZcCaJMsGqt0HnAtcO1D+I+DsqnoOsBL40yRP7dv+jqpa3rw2DzkHSVIHhgqSqvrrqjoLeD6wA7glyVeTvCnJoVM0WwGMVdX2qnoMuA5YNdDvjqq6A3h8oPxbVXVPs7wTeBBYOIN5SZJmydCHqpIcTW/v4V8D3wT+K71guWWKJouA+/vWx5uyGUmyAjgM+HZf8QeaQ14XJzl8inZrk4wmGZ2YmJjpx0qShjTsOZK/AP4G+EfAa6rqtKq6vqr+HfDkqZpNUlYzGVySY4FrgDdV1Z69lncBzwZOAo4C3jlZ26q6vKpGqmpk4UJ3ZiSpK4cMWe/Pq2pjf0GSw6vq0aoamaLNOHBc3/piYOewA0tyBHAT8PtV9fU95VX1QLP4aJKPAr83bJ+SpP1v2ENb75+k7GvTtNkELE1yfJLDgNXAhmE+rKn/GeDqqvrUwLZjm/cApwN3DtOnJKkbe90jSfKr9M5rPDHJ8/j54aoj6B3mmlJV7U5yPnAzsAC4sqq2JlkPjFbVhiQn0QuMI4HXJPmD5kqt1wEnA0cnObfp8tzmCq1PJFnYjGUz8JYZz/ogsGTdTZ1/xo4LT+38MyQd+KY7tPUqeifYFwMf6it/BHj3dJ03h8M2DpRd0Le8qel7sN3HgY9P0edLp/tcSdLs2WuQVNVVwFVJXltVn56lMUmSDiDTHdp6Q7N3sCTJ2we3V9WHJmkmSZpHpju09aTmfapLfCVJ89x0h7Yua97/YHaGI0k60Az7g8QPJjkiyaFJvpDkoSRv6HpwkqRffsP+juSVVfV94NX0fmj468A7OhuVJOmAMWyQ7Lkx428Dn6yqXR2NR5J0gBn2Fil/meTvgB8D/7b5QeBPuhuWJOlAMext5NcBvwmMVNVPgR8ycEt4SdL8NOweCcBv0Ps9SX+bq/fzeCRJB5ihgiTJNcCv0bu31c+a4sIgkaR5b9g9khFgWVXN6HkikqSD37BXbd0J/GqXA5EkHZiG3SM5BrgryTeAR/cUVtVpnYxKknTAGDZI3tflICRJB65hL//9CrADOLRZ3gTcPl27JCuTbEsylmTdJNtPTnJ7kt1JzhjYdk6Se5rXOX3lJybZ0vT54eZJiZKkOTLsvbb+DXAjcFlTtAj47DRtFgCXAKcAy4A1SZYNVLuP3oOzrh1oexTwXuAFwArgvUmObDZfCqwFljavlcPMQZLUjWFPtr8NeBHwfYCqugd42jRtVgBjVbW9qh4DrmPgR4xVtaOq7gAeH2j7KuCWqtpVVQ8DtwArm+e1H1FVX2uuILua3nPbJUlzZNggebQJAwCaHyVOdynwIuD+vvXxpmwYU7Vd1CzvS5+SpA4MGyRfSfJu4IlJXgF8CvjLadpMdu5i2N+hTNV26D6TrE0ymmR0YmJiyI+VJM3UsEGyDpgAtgBvBjYCvz9Nm3HguL71xcDOIT9vqrbjzfK0fVbV5VU1UlUjCxcuHPJjJUkzNdTlv1X1eJLPAp+tqmH/934TsDTJ8cB3gNXA7wzZ9mbgj/pOsL8SeFdV7UrySJIXArcCZwP/bcg+JUkd2OseSXrel+Qh4O+AbUkmklwwXcdVtRs4n14o3A3cUFVbk6xPclrT/0lJxoEzgcuSbG3a7gL+kF4YbQLW9z0D5a3AnwNjwLeBz8941pKk/Wa6PZLfpXe11klVdS9AkmcClyb5j1V18d4aV9VGeofB+ssu6FvexD88VNVf70rgyknKR4ETphm3JGmWTHeO5GxgzZ4QAaiq7cAbmm2SpHluuiA5tKoeGixszpMcOkl9SdI8M12QPLaP2yRJ88R050j+eZLvT1Ie4AkdjEeSdIDZa5BU1YLZGogk6cA07A8SJUmalEEiSWrFIJEktWKQSJJaMUgkSa0YJJKkVgwSSVIrBokkqRWDRJLUikEiSWrFIJEktdJpkCRZmWRbkrEk6ybZfniS65vttyZZ0pSflWRz3+vxJMubbV9u+tyz7WldzkGStHedBUmSBcAlwCnAMmBNkmUD1c4DHq6qZwEXAxcBVNUnqmp5VS0H3gjsqKrNfe3O2rO9qh7sag6SpOl1uUeyAhirqu1V9RhwHbBqoM4q4Kpm+UbgZUkyUGcN8MkOxylJaqHLIFkE3N+3Pt6UTVqnqnYD3wOOHqjzen4xSD7aHNZ6zyTBA0CStUlGk4xOTEzs6xwkSdPoMkgm+wNfM6mT5AXAj6rqzr7tZ1XVc4EXN683TvbhVXV5VY1U1cjChQtnNnJJ0tC6DJJx4Li+9cXAzqnqJDkEeAqwq2/7agb2RqrqO837I8C19A6hSZLmSJdBsglYmuT4JIfRC4UNA3U2AOc0y2cAX6yqAkjyK8CZ9M6t0JQdkuSYZvlQ4NXAnUiS5sx0z2zfZ1W1O8n5wM3AAuDKqtqaZD0wWlUbgCuAa5KM0dsTWd3XxcnAeFVt7ys7HLi5CZEFwF8DH+lqDpKk6XUWJABVtRHYOFB2Qd/yT+jtdUzW9svACwfKfgicuN8HKknaZ/6yXZLUikEiSWrFIJEktWKQSJJaMUgkSa0YJJKkVgwSSVIrBokkqRWDRJLUikEiSWrFIJEktWKQSJJaMUgkSa0YJJKkVgwSSVIrnQZJkpVJtiUZS7Juku2HJ7m+2X5rkiVN+ZIkP06yuXn9j742JybZ0rT5cJLJnvsuSZolnQVJkgXAJcApwDJgTZJlA9XOAx6uqmcBFwMX9W37dlUtb15v6Su/FFgLLG1eK7uagyRpel3ukawAxqpqe1U9Ru/Z66sG6qwCrmqWbwRetrc9jCTHAkdU1deaZ7tfDZy+/4cuSRpWl0GyCLi/b328KZu0TlXtBr4HHN1sOz7JN5N8JcmL++qPT9MnAEnWJhlNMjoxMdFuJpKkKXUZJJPtWdSQdR4Anl5VzwPeDlyb5Igh++wVVl1eVSNVNbJw4cIZDFuSNBNdBsk4cFzf+mJg51R1khwCPAXYVVWPVtX/Baiq24BvA7/e1F88TZ+SpFnUZZBsApYmOT7JYcBqYMNAnQ3AOc3yGcAXq6qSLGxO1pPkmfROqm+vqgeAR5K8sDmXcjbwuQ7nIEmaxiFddVxVu5OcD9wMLACurKqtSdYDo1W1AbgCuCbJGLCLXtgAnAysT7Ib+Bnwlqra1Wx7K/Ax4InA55uXJGmOdBYkAFW1Edg4UHZB3/JPgDMnafdp4NNT9DkKnLB/RypJ2lf+sl2S1IpBIklqxSCRJLVikEiSWjFIJEmtGCSSpFYMEklSKwaJJKkVg0SS1IpBIklqxSCRJLVikEiSWjFIJEmtGCSSpFYMEklSK50GSZKVSbYlGUuybpLthye5vtl+a5IlTfkrktyWZEvz/tK+Nl9u+tzcvJ7W5RwkSXvX2YOtmkflXgK8gt6z1jcl2VBVd/VVOw94uKqelWQ1cBHweuAh4DVVtTPJCfSesrior91ZzQOuJElzrMs9khXAWFVtr6rHgOuAVQN1VgFXNcs3Ai9Lkqr6ZlXtbMq3Ak9IcniHY5Uk7aMug2QRcH/f+jj/cK/iH9Spqt3A94CjB+q8FvhmVT3aV/bR5rDWe5Jksg9PsjbJaJLRiYmJNvOQJO1Fl0Ey2R/4mkmdJM+hd7jrzX3bz6qq5wIvbl5vnOzDq+ryqhqpqpGFCxfOaOCSpOF1GSTjwHF964uBnVPVSXII8BRgV7O+GPgMcHZVfXtPg6r6TvP+CHAtvUNokqQ50mWQbAKWJjk+yWHAamDDQJ0NwDnN8hnAF6uqkjwVuAl4V1X97z2VkxyS5Jhm+VDg1cCdHc5BkjSNzoKkOedxPr0rru4GbqiqrUnWJzmtqXYFcHSSMeDtwJ5LhM8HngW8Z+Ay38OBm5PcAWwGvgN8pKs5SJKm19nlvwBVtRHYOFB2Qd/yT4AzJ2n3fuD9U3R74v4coySpnU6DRAe2JetumushzKkdF54610OQDgjeIkWS1IpBIklqxSCRJLVikEiSWjFIJEmtGCSSpFYMEklSKwaJJKkVg0SS1IpBIklqxSCRJLXivbakKcz3e43pwDdb94tzj0SS1IpBIklqxSCRJLXSaZAkWZlkW5KxJOsm2X54kuub7bcmWdK37V1N+bYkrxq2T0nS7OosSJIsAC4BTgGWAWuSLBuodh7wcFU9C7gYuKhpu4zeM96fA6wE/nuSBUP2KUmaRV3ukawAxqpqe1U9BlwHrBqoswq4qlm+EXhZkjTl11XVo1V1LzDW9DdMn5KkWdTl5b+LgPv71seBF0xVp6p2J/kecHRT/vWBtoua5en6BCDJWmBts/qDJNv2YQ4AxwAP7WPbA918njvM7/nP57nDQTL/XLRPzfrn/oxhGnQZJJmkrIasM1X5ZHtQg332CqsuBy7f2wCHkWS0qkba9nMgms9zh/k9//k8d5jf89+XuXd5aGscOK5vfTGwc6o6SQ4BngLs2kvbYfqUJM2iLoNkE7A0yfFJDqN38nzDQJ0NwDnN8hnAF6uqmvLVzVVdxwNLgW8M2ackaRZ1dmirOedxPnAzsAC4sqq2JlkPjFbVBuAK4JokY/T2RFY3bbcmuQG4C9gNvK2qfgYwWZ9dzaHR+vDYAWw+zx3m9/zn89xhfs9/xnNPbwdAkqR94y/bJUmtGCSSpFYMkr2Yz7djSbIjyZYkm5OMzvV4upbkyiQPJrmzr+yoJLckuad5P3Iux9iVKeb+viTfab7/zUl+ey7H2JUkxyX5UpK7k2xN8h+a8oP+u9/L3Gf83XuOZArN7Vi+BbyC3mXHm4A1VXXXnA5sliTZAYxU1QH/o6xhJDkZ+AFwdVWd0JR9ENhVVRc2/yNxZFW9cy7H2YUp5v4+4AdV9SdzObauJTkWOLaqbk/yj4HbgNOBcznIv/u9zP11zPC7d49kat6OZR6pqv9J78rBfv238LmK3j+yg84Uc58XquqBqrq9WX4EuJveXTQO+u9+L3OfMYNkapPd4mWf/iMfoAr4qyS3NbebmY/+SVU9AL1/dMDT5ng8s+38JHc0h74OukM7g5q7jz8PuJV59t0PzB1m+N0bJFMb5hYvB7MXVdXz6d1p+W3N4Q/NH5cCvwYsBx4A/svcDqdbSZ4MfBr43ar6/lyPZzZNMvcZf/cGydTm9e1Yqmpn8/4g8Bl6h/rmm+82x5H3HE9+cI7HM2uq6rtV9bOqehz4CAfx95/kUHp/SD9RVX/RFM+L736yue/Ld2+QTG3e3o4lyZOak28keRLwSuDOvbc6KPXfwucc4HNzOJZZteePaONfcpB+/81jK64A7q6qD/VtOui/+6nmvi/fvVdt7UVz2duf8vPbsXxgjoc0K5I8k95eCPRuo3PtwT73JJ8EXkLvFtrfBd4LfBa4AXg6cB9wZlUddCelp5j7S+gd2ihgB/DmPecMDiZJfgv4G2AL8HhT/G565woO6u9+L3Nfwwy/e4NEktSKh7YkSa0YJJKkVgwSSVIrBokkqRWDRJLUikEi7SdJfjCwfm6SP5ur8UizxSCRfsk1d6KWfmkZJNIsSPKMJF9oboT3hSRPb8o/luSMvno/aN5f0jwr4lpgS3O3gZuS/G2SO5O8fo6mIv2CQ+Z6ANJB5IlJNvetH8XPb6vzZ/Se93FVkn8FfJjpb02+Ajihqu5N8lpgZ1WdCpDkKft57NI+c49E2n9+XFXL97yAC/q2/SZwbbN8DfBbQ/T3jaq6t1neArw8yUVJXlxV39t/w5baMUikubHn3kS7af4dNjfRO6yvzg//vnLVt4AT6QXKf07SH1LSnDJIpNnxVXp3kAY4C/hfzfIOegEBvafyHTpZ4yT/FPhRVX0c+BPg+Z2NVJohz5FIs+PfA1cmeQcwAbypKf8I8Lkk3wC+QN9eyIDnAn+c5HHgp8BbOx6vNDTv/itJasVDW5KkVgwSSVIrBokkqRWDRJLUikEiSWrFIJEktWKQSJJa+f8mIdg8sqWCzwAAAABJRU5ErkJggg==\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZIAAAEGCAYAAABPdROvAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAYqUlEQVR4nO3df7RdZZ3f8fdnwg+tFuVH7NAEDY6Z5URso1yisxxZ1p9hUEKXoMmggKWNWmk7dY3LaEd0MjoFZypTO5SCAwooAuKomUVcDOOvTqtiLpghBCZyDSlcw5JLQxV/gZFv/zg745njvbnnZmffa3Lfr7XOOns/+3me8zyclfth/zh7p6qQJGlf/cpcD0CSdGAzSCRJrRgkkqRWDBJJUisGiSSplUPmegCz4ZhjjqklS5bM9TAk6YBy2223PVRVC6erNy+CZMmSJYyOjs71MCTpgJLk/wxTz0NbkqRWDBJJUisGiSSpFYNEktSKQSJJasUgkSS1YpBIkloxSCRJrRgkkqRW5sUv29tYsu6mGbfZceGpHYxEkn45uUciSWrFIJEktWKQSJJaMUgkSa0YJJKkVgwSSVIrBokkqRWDRJLUSqdBkmRlkm1JxpKsm2T725PcleSOJF9I8oy+beckuad5ndNXfmKSLU2fH06SLucgSdq7zoIkyQLgEuAUYBmwJsmygWrfBEaq6p8BNwIfbNoeBbwXeAGwAnhvkiObNpcCa4GlzWtlV3OQJE2vyz2SFcBYVW2vqseA64BV/RWq6ktV9aNm9evA4mb5VcAtVbWrqh4GbgFWJjkWOKKqvlZVBVwNnN7hHCRJ0+gySBYB9/etjzdlUzkP+Pw0bRc1y9P2mWRtktEkoxMTEzMcuiRpWF0GyWTnLmrSiskbgBHgj6dpO3SfVXV5VY1U1cjChQuHGK4kaV90GSTjwHF964uBnYOVkrwc+E/AaVX16DRtx/n54a8p+5QkzZ4ug2QTsDTJ8UkOA1YDG/orJHkecBm9EHmwb9PNwCuTHNmcZH8lcHNVPQA8kuSFzdVaZwOf63AOkqRpdPY8kqraneR8eqGwALiyqrYmWQ+MVtUGeoeyngx8qrmK976qOq2qdiX5Q3phBLC+qnY1y28FPgY8kd45lc8jSZoznT7Yqqo2AhsHyi7oW375XtpeCVw5SfkocMJ+HKYkqQV/2S5JasUgkSS1YpBIkloxSCRJrRgkkqRWDBJJUisGiSSpFYNEktSKQSJJasUgkSS1YpBIkloxSCRJrRgkkqRWDBJJUisGiSSplU6DJMnKJNuSjCVZN8n2k5PcnmR3kjP6yv9Fks19r58kOb3Z9rEk9/ZtW97lHCRJe9fZg62SLAAuAV5B71nrm5JsqKq7+qrdB5wL/F5/26r6ErC86ecoYAz4q74q76iqG7sauyRpeF0+IXEFMFZV2wGSXAesAv4+SKpqR7Pt8b30cwbw+ar6UXdDlSTtqy4PbS0C7u9bH2/KZmo18MmBsg8kuSPJxUkO39cBSpLa6zJIMklZzaiD5FjgucDNfcXvAp4NnAQcBbxzirZrk4wmGZ2YmJjJx0qSZqDLIBkHjutbXwzsnGEfrwM+U1U/3VNQVQ9Uz6PAR+kdQvsFVXV5VY1U1cjChQtn+LGSpGF1GSSbgKVJjk9yGL1DVBtm2McaBg5rNXspJAlwOnDnfhirJGkfdRYkVbUbOJ/eYam7gRuqamuS9UlOA0hyUpJx4EzgsiRb97RPsoTeHs1XBrr+RJItwBbgGOD9Xc1BkjS9VM3otMUBaWRkpEZHR/ep7ZJ1N+3n0ewfOy48da6HIOkgl+S2qhqZrp6/bJcktWKQSJJaMUgkSa0YJJKkVgwSSVIrBokkqRWDRJLUikEiSWrFIJEktWKQSJJaMUgkSa0YJJKkVgwSSVIrBokkqRWDRJLUikEiSWql0yBJsjLJtiRjSdZNsv3kJLcn2Z3kjIFtP0uyuXlt6Cs/PsmtSe5Jcn3zGF9J0hzpLEiSLAAuAU4BlgFrkiwbqHYfcC5w7SRd/Liqljev0/rKLwIurqqlwMPAeft98JKkoXW5R7ICGKuq7VX1GHAdsKq/QlXtqKo7gMeH6TBJgJcCNzZFVwGn778hS5JmqssgWQTc37c+3pQN6wlJRpN8PcmesDga+H9VtXu6PpOsbdqPTkxMzHTskqQhHdJh35mkrGbQ/ulVtTPJM4EvJtkCfH/YPqvqcuBygJGRkZl8riRpBrrcIxkHjutbXwzsHLZxVe1s3rcDXwaeBzwEPDXJngCcUZ+SpP2vyyDZBCxtrrI6DFgNbJimDQBJjkxyeLN8DPAi4K6qKuBLwJ4rvM4BPrffRy5JGlpnQdKcxzgfuBm4G7ihqrYmWZ/kNIAkJyUZB84ELkuytWn+G8Bokr+lFxwXVtVdzbZ3Am9PMkbvnMkVXc1BkjS9Ls+RUFUbgY0DZRf0LW+id3hqsN1XgedO0ed2eleESZJ+CfjLdklSKwaJJKkVg0SS1IpBIklqxSCRJLVikEiSWjFIJEmtGCSSpFYMEklSKwaJJKkVg0SS1IpBIklqxSCRJLVikEiSWjFIJEmtDBUkST6d5NQkMwqeJCuTbEsylmTdJNtPTnJ7kt1JzugrX57ka0m2Jrkjyev7tn0syb1JNjev5TMZkyRp/xo2GC4Ffge4J8mFSZ49XYMkC4BLgFOAZcCaJMsGqt0HnAtcO1D+I+DsqnoOsBL40yRP7dv+jqpa3rw2DzkHSVIHhgqSqvrrqjoLeD6wA7glyVeTvCnJoVM0WwGMVdX2qnoMuA5YNdDvjqq6A3h8oPxbVXVPs7wTeBBYOIN5SZJmydCHqpIcTW/v4V8D3wT+K71guWWKJouA+/vWx5uyGUmyAjgM+HZf8QeaQ14XJzl8inZrk4wmGZ2YmJjpx0qShjTsOZK/AP4G+EfAa6rqtKq6vqr+HfDkqZpNUlYzGVySY4FrgDdV1Z69lncBzwZOAo4C3jlZ26q6vKpGqmpk4UJ3ZiSpK4cMWe/Pq2pjf0GSw6vq0aoamaLNOHBc3/piYOewA0tyBHAT8PtV9fU95VX1QLP4aJKPAr83bJ+SpP1v2ENb75+k7GvTtNkELE1yfJLDgNXAhmE+rKn/GeDqqvrUwLZjm/cApwN3DtOnJKkbe90jSfKr9M5rPDHJ8/j54aoj6B3mmlJV7U5yPnAzsAC4sqq2JlkPjFbVhiQn0QuMI4HXJPmD5kqt1wEnA0cnObfp8tzmCq1PJFnYjGUz8JYZz/ogsGTdTZ1/xo4LT+38MyQd+KY7tPUqeifYFwMf6it/BHj3dJ03h8M2DpRd0Le8qel7sN3HgY9P0edLp/tcSdLs2WuQVNVVwFVJXltVn56lMUmSDiDTHdp6Q7N3sCTJ2we3V9WHJmkmSZpHpju09aTmfapLfCVJ89x0h7Yua97/YHaGI0k60Az7g8QPJjkiyaFJvpDkoSRv6HpwkqRffsP+juSVVfV94NX0fmj468A7OhuVJOmAMWyQ7Lkx428Dn6yqXR2NR5J0gBn2Fil/meTvgB8D/7b5QeBPuhuWJOlAMext5NcBvwmMVNVPgR8ycEt4SdL8NOweCcBv0Ps9SX+bq/fzeCRJB5ihgiTJNcCv0bu31c+a4sIgkaR5b9g9khFgWVXN6HkikqSD37BXbd0J/GqXA5EkHZiG3SM5BrgryTeAR/cUVtVpnYxKknTAGDZI3tflICRJB65hL//9CrADOLRZ3gTcPl27JCuTbEsylmTdJNtPTnJ7kt1JzhjYdk6Se5rXOX3lJybZ0vT54eZJiZKkOTLsvbb+DXAjcFlTtAj47DRtFgCXAKcAy4A1SZYNVLuP3oOzrh1oexTwXuAFwArgvUmObDZfCqwFljavlcPMQZLUjWFPtr8NeBHwfYCqugd42jRtVgBjVbW9qh4DrmPgR4xVtaOq7gAeH2j7KuCWqtpVVQ8DtwArm+e1H1FVX2uuILua3nPbJUlzZNggebQJAwCaHyVOdynwIuD+vvXxpmwYU7Vd1CzvS5+SpA4MGyRfSfJu4IlJXgF8CvjLadpMdu5i2N+hTNV26D6TrE0ymmR0YmJiyI+VJM3UsEGyDpgAtgBvBjYCvz9Nm3HguL71xcDOIT9vqrbjzfK0fVbV5VU1UlUjCxcuHPJjJUkzNdTlv1X1eJLPAp+tqmH/934TsDTJ8cB3gNXA7wzZ9mbgj/pOsL8SeFdV7UrySJIXArcCZwP/bcg+JUkd2OseSXrel+Qh4O+AbUkmklwwXcdVtRs4n14o3A3cUFVbk6xPclrT/0lJxoEzgcuSbG3a7gL+kF4YbQLW9z0D5a3AnwNjwLeBz8941pKk/Wa6PZLfpXe11klVdS9AkmcClyb5j1V18d4aV9VGeofB+ssu6FvexD88VNVf70rgyknKR4ETphm3JGmWTHeO5GxgzZ4QAaiq7cAbmm2SpHluuiA5tKoeGixszpMcOkl9SdI8M12QPLaP2yRJ88R050j+eZLvT1Ie4AkdjEeSdIDZa5BU1YLZGogk6cA07A8SJUmalEEiSWrFIJEktWKQSJJaMUgkSa0YJJKkVgwSSVIrBokkqRWDRJLUikEiSWrFIJEktdJpkCRZmWRbkrEk6ybZfniS65vttyZZ0pSflWRz3+vxJMubbV9u+tyz7WldzkGStHedBUmSBcAlwCnAMmBNkmUD1c4DHq6qZwEXAxcBVNUnqmp5VS0H3gjsqKrNfe3O2rO9qh7sag6SpOl1uUeyAhirqu1V9RhwHbBqoM4q4Kpm+UbgZUkyUGcN8MkOxylJaqHLIFkE3N+3Pt6UTVqnqnYD3wOOHqjzen4xSD7aHNZ6zyTBA0CStUlGk4xOTEzs6xwkSdPoMkgm+wNfM6mT5AXAj6rqzr7tZ1XVc4EXN683TvbhVXV5VY1U1cjChQtnNnJJ0tC6DJJx4Li+9cXAzqnqJDkEeAqwq2/7agb2RqrqO837I8C19A6hSZLmSJdBsglYmuT4JIfRC4UNA3U2AOc0y2cAX6yqAkjyK8CZ9M6t0JQdkuSYZvlQ4NXAnUiS5sx0z2zfZ1W1O8n5wM3AAuDKqtqaZD0wWlUbgCuAa5KM0dsTWd3XxcnAeFVt7ys7HLi5CZEFwF8DH+lqDpKk6XUWJABVtRHYOFB2Qd/yT+jtdUzW9svACwfKfgicuN8HKknaZ/6yXZLUikEiSWrFIJEktWKQSJJaMUgkSa0YJJKkVgwSSVIrBokkqRWDRJLUikEiSWrFIJEktWKQSJJaMUgkSa0YJJKkVgwSSVIrnQZJkpVJtiUZS7Juku2HJ7m+2X5rkiVN+ZIkP06yuXn9j742JybZ0rT5cJLJnvsuSZolnQVJkgXAJcApwDJgTZJlA9XOAx6uqmcBFwMX9W37dlUtb15v6Su/FFgLLG1eK7uagyRpel3ukawAxqpqe1U9Ru/Z66sG6qwCrmqWbwRetrc9jCTHAkdU1deaZ7tfDZy+/4cuSRpWl0GyCLi/b328KZu0TlXtBr4HHN1sOz7JN5N8JcmL++qPT9MnAEnWJhlNMjoxMdFuJpKkKXUZJJPtWdSQdR4Anl5VzwPeDlyb5Igh++wVVl1eVSNVNbJw4cIZDFuSNBNdBsk4cFzf+mJg51R1khwCPAXYVVWPVtX/Baiq24BvA7/e1F88TZ+SpFnUZZBsApYmOT7JYcBqYMNAnQ3AOc3yGcAXq6qSLGxO1pPkmfROqm+vqgeAR5K8sDmXcjbwuQ7nIEmaxiFddVxVu5OcD9wMLACurKqtSdYDo1W1AbgCuCbJGLCLXtgAnAysT7Ib+Bnwlqra1Wx7K/Ax4InA55uXJGmOdBYkAFW1Edg4UHZB3/JPgDMnafdp4NNT9DkKnLB/RypJ2lf+sl2S1IpBIklqxSCRJLVikEiSWjFIJEmtGCSSpFYMEklSKwaJJKkVg0SS1IpBIklqxSCRJLVikEiSWjFIJEmtGCSSpFYMEklSK50GSZKVSbYlGUuybpLthye5vtl+a5IlTfkrktyWZEvz/tK+Nl9u+tzcvJ7W5RwkSXvX2YOtmkflXgK8gt6z1jcl2VBVd/VVOw94uKqelWQ1cBHweuAh4DVVtTPJCfSesrior91ZzQOuJElzrMs9khXAWFVtr6rHgOuAVQN1VgFXNcs3Ai9Lkqr6ZlXtbMq3Ak9IcniHY5Uk7aMug2QRcH/f+jj/cK/iH9Spqt3A94CjB+q8FvhmVT3aV/bR5rDWe5Jksg9PsjbJaJLRiYmJNvOQJO1Fl0Ey2R/4mkmdJM+hd7jrzX3bz6qq5wIvbl5vnOzDq+ryqhqpqpGFCxfOaOCSpOF1GSTjwHF964uBnVPVSXII8BRgV7O+GPgMcHZVfXtPg6r6TvP+CHAtvUNokqQ50mWQbAKWJjk+yWHAamDDQJ0NwDnN8hnAF6uqkjwVuAl4V1X97z2VkxyS5Jhm+VDg1cCdHc5BkjSNzoKkOedxPr0rru4GbqiqrUnWJzmtqXYFcHSSMeDtwJ5LhM8HngW8Z+Ay38OBm5PcAWwGvgN8pKs5SJKm19nlvwBVtRHYOFB2Qd/yT4AzJ2n3fuD9U3R74v4coySpnU6DRAe2JetumushzKkdF54610OQDgjeIkWS1IpBIklqxSCRJLVikEiSWjFIJEmtGCSSpFYMEklSKwaJJKkVg0SS1IpBIklqxSCRJLXivbakKcz3e43pwDdb94tzj0SS1IpBIklqxSCRJLXSaZAkWZlkW5KxJOsm2X54kuub7bcmWdK37V1N+bYkrxq2T0nS7OosSJIsAC4BTgGWAWuSLBuodh7wcFU9C7gYuKhpu4zeM96fA6wE/nuSBUP2KUmaRV3ukawAxqpqe1U9BlwHrBqoswq4qlm+EXhZkjTl11XVo1V1LzDW9DdMn5KkWdTl5b+LgPv71seBF0xVp6p2J/kecHRT/vWBtoua5en6BCDJWmBts/qDJNv2YQ4AxwAP7WPbA918njvM7/nP57nDQTL/XLRPzfrn/oxhGnQZJJmkrIasM1X5ZHtQg332CqsuBy7f2wCHkWS0qkba9nMgms9zh/k9//k8d5jf89+XuXd5aGscOK5vfTGwc6o6SQ4BngLs2kvbYfqUJM2iLoNkE7A0yfFJDqN38nzDQJ0NwDnN8hnAF6uqmvLVzVVdxwNLgW8M2ackaRZ1dmirOedxPnAzsAC4sqq2JlkPjFbVBuAK4JokY/T2RFY3bbcmuQG4C9gNvK2qfgYwWZ9dzaHR+vDYAWw+zx3m9/zn89xhfs9/xnNPbwdAkqR94y/bJUmtGCSSpFYMkr2Yz7djSbIjyZYkm5OMzvV4upbkyiQPJrmzr+yoJLckuad5P3Iux9iVKeb+viTfab7/zUl+ey7H2JUkxyX5UpK7k2xN8h+a8oP+u9/L3Gf83XuOZArN7Vi+BbyC3mXHm4A1VXXXnA5sliTZAYxU1QH/o6xhJDkZ+AFwdVWd0JR9ENhVVRc2/yNxZFW9cy7H2YUp5v4+4AdV9SdzObauJTkWOLaqbk/yj4HbgNOBcznIv/u9zP11zPC7d49kat6OZR6pqv9J78rBfv238LmK3j+yg84Uc58XquqBqrq9WX4EuJveXTQO+u9+L3OfMYNkapPd4mWf/iMfoAr4qyS3NbebmY/+SVU9AL1/dMDT5ng8s+38JHc0h74OukM7g5q7jz8PuJV59t0PzB1m+N0bJFMb5hYvB7MXVdXz6d1p+W3N4Q/NH5cCvwYsBx4A/svcDqdbSZ4MfBr43ar6/lyPZzZNMvcZf/cGydTm9e1Yqmpn8/4g8Bl6h/rmm+82x5H3HE9+cI7HM2uq6rtV9bOqehz4CAfx95/kUHp/SD9RVX/RFM+L736yue/Ld2+QTG3e3o4lyZOak28keRLwSuDOvbc6KPXfwucc4HNzOJZZteePaONfcpB+/81jK64A7q6qD/VtOui/+6nmvi/fvVdt7UVz2duf8vPbsXxgjoc0K5I8k95eCPRuo3PtwT73JJ8EXkLvFtrfBd4LfBa4AXg6cB9wZlUddCelp5j7S+gd2ihgB/DmPecMDiZJfgv4G2AL8HhT/G565woO6u9+L3Nfwwy/e4NEktSKh7YkSa0YJJKkVgwSSVIrBokkqRWDRJLUikEi7SdJfjCwfm6SP5ur8UizxSCRfsk1d6KWfmkZJNIsSPKMJF9oboT3hSRPb8o/luSMvno/aN5f0jwr4lpgS3O3gZuS/G2SO5O8fo6mIv2CQ+Z6ANJB5IlJNvetH8XPb6vzZ/Se93FVkn8FfJjpb02+Ajihqu5N8lpgZ1WdCpDkKft57NI+c49E2n9+XFXL97yAC/q2/SZwbbN8DfBbQ/T3jaq6t1neArw8yUVJXlxV39t/w5baMUikubHn3kS7af4dNjfRO6yvzg//vnLVt4AT6QXKf07SH1LSnDJIpNnxVXp3kAY4C/hfzfIOegEBvafyHTpZ4yT/FPhRVX0c+BPg+Z2NVJohz5FIs+PfA1cmeQcwAbypKf8I8Lkk3wC+QN9eyIDnAn+c5HHgp8BbOx6vNDTv/itJasVDW5KkVgwSSVIrBokkqRWDRJLUikEiSWrFIJEktWKQSJJa+f8mIdg8sqWCzwAAAABJRU5ErkJggg==",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
@@ -275,62 +268,62 @@
             "needs_background": "light"
           }
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Y4vQlcG2_G-_"
-      },
-      "source": [
-        "## Let's use an actual dataset"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "nTs4tXrh_G_A"
-      },
-      "source": [
-        "import vega_datasets"
       ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "5W2VDMUw_O9_"
-      },
-      "source": [
-        "vega_datasets.__version__"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "2qrsL-7B_SIe"
-      },
-      "source": [
-        "**Note:** Please check your `vega_datasets` version using `vega_datasets.__version__`. If you have a version lower than `0.9.0`, you will need to check the column names in `movies.head()` and update it accordingly in the code cells below."
-      ]
-    },
-    {
-      "cell_type": "code",
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "QAuKwXO-_G_A",
-        "outputId": "087c0499-f1e1-4167-8ba6-b94347090067"
-      },
+        "id": "scqFe0gC_G-_",
+        "outputId": "5e311534-9f21-443e-9d9b-7ce214888274"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Let's use an actual dataset"
+      ],
+      "metadata": {
+        "id": "Y4vQlcG2_G-_"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "import vega_datasets"
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "nTs4tXrh_G_A"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "vega_datasets.__version__"
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "5W2VDMUw_O9_"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "**Note:** Please check your `vega_datasets` version using `vega_datasets.__version__`. If you have a version lower than `0.9.0`, you will need to check the column names in `movies.head()` and update it accordingly in the code cells below."
+      ],
+      "metadata": {
+        "id": "2qrsL-7B_SIe"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "movies = vega_datasets.data.movies()\n",
         "movies.head()"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -507,40 +500,40 @@
           },
           "execution_count": 8
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "SrNIv642_G_B"
-      },
-      "source": [
-        "Let's plot the histogram of IMDB ratings. "
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "bWFmgyf6_G_B",
-        "outputId": "364d0d2d-9fe2-4bb1-e889-47714ca7576a"
-      },
+        "id": "QAuKwXO-_G_A",
+        "outputId": "087c0499-f1e1-4167-8ba6-b94347090067"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let's plot the histogram of IMDB ratings. "
+      ],
+      "metadata": {
+        "id": "SrNIv642_G_B"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "plt.hist(movies['IMDB_Rating'])"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
+          "name": "stderr",
           "text": [
             "/opt/anaconda3/envs/py37/lib/python3.7/site-packages/numpy/lib/histograms.py:839: RuntimeWarning: invalid value encountered in greater_equal\n",
             "  keep = (tmp_a >= first_edge)\n",
             "/opt/anaconda3/envs/py37/lib/python3.7/site-packages/numpy/lib/histograms.py:840: RuntimeWarning: invalid value encountered in less_equal\n",
             "  keep &= (tmp_a <= last_edge)\n"
-          ],
-          "name": "stderr"
+          ]
         },
         {
           "output_type": "execute_result",
@@ -559,7 +552,7 @@
         {
           "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD4CAYAAAAXUaZHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAS1ElEQVR4nO3db4yd5Xnn8e+vOIRAm5g/Brm2d00VK5uoUgg7om6R0C5OqwBRzK6CRLRbLGTJ1YrNkrJS6/bNqtK+AKkqDdIKycJtzW5KQkkQVkBpkCG72xe4HQPhT5zKDiX2xC6eFnCaZbsJ7bUvzj0wto89x+OZOcPd70c6ep7neu4z5zqW/fM99zzPmVQVkqS+/NS4G5AkLTzDXZI6ZLhLUocMd0nqkOEuSR1aMe4GAC677LJav379uNuQpPeUffv2/U1VrRp2blmE+/r165mcnBx3G5L0npLk+6c757KMJHVopHBP8utJXk7yUpKHklyQ5Moke5McSPKVJOe3se9vxwfb+fWL+QYkSaeaM9yTrAH+EzBRVT8PnAfcCtwD3FtVG4A3gK3tKVuBN6rqw8C9bZwkaQmNuiyzAvhAkhXAhcBR4HrgkXZ+F3Bz29/cjmnnNyXJwrQrSRrFnOFeVT8Afhc4xCDUjwP7gDer6u02bApY0/bXAIfbc99u4y89+esm2ZZkMsnk9PT0ub4PSdIsoyzLXMxgNn4l8LPARcANQ4bOfALZsFn6KZ9OVlU7qmqiqiZWrRp6JY8kaZ5GWZb5JPBXVTVdVT8Bvgb8ErCyLdMArAWOtP0pYB1AO/8h4PUF7VqSdEajhPshYGOSC9va+SbgO8DTwGfbmC3AY21/dzumnX+q/FxhSVpSo6y572Xwg9FngRfbc3YAvwncleQggzX1ne0pO4FLW/0uYPsi9C1JOoMsh0n1xMREeYeqdKL12x8fy+u+evdNY3ldnb0k+6pqYtg571CVpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktShOcM9yUeSPD/r8cMkX0hySZInkxxo24vb+CS5L8nBJC8kuXrx34YkabZRfkH2X1bVVVV1FfAvgbeARxn84us9VbUB2MO7vwj7BmBDe2wD7l+MxiVJp3e2yzKbgO9V1feBzcCuVt8F3Nz2NwMP1sAzwMokqxekW0nSSM423G8FHmr7V1TVUYC2vbzV1wCHZz1nqtVOkGRbkskkk9PT02fZhiTpTEYO9yTnA58B/mSuoUNqdUqhakdVTVTVxKpVq0ZtQ5I0grOZud8APFtVr7Xj12aWW9r2WKtPAetmPW8tcORcG5Ukje5swv1zvLskA7Ab2NL2twCPzarf1q6a2Qgcn1m+kSQtjRWjDEpyIfDLwK/NKt8NPJxkK3AIuKXVnwBuBA4yuLLm9gXrVtKiW7/98bG99qt33zS21+7NSOFeVW8Bl55U+1sGV8+cPLaAOxakO0nSvHiHqiR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHVopHBPsjLJI0m+m2R/kl9MckmSJ5McaNuL29gkuS/JwSQvJLl6cd+CJOlko87cvwh8o6r+BfBxYD+wHdhTVRuAPe0Y4AZgQ3tsA+5f0I4lSXOaM9yTfBC4DtgJUFU/rqo3gc3ArjZsF3Bz298MPFgDzwArk6xe8M4lSac1ysz954Bp4A+TPJfkgSQXAVdU1VGAtr28jV8DHJ71/KlWO0GSbUkmk0xOT0+f05uQJJ1oxYhjrgY+X1V7k3yRd5dghsmQWp1SqNoB7ACYmJg45by0HKzf/vi4W5DmZZSZ+xQwVVV72/EjDML+tZnllrY9Nmv8ulnPXwscWZh2JUmjmDPcq+qvgcNJPtJKm4DvALuBLa22BXis7e8GbmtXzWwEjs8s30iSlsYoyzIAnwe+lOR84BXgdgb/MTycZCtwCLiljX0CuBE4CLzVxkqSltBI4V5VzwMTQ05tGjK2gDvOsS9J0jnwDlVJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0aKdyTvJrkxSTPJ5lstUuSPJnkQNte3OpJcl+Sg0leSHL1Yr4BSdKpzmbm/q+r6qqqmvldqtuBPVW1AdjTjgFuADa0xzbg/oVqVpI0mnNZltkM7Gr7u4CbZ9UfrIFngJVJVp/D60iSztKo4V7AN5PsS7Kt1a6oqqMAbXt5q68BDs967lSrnSDJtiSTSSanp6fn170kaagVI467tqqOJLkceDLJd88wNkNqdUqhagewA2BiYuKU85Kk+Rtp5l5VR9r2GPAocA3w2sxyS9sea8OngHWznr4WOLJQDUuS5jZnuCe5KMnPzOwDvwK8BOwGtrRhW4DH2v5u4LZ21cxG4PjM8o0kaWmMsixzBfBokpnxf1xV30jyF8DDSbYCh4Bb2vgngBuBg8BbwO0L3rUk6YzmDPeqegX4+JD63wKbhtQLuGNBupMkzYt3qEpShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHRg73JOcleS7J19vxlUn2JjmQ5CtJzm/197fjg+38+sVpXZJ0Omczc78T2D/r+B7g3qraALwBbG31rcAbVfVh4N42TpK0hEYK9yRrgZuAB9pxgOuBR9qQXcDNbX9zO6ad39TGS5KWyKgz998HfgP4x3Z8KfBmVb3djqeANW1/DXAYoJ0/3safIMm2JJNJJqenp+fZviRpmDnDPcmngWNVtW92ecjQGuHcu4WqHVU1UVUTq1atGqlZSdJoVoww5lrgM0luBC4APshgJr8yyYo2O18LHGnjp4B1wFSSFcCHgNcXvHNJ0mnNOXOvqt+qqrVVtR64FXiqqv4d8DTw2TZsC/BY29/djmnnn6qqU2bukqTFcy7Xuf8mcFeSgwzW1He2+k7g0la/C9h+bi1Kks7WKMsy76iqbwHfavuvANcMGfP3wC0L0JskaZ68Q1WSOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdeisPvJXkhbT+u2Pj+V1X737prG87mJy5i5JHTLcJalDc4Z7kguS/HmSbyd5OcnvtPqVSfYmOZDkK0nOb/X3t+OD7fz6xX0LkqSTjTJz/3/A9VX1ceAq4FNJNgL3APdW1QbgDWBrG78VeKOqPgzc28ZJkpbQnOFeAz9qh+9rjwKuBx5p9V3AzW1/czumnd+UJAvWsSRpTiOtuSc5L8nzwDHgSeB7wJtV9XYbMgWsaftrgMMA7fxx4NKFbFqSdGYjhXtV/UNVXQWsBa4BPjpsWNsOm6XXyYUk25JMJpmcnp4etV9J0gjO6jr3qnozybeAjcDKJCva7HwtcKQNmwLWAVNJVgAfAl4f8rV2ADsAJiYmTgl/abZxXf8svVeNcrXMqiQr2/4HgE8C+4Gngc+2YVuAx9r+7nZMO/9UVRnekrSERpm5rwZ2JTmPwX8GD1fV15N8B/hykv8KPAfsbON3Av89yUEGM/ZbF6FvSdIZzBnuVfUC8Ikh9VcYrL+fXP974JYF6U6SNC/eoSpJHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOj/ILsdUmeTrI/yctJ7mz1S5I8meRA217c6klyX5KDSV5IcvVivwlJ0olGmbm/DfznqvoosBG4I8nHgO3AnqraAOxpxwA3ABvaYxtw/4J3LUk6oznDvaqOVtWzbf/vgP3AGmAzsKsN2wXc3PY3Aw/WwDPAyiSrF7xzSdJpndWae5L1wCeAvcAVVXUUBv8BAJe3YWuAw7OeNtVqJ3+tbUkmk0xOT0+ffeeSpNMaOdyT/DTwVeALVfXDMw0dUqtTClU7qmqiqiZWrVo1ahuSpBGMFO5J3scg2L9UVV9r5ddmllva9lirTwHrZj19LXBkYdqVJI1ilKtlAuwE9lfV7806tRvY0va3AI/Nqt/WrprZCByfWb6RJC2NFSOMuRb4VeDFJM+32m8DdwMPJ9kKHAJuaeeeAG4EDgJvAbcvaMeSpDnNGe5V9WcMX0cH2DRkfAF3nGNfkqRz4B2qktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SerQKJ8KKb1j/fbHx92CpBE4c5ekDhnuktQhw12SOmS4S1KHRvkdqn+Q5FiSl2bVLknyZJIDbXtxqyfJfUkOJnkhydWL2bwkabhRZu5/BHzqpNp2YE9VbQD2tGOAG4AN7bENuH9h2pQknY05w72q/hfw+knlzcCutr8LuHlW/cEaeAZYmWT1QjUrSRrNfNfcr6iqowBte3mrrwEOzxo31WqnSLItyWSSyenp6Xm2IUkaZqF/oJohtRo2sKp2VNVEVU2sWrVqgduQpH/a5hvur80st7TtsVafAtbNGrcWODL/9iRJ8zHfcN8NbGn7W4DHZtVva1fNbASOzyzfSJKWzpyfLZPkIeBfAZclmQL+C3A38HCSrcAh4JY2/AngRuAg8BZw+yL0LEmaw5zhXlWfO82pTUPGFnDHuTYlSTo33qEqSR3yI3/fg/zYXUlzceYuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOuSlkJL+yRvn5cWv3n3TonxdZ+6S1CFn7ufAm4kkLVfO3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6tCiXOee5FPAF4HzgAeq6u7FeB3wWnNJGmbBZ+5JzgP+G3AD8DHgc0k+ttCvI0k6vcVYlrkGOFhVr1TVj4EvA5sX4XUkSaexGMsya4DDs46ngF84eVCSbcC2dvijJH+5CL0shMuAvxl3E6dhb/Njb/Njb/Nzxt5yzzl97X9+uhOLEe4ZUqtTClU7gB2L8PoLKslkVU2Mu49h7G1+7G1+7G1+xtXbYizLTAHrZh2vBY4swutIkk5jMcL9L4ANSa5Mcj5wK7B7EV5HknQaC74sU1VvJ/mPwJ8yuBTyD6rq5YV+nSW0nJeO7G1+7G1+7G1+xtJbqk5ZDpckvcd5h6okdchwl6QOGe5DJFmX5Okk+5O8nOTOcfc0I8kFSf48ybdbb78z7p5OluS8JM8l+fq4e5ktyatJXkzyfJLJcfczW5KVSR5J8t329+4Xx90TQJKPtD+vmccPk3xh3H3NSPLr7d/BS0keSnLBuHuakeTO1tfL4/gzc819iCSrgdVV9WySnwH2ATdX1XfG3BpJAlxUVT9K8j7gz4A7q+qZMbf2jiR3ARPAB6vq0+PuZ0aSV4GJqlp2N7sk2QX876p6oF1ldmFVvTnuvmZrHy3yA+AXqur7y6CfNQz+/n+sqv5vkoeBJ6rqj8bbGST5eQZ3518D/Bj4BvAfqurAUvXgzH2IqjpaVc+2/b8D9jO483bsauBH7fB97bFs/odOsha4CXhg3L28VyT5IHAdsBOgqn683IK92QR8bzkE+ywrgA8kWQFcyPK5p+ajwDNV9VZVvQ38T+DfLGUDhvsckqwHPgHsHW8n72rLHs8Dx4Anq2rZ9Ab8PvAbwD+Ou5EhCvhmkn3t4y+Wi58DpoE/bMtZDyS5aNxNDXEr8NC4m5hRVT8Afhc4BBwFjlfVN8fb1TteAq5LcmmSC4EbOfHmzkVnuJ9Bkp8Gvgp8oap+OO5+ZlTVP1TVVQzu/r2mfQs4dkk+DRyrqn3j7uU0rq2qqxl8YukdSa4bd0PNCuBq4P6q+gTwf4Dt423pRG2p6DPAn4y7lxlJLmbwoYRXAj8LXJTk34+3q4Gq2g/cAzzJYEnm28DbS9mD4X4abT37q8CXqupr4+5nmPat+7eAT425lRnXAp9pa9tfBq5P8j/G29K7qupI2x4DHmWwHrocTAFTs74De4RB2C8nNwDPVtVr425klk8Cf1VV01X1E+BrwC+Nuad3VNXOqrq6qq4DXgeWbL0dDPeh2g8tdwL7q+r3xt3PbElWJVnZ9j/A4C/4d8fb1UBV/VZVra2q9Qy+hX+qqpbFTCrJRe2H47Qlj19h8K3z2FXVXwOHk3yklTYBY//h/Uk+xzJakmkOARuTXNj+zW5i8POxZSHJ5W37z4B/yxL/+S3Kb2LqwLXArwIvtrVtgN+uqifG2NOM1cCuduXCTwEPV9WyuuRwmboCeHSQAawA/riqvjHelk7weeBLbfnjFeD2MffzjrZm/MvAr427l9mqam+SR4BnGSx5PMfy+hiCrya5FPgJcEdVvbGUL+6lkJLUIZdlJKlDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nq0P8HFgImXgFgiHcAAAAASUVORK5CYII=\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD4CAYAAAAXUaZHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAS1ElEQVR4nO3db4yd5Xnn8e+vOIRAm5g/Brm2d00VK5uoUgg7om6R0C5OqwBRzK6CRLRbLGTJ1YrNkrJS6/bNqtK+AKkqDdIKycJtzW5KQkkQVkBpkCG72xe4HQPhT5zKDiX2xC6eFnCaZbsJ7bUvzj0wto89x+OZOcPd70c6ep7neu4z5zqW/fM99zzPmVQVkqS+/NS4G5AkLTzDXZI6ZLhLUocMd0nqkOEuSR1aMe4GAC677LJav379uNuQpPeUffv2/U1VrRp2blmE+/r165mcnBx3G5L0npLk+6c757KMJHVopHBP8utJXk7yUpKHklyQ5Moke5McSPKVJOe3se9vxwfb+fWL+QYkSaeaM9yTrAH+EzBRVT8PnAfcCtwD3FtVG4A3gK3tKVuBN6rqw8C9bZwkaQmNuiyzAvhAkhXAhcBR4HrgkXZ+F3Bz29/cjmnnNyXJwrQrSRrFnOFeVT8Afhc4xCDUjwP7gDer6u02bApY0/bXAIfbc99u4y89+esm2ZZkMsnk9PT0ub4PSdIsoyzLXMxgNn4l8LPARcANQ4bOfALZsFn6KZ9OVlU7qmqiqiZWrRp6JY8kaZ5GWZb5JPBXVTVdVT8Bvgb8ErCyLdMArAWOtP0pYB1AO/8h4PUF7VqSdEajhPshYGOSC9va+SbgO8DTwGfbmC3AY21/dzumnX+q/FxhSVpSo6y572Xwg9FngRfbc3YAvwncleQggzX1ne0pO4FLW/0uYPsi9C1JOoMsh0n1xMREeYeqdKL12x8fy+u+evdNY3ldnb0k+6pqYtg571CVpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktShOcM9yUeSPD/r8cMkX0hySZInkxxo24vb+CS5L8nBJC8kuXrx34YkabZRfkH2X1bVVVV1FfAvgbeARxn84us9VbUB2MO7vwj7BmBDe2wD7l+MxiVJp3e2yzKbgO9V1feBzcCuVt8F3Nz2NwMP1sAzwMokqxekW0nSSM423G8FHmr7V1TVUYC2vbzV1wCHZz1nqtVOkGRbkskkk9PT02fZhiTpTEYO9yTnA58B/mSuoUNqdUqhakdVTVTVxKpVq0ZtQ5I0grOZud8APFtVr7Xj12aWW9r2WKtPAetmPW8tcORcG5Ukje5swv1zvLskA7Ab2NL2twCPzarf1q6a2Qgcn1m+kSQtjRWjDEpyIfDLwK/NKt8NPJxkK3AIuKXVnwBuBA4yuLLm9gXrVtKiW7/98bG99qt33zS21+7NSOFeVW8Bl55U+1sGV8+cPLaAOxakO0nSvHiHqiR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHVopHBPsjLJI0m+m2R/kl9MckmSJ5McaNuL29gkuS/JwSQvJLl6cd+CJOlko87cvwh8o6r+BfBxYD+wHdhTVRuAPe0Y4AZgQ3tsA+5f0I4lSXOaM9yTfBC4DtgJUFU/rqo3gc3ArjZsF3Bz298MPFgDzwArk6xe8M4lSac1ysz954Bp4A+TPJfkgSQXAVdU1VGAtr28jV8DHJ71/KlWO0GSbUkmk0xOT0+f05uQJJ1oxYhjrgY+X1V7k3yRd5dghsmQWp1SqNoB7ACYmJg45by0HKzf/vi4W5DmZZSZ+xQwVVV72/EjDML+tZnllrY9Nmv8ulnPXwscWZh2JUmjmDPcq+qvgcNJPtJKm4DvALuBLa22BXis7e8GbmtXzWwEjs8s30iSlsYoyzIAnwe+lOR84BXgdgb/MTycZCtwCLiljX0CuBE4CLzVxkqSltBI4V5VzwMTQ05tGjK2gDvOsS9J0jnwDlVJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0aKdyTvJrkxSTPJ5lstUuSPJnkQNte3OpJcl+Sg0leSHL1Yr4BSdKpzmbm/q+r6qqqmvldqtuBPVW1AdjTjgFuADa0xzbg/oVqVpI0mnNZltkM7Gr7u4CbZ9UfrIFngJVJVp/D60iSztKo4V7AN5PsS7Kt1a6oqqMAbXt5q68BDs967lSrnSDJtiSTSSanp6fn170kaagVI467tqqOJLkceDLJd88wNkNqdUqhagewA2BiYuKU85Kk+Rtp5l5VR9r2GPAocA3w2sxyS9sea8OngHWznr4WOLJQDUuS5jZnuCe5KMnPzOwDvwK8BOwGtrRhW4DH2v5u4LZ21cxG4PjM8o0kaWmMsixzBfBokpnxf1xV30jyF8DDSbYCh4Bb2vgngBuBg8BbwO0L3rUk6YzmDPeqegX4+JD63wKbhtQLuGNBupMkzYt3qEpShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHRg73JOcleS7J19vxlUn2JjmQ5CtJzm/197fjg+38+sVpXZJ0Omczc78T2D/r+B7g3qraALwBbG31rcAbVfVh4N42TpK0hEYK9yRrgZuAB9pxgOuBR9qQXcDNbX9zO6ad39TGS5KWyKgz998HfgP4x3Z8KfBmVb3djqeANW1/DXAYoJ0/3safIMm2JJNJJqenp+fZviRpmDnDPcmngWNVtW92ecjQGuHcu4WqHVU1UVUTq1atGqlZSdJoVoww5lrgM0luBC4APshgJr8yyYo2O18LHGnjp4B1wFSSFcCHgNcXvHNJ0mnNOXOvqt+qqrVVtR64FXiqqv4d8DTw2TZsC/BY29/djmnnn6qqU2bukqTFcy7Xuf8mcFeSgwzW1He2+k7g0la/C9h+bi1Kks7WKMsy76iqbwHfavuvANcMGfP3wC0L0JskaZ68Q1WSOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdeisPvJXkhbT+u2Pj+V1X737prG87mJy5i5JHTLcJalDc4Z7kguS/HmSbyd5OcnvtPqVSfYmOZDkK0nOb/X3t+OD7fz6xX0LkqSTjTJz/3/A9VX1ceAq4FNJNgL3APdW1QbgDWBrG78VeKOqPgzc28ZJkpbQnOFeAz9qh+9rjwKuBx5p9V3AzW1/czumnd+UJAvWsSRpTiOtuSc5L8nzwDHgSeB7wJtV9XYbMgWsaftrgMMA7fxx4NKFbFqSdGYjhXtV/UNVXQWsBa4BPjpsWNsOm6XXyYUk25JMJpmcnp4etV9J0gjO6jr3qnozybeAjcDKJCva7HwtcKQNmwLWAVNJVgAfAl4f8rV2ADsAJiYmTgl/abZxXf8svVeNcrXMqiQr2/4HgE8C+4Gngc+2YVuAx9r+7nZMO/9UVRnekrSERpm5rwZ2JTmPwX8GD1fV15N8B/hykv8KPAfsbON3Av89yUEGM/ZbF6FvSdIZzBnuVfUC8Ikh9VcYrL+fXP974JYF6U6SNC/eoSpJHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOj/ILsdUmeTrI/yctJ7mz1S5I8meRA217c6klyX5KDSV5IcvVivwlJ0olGmbm/DfznqvoosBG4I8nHgO3AnqraAOxpxwA3ABvaYxtw/4J3LUk6oznDvaqOVtWzbf/vgP3AGmAzsKsN2wXc3PY3Aw/WwDPAyiSrF7xzSdJpndWae5L1wCeAvcAVVXUUBv8BAJe3YWuAw7OeNtVqJ3+tbUkmk0xOT0+ffeeSpNMaOdyT/DTwVeALVfXDMw0dUqtTClU7qmqiqiZWrVo1ahuSpBGMFO5J3scg2L9UVV9r5ddmllva9lirTwHrZj19LXBkYdqVJI1ilKtlAuwE9lfV7806tRvY0va3AI/Nqt/WrprZCByfWb6RJC2NFSOMuRb4VeDFJM+32m8DdwMPJ9kKHAJuaeeeAG4EDgJvAbcvaMeSpDnNGe5V9WcMX0cH2DRkfAF3nGNfkqRz4B2qktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SerQKJ8KKb1j/fbHx92CpBE4c5ekDhnuktQhw12SOmS4S1KHRvkdqn+Q5FiSl2bVLknyZJIDbXtxqyfJfUkOJnkhydWL2bwkabhRZu5/BHzqpNp2YE9VbQD2tGOAG4AN7bENuH9h2pQknY05w72q/hfw+knlzcCutr8LuHlW/cEaeAZYmWT1QjUrSRrNfNfcr6iqowBte3mrrwEOzxo31WqnSLItyWSSyenp6Xm2IUkaZqF/oJohtRo2sKp2VNVEVU2sWrVqgduQpH/a5hvur80st7TtsVafAtbNGrcWODL/9iRJ8zHfcN8NbGn7W4DHZtVva1fNbASOzyzfSJKWzpyfLZPkIeBfAZclmQL+C3A38HCSrcAh4JY2/AngRuAg8BZw+yL0LEmaw5zhXlWfO82pTUPGFnDHuTYlSTo33qEqSR3yI3/fg/zYXUlzceYuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOuSlkJL+yRvn5cWv3n3TonxdZ+6S1CFn7ufAm4kkLVfO3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6tCiXOee5FPAF4HzgAeq6u7FeB3wWnNJGmbBZ+5JzgP+G3AD8DHgc0k+ttCvI0k6vcVYlrkGOFhVr1TVj4EvA5sX4XUkSaexGMsya4DDs46ngF84eVCSbcC2dvijJH+5CL0shMuAvxl3E6dhb/Njb/Njb/Nzxt5yzzl97X9+uhOLEe4ZUqtTClU7gB2L8PoLKslkVU2Mu49h7G1+7G1+7G1+xtXbYizLTAHrZh2vBY4swutIkk5jMcL9L4ANSa5Mcj5wK7B7EV5HknQaC74sU1VvJ/mPwJ8yuBTyD6rq5YV+nSW0nJeO7G1+7G1+7G1+xtJbqk5ZDpckvcd5h6okdchwl6QOGe5DJFmX5Okk+5O8nOTOcfc0I8kFSf48ybdbb78z7p5OluS8JM8l+fq4e5ktyatJXkzyfJLJcfczW5KVSR5J8t329+4Xx90TQJKPtD+vmccPk3xh3H3NSPLr7d/BS0keSnLBuHuakeTO1tfL4/gzc819iCSrgdVV9WySnwH2ATdX1XfG3BpJAlxUVT9K8j7gz4A7q+qZMbf2jiR3ARPAB6vq0+PuZ0aSV4GJqlp2N7sk2QX876p6oF1ldmFVvTnuvmZrHy3yA+AXqur7y6CfNQz+/n+sqv5vkoeBJ6rqj8bbGST5eQZ3518D/Bj4BvAfqurAUvXgzH2IqjpaVc+2/b8D9jO483bsauBH7fB97bFs/odOsha4CXhg3L28VyT5IHAdsBOgqn683IK92QR8bzkE+ywrgA8kWQFcyPK5p+ajwDNV9VZVvQ38T+DfLGUDhvsckqwHPgHsHW8n72rLHs8Dx4Anq2rZ9Ab8PvAbwD+Ou5EhCvhmkn3t4y+Wi58DpoE/bMtZDyS5aNxNDXEr8NC4m5hRVT8Afhc4BBwFjlfVN8fb1TteAq5LcmmSC4EbOfHmzkVnuJ9Bkp8Gvgp8oap+OO5+ZlTVP1TVVQzu/r2mfQs4dkk+DRyrqn3j7uU0rq2qqxl8YukdSa4bd0PNCuBq4P6q+gTwf4Dt423pRG2p6DPAn4y7lxlJLmbwoYRXAj8LXJTk34+3q4Gq2g/cAzzJYEnm28DbS9mD4X4abT37q8CXqupr4+5nmPat+7eAT425lRnXAp9pa9tfBq5P8j/G29K7qupI2x4DHmWwHrocTAFTs74De4RB2C8nNwDPVtVr425klk8Cf1VV01X1E+BrwC+Nuad3VNXOqrq6qq4DXgeWbL0dDPeh2g8tdwL7q+r3xt3PbElWJVnZ9j/A4C/4d8fb1UBV/VZVra2q9Qy+hX+qqpbFTCrJRe2H47Qlj19h8K3z2FXVXwOHk3yklTYBY//h/Uk+xzJakmkOARuTXNj+zW5i8POxZSHJ5W37z4B/yxL/+S3Kb2LqwLXArwIvtrVtgN+uqifG2NOM1cCuduXCTwEPV9WyuuRwmboCeHSQAawA/riqvjHelk7weeBLbfnjFeD2MffzjrZm/MvAr427l9mqam+SR4BnGSx5PMfy+hiCrya5FPgJcEdVvbGUL+6lkJLUIZdlJKlDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nq0P8HFgImXgFgiHcAAAAASUVORK5CYII=",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
@@ -569,32 +562,32 @@
             "needs_background": "light"
           }
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "xq651UDL_G_C"
-      },
-      "source": [
-        "Did you get an error or a warning? What's going on? \n",
-        "\n",
-        "The problem is that the column contains `NaN` (Not a Number) values, which represent missing data points. The following command check whether each value is a `NaN` and returns the result. "
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "l-bbby0r_G_C",
-        "outputId": "db24a93e-5e7f-440c-bd0e-2a8c5a197a13"
-      },
+        "id": "bWFmgyf6_G_B",
+        "outputId": "364d0d2d-9fe2-4bb1-e889-47714ca7576a"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Did you get an error or a warning? What's going on? \n",
+        "\n",
+        "The problem is that the column contains `NaN` (Not a Number) values, which represent missing data points. The following command check whether each value is a `NaN` and returns the result. "
+      ],
+      "metadata": {
+        "id": "xq651UDL_G_C"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "movies['IMDB_Rating'].isna()"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -619,30 +612,30 @@
           },
           "execution_count": 18
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5KArMNuy_G_D"
-      },
-      "source": [
-        "As you can see there are a bunch of missing rows. You can count them. "
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "NLIOP85J_G_D",
-        "outputId": "d39e0066-8ce3-43da-8643-197397c8573d"
-      },
+        "id": "l-bbby0r_G_C",
+        "outputId": "db24a93e-5e7f-440c-bd0e-2a8c5a197a13"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "As you can see there are a bunch of missing rows. You can count them. "
+      ],
+      "metadata": {
+        "id": "5KArMNuy_G_D"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "sum(movies['IMDB_Rating'].isna())"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -656,31 +649,31 @@
           },
           "execution_count": 19
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "HNl9DzI8_G_D"
-      },
-      "source": [
-        "or drop them. "
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "fRcgNczJ_G_E",
-        "outputId": "985f5bca-2af6-4435-cb01-8f3607cd8892"
-      },
+        "id": "NLIOP85J_G_D",
+        "outputId": "d39e0066-8ce3-43da-8643-197397c8573d"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "or drop them. "
+      ],
+      "metadata": {
+        "id": "HNl9DzI8_G_D"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "IMDB_ratings_nan_dropped = movies['IMDB_Rating'].dropna()\n",
         "len(IMDB_ratings_nan_dropped)"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -694,21 +687,21 @@
           },
           "execution_count": 20
         }
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "IwHSLkO-_G_E",
-        "outputId": "a1e1bec0-7410-4c14-94c8-717b82a09fcc"
-      },
+        "id": "fRcgNczJ_G_E",
+        "outputId": "985f5bca-2af6-4435-cb01-8f3607cd8892"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "213 + 2988"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -722,85 +715,85 @@
           },
           "execution_count": 21
         }
-      ]
+      ],
+      "metadata": {
+        "jupyter": {
+          "outputs_hidden": false
+        },
+        "id": "IwHSLkO-_G_E",
+        "outputId": "a1e1bec0-7410-4c14-94c8-717b82a09fcc"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "ilwIh89N_G_F"
-      },
       "source": [
         "The `dropna` can be applied to the dataframe too. \n",
         "\n",
         "**Q: drop rows from `movies` dataframe where either `IMDB_Rating` or `IMDB_Votes` is `NaN`.**"
-      ]
+      ],
+      "metadata": {
+        "id": "ilwIh89N_G_F"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "id": "-3lfyoBg_G_F"
-      },
+      "execution_count": null,
       "source": [
         "# TODO\n"
       ],
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "metadata": {
+        "id": "-3lfyoBg_G_F"
+      }
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "# Both should be zero. \n",
+        "print(sum(movies['IMDB_Rating'].isna()), sum(movies['IMDB_Votes'].isna()))"
+      ],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "0 0\n"
+          ]
+        }
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
         "id": "fDbetoUi_G_F",
         "outputId": "7280693c-567c-4c0e-a181-5a742588907f"
-      },
-      "source": [
-        "# Both should be zero. \n",
-        "print(sum(movies['IMDB_Rating'].isna()), sum(movies['IMDB_Votes'].isna()))"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "0 0\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "ce-ZFHwu_G_G"
-      },
       "source": [
         "How does `matplotlib` decides the bins? Actually `matplotlib`'s `hist` function uses `numpy`'s `histogram` function under the hood. "
-      ]
+      ],
+      "metadata": {
+        "id": "ce-ZFHwu_G_G"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "zOm7ESwb_G_G"
-      },
       "source": [
         "**Q: Plot the histogram of movie ratings (`IMDB_Rating`) using the `plt.hist()` function.**"
-      ]
+      ],
+      "metadata": {
+        "id": "zOm7ESwb_G_G"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "jupyter": {
-          "outputs_hidden": false
-        },
-        "id": "UBp4ZGKW_G_H",
-        "outputId": "aca207de-0d5c-4858-feb6-72855368ac02"
-      },
+      "execution_count": null,
       "source": [
         "# TODO\n"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -819,7 +812,7 @@
         {
           "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD4CAYAAAAXUaZHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAS1ElEQVR4nO3db4yd5Xnn8e+vOIRAm5g/Brm2d00VK5uoUgg7om6R0C5OqwBRzK6CRLRbLGTJ1YrNkrJS6/bNqtK+AKkqDdIKycJtzW5KQkkQVkBpkCG72xe4HQPhT5zKDiX2xC6eFnCaZbsJ7bUvzj0wto89x+OZOcPd70c6ep7neu4z5zqW/fM99zzPmVQVkqS+/NS4G5AkLTzDXZI6ZLhLUocMd0nqkOEuSR1aMe4GAC677LJav379uNuQpPeUffv2/U1VrRp2blmE+/r165mcnBx3G5L0npLk+6c757KMJHVopHBP8utJXk7yUpKHklyQ5Moke5McSPKVJOe3se9vxwfb+fWL+QYkSaeaM9yTrAH+EzBRVT8PnAfcCtwD3FtVG4A3gK3tKVuBN6rqw8C9bZwkaQmNuiyzAvhAkhXAhcBR4HrgkXZ+F3Bz29/cjmnnNyXJwrQrSRrFnOFeVT8Afhc4xCDUjwP7gDer6u02bApY0/bXAIfbc99u4y89+esm2ZZkMsnk9PT0ub4PSdIsoyzLXMxgNn4l8LPARcANQ4bOfALZsFn6KZ9OVlU7qmqiqiZWrRp6JY8kaZ5GWZb5JPBXVTVdVT8Bvgb8ErCyLdMArAWOtP0pYB1AO/8h4PUF7VqSdEajhPshYGOSC9va+SbgO8DTwGfbmC3AY21/dzumnX+q/FxhSVpSo6y572Xwg9FngRfbc3YAvwncleQggzX1ne0pO4FLW/0uYPsi9C1JOoMsh0n1xMREeYeqdKL12x8fy+u+evdNY3ldnb0k+6pqYtg571CVpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktShOcM9yUeSPD/r8cMkX0hySZInkxxo24vb+CS5L8nBJC8kuXrx34YkabZRfkH2X1bVVVV1FfAvgbeARxn84us9VbUB2MO7vwj7BmBDe2wD7l+MxiVJp3e2yzKbgO9V1feBzcCuVt8F3Nz2NwMP1sAzwMokqxekW0nSSM423G8FHmr7V1TVUYC2vbzV1wCHZz1nqtVOkGRbkskkk9PT02fZhiTpTEYO9yTnA58B/mSuoUNqdUqhakdVTVTVxKpVq0ZtQ5I0grOZud8APFtVr7Xj12aWW9r2WKtPAetmPW8tcORcG5Ukje5swv1zvLskA7Ab2NL2twCPzarf1q6a2Qgcn1m+kSQtjRWjDEpyIfDLwK/NKt8NPJxkK3AIuKXVnwBuBA4yuLLm9gXrVtKiW7/98bG99qt33zS21+7NSOFeVW8Bl55U+1sGV8+cPLaAOxakO0nSvHiHqiR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHVopHBPsjLJI0m+m2R/kl9MckmSJ5McaNuL29gkuS/JwSQvJLl6cd+CJOlko87cvwh8o6r+BfBxYD+wHdhTVRuAPe0Y4AZgQ3tsA+5f0I4lSXOaM9yTfBC4DtgJUFU/rqo3gc3ArjZsF3Bz298MPFgDzwArk6xe8M4lSac1ysz954Bp4A+TPJfkgSQXAVdU1VGAtr28jV8DHJ71/KlWO0GSbUkmk0xOT0+f05uQJJ1oxYhjrgY+X1V7k3yRd5dghsmQWp1SqNoB7ACYmJg45by0HKzf/vi4W5DmZZSZ+xQwVVV72/EjDML+tZnllrY9Nmv8ulnPXwscWZh2JUmjmDPcq+qvgcNJPtJKm4DvALuBLa22BXis7e8GbmtXzWwEjs8s30iSlsYoyzIAnwe+lOR84BXgdgb/MTycZCtwCLiljX0CuBE4CLzVxkqSltBI4V5VzwMTQ05tGjK2gDvOsS9J0jnwDlVJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0aKdyTvJrkxSTPJ5lstUuSPJnkQNte3OpJcl+Sg0leSHL1Yr4BSdKpzmbm/q+r6qqqmvldqtuBPVW1AdjTjgFuADa0xzbg/oVqVpI0mnNZltkM7Gr7u4CbZ9UfrIFngJVJVp/D60iSztKo4V7AN5PsS7Kt1a6oqqMAbXt5q68BDs967lSrnSDJtiSTSSanp6fn170kaagVI467tqqOJLkceDLJd88wNkNqdUqhagewA2BiYuKU85Kk+Rtp5l5VR9r2GPAocA3w2sxyS9sea8OngHWznr4WOLJQDUuS5jZnuCe5KMnPzOwDvwK8BOwGtrRhW4DH2v5u4LZ21cxG4PjM8o0kaWmMsixzBfBokpnxf1xV30jyF8DDSbYCh4Bb2vgngBuBg8BbwO0L3rUk6YzmDPeqegX4+JD63wKbhtQLuGNBupMkzYt3qEpShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHRg73JOcleS7J19vxlUn2JjmQ5CtJzm/197fjg+38+sVpXZJ0Omczc78T2D/r+B7g3qraALwBbG31rcAbVfVh4N42TpK0hEYK9yRrgZuAB9pxgOuBR9qQXcDNbX9zO6ad39TGS5KWyKgz998HfgP4x3Z8KfBmVb3djqeANW1/DXAYoJ0/3safIMm2JJNJJqenp+fZviRpmDnDPcmngWNVtW92ecjQGuHcu4WqHVU1UVUTq1atGqlZSdJoVoww5lrgM0luBC4APshgJr8yyYo2O18LHGnjp4B1wFSSFcCHgNcXvHNJ0mnNOXOvqt+qqrVVtR64FXiqqv4d8DTw2TZsC/BY29/djmnnn6qqU2bukqTFcy7Xuf8mcFeSgwzW1He2+k7g0la/C9h+bi1Kks7WKMsy76iqbwHfavuvANcMGfP3wC0L0JskaZ68Q1WSOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdeisPvJXkhbT+u2Pj+V1X737prG87mJy5i5JHTLcJalDc4Z7kguS/HmSbyd5OcnvtPqVSfYmOZDkK0nOb/X3t+OD7fz6xX0LkqSTjTJz/3/A9VX1ceAq4FNJNgL3APdW1QbgDWBrG78VeKOqPgzc28ZJkpbQnOFeAz9qh+9rjwKuBx5p9V3AzW1/czumnd+UJAvWsSRpTiOtuSc5L8nzwDHgSeB7wJtV9XYbMgWsaftrgMMA7fxx4NKFbFqSdGYjhXtV/UNVXQWsBa4BPjpsWNsOm6XXyYUk25JMJpmcnp4etV9J0gjO6jr3qnozybeAjcDKJCva7HwtcKQNmwLWAVNJVgAfAl4f8rV2ADsAJiYmTgl/abZxXf8svVeNcrXMqiQr2/4HgE8C+4Gngc+2YVuAx9r+7nZMO/9UVRnekrSERpm5rwZ2JTmPwX8GD1fV15N8B/hykv8KPAfsbON3Av89yUEGM/ZbF6FvSdIZzBnuVfUC8Ikh9VcYrL+fXP974JYF6U6SNC/eoSpJHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOj/ILsdUmeTrI/yctJ7mz1S5I8meRA217c6klyX5KDSV5IcvVivwlJ0olGmbm/DfznqvoosBG4I8nHgO3AnqraAOxpxwA3ABvaYxtw/4J3LUk6oznDvaqOVtWzbf/vgP3AGmAzsKsN2wXc3PY3Aw/WwDPAyiSrF7xzSdJpndWae5L1wCeAvcAVVXUUBv8BAJe3YWuAw7OeNtVqJ3+tbUkmk0xOT0+ffeeSpNMaOdyT/DTwVeALVfXDMw0dUqtTClU7qmqiqiZWrVo1ahuSpBGMFO5J3scg2L9UVV9r5ddmllva9lirTwHrZj19LXBkYdqVJI1ilKtlAuwE9lfV7806tRvY0va3AI/Nqt/WrprZCByfWb6RJC2NFSOMuRb4VeDFJM+32m8DdwMPJ9kKHAJuaeeeAG4EDgJvAbcvaMeSpDnNGe5V9WcMX0cH2DRkfAF3nGNfkqRz4B2qktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SerQKJ8KKb1j/fbHx92CpBE4c5ekDhnuktQhw12SOmS4S1KHRvkdqn+Q5FiSl2bVLknyZJIDbXtxqyfJfUkOJnkhydWL2bwkabhRZu5/BHzqpNp2YE9VbQD2tGOAG4AN7bENuH9h2pQknY05w72q/hfw+knlzcCutr8LuHlW/cEaeAZYmWT1QjUrSRrNfNfcr6iqowBte3mrrwEOzxo31WqnSLItyWSSyenp6Xm2IUkaZqF/oJohtRo2sKp2VNVEVU2sWrVqgduQpH/a5hvur80st7TtsVafAtbNGrcWODL/9iRJ8zHfcN8NbGn7W4DHZtVva1fNbASOzyzfSJKWzpyfLZPkIeBfAZclmQL+C3A38HCSrcAh4JY2/AngRuAg8BZw+yL0LEmaw5zhXlWfO82pTUPGFnDHuTYlSTo33qEqSR3yI3/fg/zYXUlzceYuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOuSlkJL+yRvn5cWv3n3TonxdZ+6S1CFn7ufAm4kkLVfO3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6tCiXOee5FPAF4HzgAeq6u7FeB3wWnNJGmbBZ+5JzgP+G3AD8DHgc0k+ttCvI0k6vcVYlrkGOFhVr1TVj4EvA5sX4XUkSaexGMsya4DDs46ngF84eVCSbcC2dvijJH+5CL0shMuAvxl3E6dhb/Njb/Njb/Nzxt5yzzl97X9+uhOLEe4ZUqtTClU7gB2L8PoLKslkVU2Mu49h7G1+7G1+7G1+xtXbYizLTAHrZh2vBY4swutIkk5jMcL9L4ANSa5Mcj5wK7B7EV5HknQaC74sU1VvJ/mPwJ8yuBTyD6rq5YV+nSW0nJeO7G1+7G1+7G1+xtJbqk5ZDpckvcd5h6okdchwl6QOGe5DJFmX5Okk+5O8nOTOcfc0I8kFSf48ybdbb78z7p5OluS8JM8l+fq4e5ktyatJXkzyfJLJcfczW5KVSR5J8t329+4Xx90TQJKPtD+vmccPk3xh3H3NSPLr7d/BS0keSnLBuHuakeTO1tfL4/gzc819iCSrgdVV9WySnwH2ATdX1XfG3BpJAlxUVT9K8j7gz4A7q+qZMbf2jiR3ARPAB6vq0+PuZ0aSV4GJqlp2N7sk2QX876p6oF1ldmFVvTnuvmZrHy3yA+AXqur7y6CfNQz+/n+sqv5vkoeBJ6rqj8bbGST5eQZ3518D/Bj4BvAfqurAUvXgzH2IqjpaVc+2/b8D9jO483bsauBH7fB97bFs/odOsha4CXhg3L28VyT5IHAdsBOgqn683IK92QR8bzkE+ywrgA8kWQFcyPK5p+ajwDNV9VZVvQ38T+DfLGUDhvsckqwHPgHsHW8n72rLHs8Dx4Anq2rZ9Ab8PvAbwD+Ou5EhCvhmkn3t4y+Wi58DpoE/bMtZDyS5aNxNDXEr8NC4m5hRVT8Afhc4BBwFjlfVN8fb1TteAq5LcmmSC4EbOfHmzkVnuJ9Bkp8Gvgp8oap+OO5+ZlTVP1TVVQzu/r2mfQs4dkk+DRyrqn3j7uU0rq2qqxl8YukdSa4bd0PNCuBq4P6q+gTwf4Dt423pRG2p6DPAn4y7lxlJLmbwoYRXAj8LXJTk34+3q4Gq2g/cAzzJYEnm28DbS9mD4X4abT37q8CXqupr4+5nmPat+7eAT425lRnXAp9pa9tfBq5P8j/G29K7qupI2x4DHmWwHrocTAFTs74De4RB2C8nNwDPVtVr425klk8Cf1VV01X1E+BrwC+Nuad3VNXOqrq6qq4DXgeWbL0dDPeh2g8tdwL7q+r3xt3PbElWJVnZ9j/A4C/4d8fb1UBV/VZVra2q9Qy+hX+qqpbFTCrJRe2H47Qlj19h8K3z2FXVXwOHk3yklTYBY//h/Uk+xzJakmkOARuTXNj+zW5i8POxZSHJ5W37z4B/yxL/+S3Kb2LqwLXArwIvtrVtgN+uqifG2NOM1cCuduXCTwEPV9WyuuRwmboCeHSQAawA/riqvjHelk7weeBLbfnjFeD2MffzjrZm/MvAr427l9mqam+SR4BnGSx5PMfy+hiCrya5FPgJcEdVvbGUL+6lkJLUIZdlJKlDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nq0P8HFgImXgFgiHcAAAAASUVORK5CYII=\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD4CAYAAAAXUaZHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAS1ElEQVR4nO3db4yd5Xnn8e+vOIRAm5g/Brm2d00VK5uoUgg7om6R0C5OqwBRzK6CRLRbLGTJ1YrNkrJS6/bNqtK+AKkqDdIKycJtzW5KQkkQVkBpkCG72xe4HQPhT5zKDiX2xC6eFnCaZbsJ7bUvzj0wto89x+OZOcPd70c6ep7neu4z5zqW/fM99zzPmVQVkqS+/NS4G5AkLTzDXZI6ZLhLUocMd0nqkOEuSR1aMe4GAC677LJav379uNuQpPeUffv2/U1VrRp2blmE+/r165mcnBx3G5L0npLk+6c757KMJHVopHBP8utJXk7yUpKHklyQ5Moke5McSPKVJOe3se9vxwfb+fWL+QYkSaeaM9yTrAH+EzBRVT8PnAfcCtwD3FtVG4A3gK3tKVuBN6rqw8C9bZwkaQmNuiyzAvhAkhXAhcBR4HrgkXZ+F3Bz29/cjmnnNyXJwrQrSRrFnOFeVT8Afhc4xCDUjwP7gDer6u02bApY0/bXAIfbc99u4y89+esm2ZZkMsnk9PT0ub4PSdIsoyzLXMxgNn4l8LPARcANQ4bOfALZsFn6KZ9OVlU7qmqiqiZWrRp6JY8kaZ5GWZb5JPBXVTVdVT8Bvgb8ErCyLdMArAWOtP0pYB1AO/8h4PUF7VqSdEajhPshYGOSC9va+SbgO8DTwGfbmC3AY21/dzumnX+q/FxhSVpSo6y572Xwg9FngRfbc3YAvwncleQggzX1ne0pO4FLW/0uYPsi9C1JOoMsh0n1xMREeYeqdKL12x8fy+u+evdNY3ldnb0k+6pqYtg571CVpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktShOcM9yUeSPD/r8cMkX0hySZInkxxo24vb+CS5L8nBJC8kuXrx34YkabZRfkH2X1bVVVV1FfAvgbeARxn84us9VbUB2MO7vwj7BmBDe2wD7l+MxiVJp3e2yzKbgO9V1feBzcCuVt8F3Nz2NwMP1sAzwMokqxekW0nSSM423G8FHmr7V1TVUYC2vbzV1wCHZz1nqtVOkGRbkskkk9PT02fZhiTpTEYO9yTnA58B/mSuoUNqdUqhakdVTVTVxKpVq0ZtQ5I0grOZud8APFtVr7Xj12aWW9r2WKtPAetmPW8tcORcG5Ukje5swv1zvLskA7Ab2NL2twCPzarf1q6a2Qgcn1m+kSQtjRWjDEpyIfDLwK/NKt8NPJxkK3AIuKXVnwBuBA4yuLLm9gXrVtKiW7/98bG99qt33zS21+7NSOFeVW8Bl55U+1sGV8+cPLaAOxakO0nSvHiHqiR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHVopHBPsjLJI0m+m2R/kl9MckmSJ5McaNuL29gkuS/JwSQvJLl6cd+CJOlko87cvwh8o6r+BfBxYD+wHdhTVRuAPe0Y4AZgQ3tsA+5f0I4lSXOaM9yTfBC4DtgJUFU/rqo3gc3ArjZsF3Bz298MPFgDzwArk6xe8M4lSac1ysz954Bp4A+TPJfkgSQXAVdU1VGAtr28jV8DHJ71/KlWO0GSbUkmk0xOT0+f05uQJJ1oxYhjrgY+X1V7k3yRd5dghsmQWp1SqNoB7ACYmJg45by0HKzf/vi4W5DmZZSZ+xQwVVV72/EjDML+tZnllrY9Nmv8ulnPXwscWZh2JUmjmDPcq+qvgcNJPtJKm4DvALuBLa22BXis7e8GbmtXzWwEjs8s30iSlsYoyzIAnwe+lOR84BXgdgb/MTycZCtwCLiljX0CuBE4CLzVxkqSltBI4V5VzwMTQ05tGjK2gDvOsS9J0jnwDlVJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0aKdyTvJrkxSTPJ5lstUuSPJnkQNte3OpJcl+Sg0leSHL1Yr4BSdKpzmbm/q+r6qqqmvldqtuBPVW1AdjTjgFuADa0xzbg/oVqVpI0mnNZltkM7Gr7u4CbZ9UfrIFngJVJVp/D60iSztKo4V7AN5PsS7Kt1a6oqqMAbXt5q68BDs967lSrnSDJtiSTSSanp6fn170kaagVI467tqqOJLkceDLJd88wNkNqdUqhagewA2BiYuKU85Kk+Rtp5l5VR9r2GPAocA3w2sxyS9sea8OngHWznr4WOLJQDUuS5jZnuCe5KMnPzOwDvwK8BOwGtrRhW4DH2v5u4LZ21cxG4PjM8o0kaWmMsixzBfBokpnxf1xV30jyF8DDSbYCh4Bb2vgngBuBg8BbwO0L3rUk6YzmDPeqegX4+JD63wKbhtQLuGNBupMkzYt3qEpShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHRg73JOcleS7J19vxlUn2JjmQ5CtJzm/197fjg+38+sVpXZJ0Omczc78T2D/r+B7g3qraALwBbG31rcAbVfVh4N42TpK0hEYK9yRrgZuAB9pxgOuBR9qQXcDNbX9zO6ad39TGS5KWyKgz998HfgP4x3Z8KfBmVb3djqeANW1/DXAYoJ0/3safIMm2JJNJJqenp+fZviRpmDnDPcmngWNVtW92ecjQGuHcu4WqHVU1UVUTq1atGqlZSdJoVoww5lrgM0luBC4APshgJr8yyYo2O18LHGnjp4B1wFSSFcCHgNcXvHNJ0mnNOXOvqt+qqrVVtR64FXiqqv4d8DTw2TZsC/BY29/djmnnn6qqU2bukqTFcy7Xuf8mcFeSgwzW1He2+k7g0la/C9h+bi1Kks7WKMsy76iqbwHfavuvANcMGfP3wC0L0JskaZ68Q1WSOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdeisPvJXkhbT+u2Pj+V1X737prG87mJy5i5JHTLcJalDc4Z7kguS/HmSbyd5OcnvtPqVSfYmOZDkK0nOb/X3t+OD7fz6xX0LkqSTjTJz/3/A9VX1ceAq4FNJNgL3APdW1QbgDWBrG78VeKOqPgzc28ZJkpbQnOFeAz9qh+9rjwKuBx5p9V3AzW1/czumnd+UJAvWsSRpTiOtuSc5L8nzwDHgSeB7wJtV9XYbMgWsaftrgMMA7fxx4NKFbFqSdGYjhXtV/UNVXQWsBa4BPjpsWNsOm6XXyYUk25JMJpmcnp4etV9J0gjO6jr3qnozybeAjcDKJCva7HwtcKQNmwLWAVNJVgAfAl4f8rV2ADsAJiYmTgl/abZxXf8svVeNcrXMqiQr2/4HgE8C+4Gngc+2YVuAx9r+7nZMO/9UVRnekrSERpm5rwZ2JTmPwX8GD1fV15N8B/hykv8KPAfsbON3Av89yUEGM/ZbF6FvSdIZzBnuVfUC8Ikh9VcYrL+fXP974JYF6U6SNC/eoSpJHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOj/ILsdUmeTrI/yctJ7mz1S5I8meRA217c6klyX5KDSV5IcvVivwlJ0olGmbm/DfznqvoosBG4I8nHgO3AnqraAOxpxwA3ABvaYxtw/4J3LUk6oznDvaqOVtWzbf/vgP3AGmAzsKsN2wXc3PY3Aw/WwDPAyiSrF7xzSdJpndWae5L1wCeAvcAVVXUUBv8BAJe3YWuAw7OeNtVqJ3+tbUkmk0xOT0+ffeeSpNMaOdyT/DTwVeALVfXDMw0dUqtTClU7qmqiqiZWrVo1ahuSpBGMFO5J3scg2L9UVV9r5ddmllva9lirTwHrZj19LXBkYdqVJI1ilKtlAuwE9lfV7806tRvY0va3AI/Nqt/WrprZCByfWb6RJC2NFSOMuRb4VeDFJM+32m8DdwMPJ9kKHAJuaeeeAG4EDgJvAbcvaMeSpDnNGe5V9WcMX0cH2DRkfAF3nGNfkqRz4B2qktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SerQKJ8KKb1j/fbHx92CpBE4c5ekDhnuktQhw12SOmS4S1KHRvkdqn+Q5FiSl2bVLknyZJIDbXtxqyfJfUkOJnkhydWL2bwkabhRZu5/BHzqpNp2YE9VbQD2tGOAG4AN7bENuH9h2pQknY05w72q/hfw+knlzcCutr8LuHlW/cEaeAZYmWT1QjUrSRrNfNfcr6iqowBte3mrrwEOzxo31WqnSLItyWSSyenp6Xm2IUkaZqF/oJohtRo2sKp2VNVEVU2sWrVqgduQpH/a5hvur80st7TtsVafAtbNGrcWODL/9iRJ8zHfcN8NbGn7W4DHZtVva1fNbASOzyzfSJKWzpyfLZPkIeBfAZclmQL+C3A38HCSrcAh4JY2/AngRuAg8BZw+yL0LEmaw5zhXlWfO82pTUPGFnDHuTYlSTo33qEqSR3yI3/fg/zYXUlzceYuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOuSlkJL+yRvn5cWv3n3TonxdZ+6S1CFn7ufAm4kkLVfO3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6tCiXOee5FPAF4HzgAeq6u7FeB3wWnNJGmbBZ+5JzgP+G3AD8DHgc0k+ttCvI0k6vcVYlrkGOFhVr1TVj4EvA5sX4XUkSaexGMsya4DDs46ngF84eVCSbcC2dvijJH+5CL0shMuAvxl3E6dhb/Njb/Njb/Nzxt5yzzl97X9+uhOLEe4ZUqtTClU7gB2L8PoLKslkVU2Mu49h7G1+7G1+7G1+xtXbYizLTAHrZh2vBY4swutIkk5jMcL9L4ANSa5Mcj5wK7B7EV5HknQaC74sU1VvJ/mPwJ8yuBTyD6rq5YV+nSW0nJeO7G1+7G1+7G1+xtJbqk5ZDpckvcd5h6okdchwl6QOGe5DJFmX5Okk+5O8nOTOcfc0I8kFSf48ybdbb78z7p5OluS8JM8l+fq4e5ktyatJXkzyfJLJcfczW5KVSR5J8t329+4Xx90TQJKPtD+vmccPk3xh3H3NSPLr7d/BS0keSnLBuHuakeTO1tfL4/gzc819iCSrgdVV9WySnwH2ATdX1XfG3BpJAlxUVT9K8j7gz4A7q+qZMbf2jiR3ARPAB6vq0+PuZ0aSV4GJqlp2N7sk2QX876p6oF1ldmFVvTnuvmZrHy3yA+AXqur7y6CfNQz+/n+sqv5vkoeBJ6rqj8bbGST5eQZ3518D/Bj4BvAfqurAUvXgzH2IqjpaVc+2/b8D9jO483bsauBH7fB97bFs/odOsha4CXhg3L28VyT5IHAdsBOgqn683IK92QR8bzkE+ywrgA8kWQFcyPK5p+ajwDNV9VZVvQ38T+DfLGUDhvsckqwHPgHsHW8n72rLHs8Dx4Anq2rZ9Ab8PvAbwD+Ou5EhCvhmkn3t4y+Wi58DpoE/bMtZDyS5aNxNDXEr8NC4m5hRVT8Afhc4BBwFjlfVN8fb1TteAq5LcmmSC4EbOfHmzkVnuJ9Bkp8Gvgp8oap+OO5+ZlTVP1TVVQzu/r2mfQs4dkk+DRyrqn3j7uU0rq2qqxl8YukdSa4bd0PNCuBq4P6q+gTwf4Dt423pRG2p6DPAn4y7lxlJLmbwoYRXAj8LXJTk34+3q4Gq2g/cAzzJYEnm28DbS9mD4X4abT37q8CXqupr4+5nmPat+7eAT425lRnXAp9pa9tfBq5P8j/G29K7qupI2x4DHmWwHrocTAFTs74De4RB2C8nNwDPVtVr425klk8Cf1VV01X1E+BrwC+Nuad3VNXOqrq6qq4DXgeWbL0dDPeh2g8tdwL7q+r3xt3PbElWJVnZ9j/A4C/4d8fb1UBV/VZVra2q9Qy+hX+qqpbFTCrJRe2H47Qlj19h8K3z2FXVXwOHk3yklTYBY//h/Uk+xzJakmkOARuTXNj+zW5i8POxZSHJ5W37z4B/yxL/+S3Kb2LqwLXArwIvtrVtgN+uqifG2NOM1cCuduXCTwEPV9WyuuRwmboCeHSQAawA/riqvjHelk7weeBLbfnjFeD2MffzjrZm/MvAr427l9mqam+SR4BnGSx5PMfy+hiCrya5FPgJcEdVvbGUL+6lkJLUIZdlJKlDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nq0P8HFgImXgFgiHcAAAAASUVORK5CYII=",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
@@ -829,90 +822,91 @@
             "needs_background": "light"
           }
         }
-      ]
+      ],
+      "metadata": {
+        "jupyter": {
+          "outputs_hidden": false
+        },
+        "id": "UBp4ZGKW_G_H",
+        "outputId": "aca207de-0d5c-4858-feb6-72855368ac02"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "WKd-vsn6_G_H"
-      },
       "source": [
         "Have you noticed that this function returns three objects? Take a look at the documentation [here](http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.hist) to figure out what they are.\n",
         "\n",
         "To get the returned three objects:"
-      ]
+      ],
+      "metadata": {
+        "id": "WKd-vsn6_G_H"
+      }
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "# TODO: Replace dummy value of below variables with actual values.\n",
+        "n_raw, bins_raw, patches = [1., 2.], [0.5, 1.0], 0.\n",
+        "print(n_raw)\n",
+        "print(bins_raw)"
+      ],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "[  9.  39.  76. 133. 293. 599. 784. 684. 323.  48.]\n",
+            "[1.4  2.18 2.96 3.74 4.52 5.3  6.08 6.86 7.64 8.42 9.2 ]\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD4CAYAAAAXUaZHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAS1ElEQVR4nO3db4yd5Xnn8e+vOIRAm5g/Brm2d00VK5uoUgg7om6R0C5OqwBRzK6CRLRbLGTJ1YrNkrJS6/bNqtK+AKkqDdIKycJtzW5KQkkQVkBpkCG72xe4HQPhT5zKDiX2xC6eFnCaZbsJ7bUvzj0wto89x+OZOcPd70c6ep7neu4z5zqW/fM99zzPmVQVkqS+/NS4G5AkLTzDXZI6ZLhLUocMd0nqkOEuSR1aMe4GAC677LJav379uNuQpPeUffv2/U1VrRp2blmE+/r165mcnBx3G5L0npLk+6c757KMJHVopHBP8utJXk7yUpKHklyQ5Moke5McSPKVJOe3se9vxwfb+fWL+QYkSaeaM9yTrAH+EzBRVT8PnAfcCtwD3FtVG4A3gK3tKVuBN6rqw8C9bZwkaQmNuiyzAvhAkhXAhcBR4HrgkXZ+F3Bz29/cjmnnNyXJwrQrSRrFnOFeVT8Afhc4xCDUjwP7gDer6u02bApY0/bXAIfbc99u4y89+esm2ZZkMsnk9PT0ub4PSdIsoyzLXMxgNn4l8LPARcANQ4bOfALZsFn6KZ9OVlU7qmqiqiZWrRp6JY8kaZ5GWZb5JPBXVTVdVT8Bvgb8ErCyLdMArAWOtP0pYB1AO/8h4PUF7VqSdEajhPshYGOSC9va+SbgO8DTwGfbmC3AY21/dzumnX+q/FxhSVpSo6y572Xwg9FngRfbc3YAvwncleQggzX1ne0pO4FLW/0uYPsi9C1JOoMsh0n1xMREeYeqdKL12x8fy+u+evdNY3ldnb0k+6pqYtg571CVpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktShOcM9yUeSPD/r8cMkX0hySZInkxxo24vb+CS5L8nBJC8kuXrx34YkabZRfkH2X1bVVVV1FfAvgbeARxn84us9VbUB2MO7vwj7BmBDe2wD7l+MxiVJp3e2yzKbgO9V1feBzcCuVt8F3Nz2NwMP1sAzwMokqxekW0nSSM423G8FHmr7V1TVUYC2vbzV1wCHZz1nqtVOkGRbkskkk9PT02fZhiTpTEYO9yTnA58B/mSuoUNqdUqhakdVTVTVxKpVq0ZtQ5I0grOZud8APFtVr7Xj12aWW9r2WKtPAetmPW8tcORcG5Ukje5swv1zvLskA7Ab2NL2twCPzarf1q6a2Qgcn1m+kSQtjRWjDEpyIfDLwK/NKt8NPJxkK3AIuKXVnwBuBA4yuLLm9gXrVtKiW7/98bG99qt33zS21+7NSOFeVW8Bl55U+1sGV8+cPLaAOxakO0nSvHiHqiR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHVopHBPsjLJI0m+m2R/kl9MckmSJ5McaNuL29gkuS/JwSQvJLl6cd+CJOlko87cvwh8o6r+BfBxYD+wHdhTVRuAPe0Y4AZgQ3tsA+5f0I4lSXOaM9yTfBC4DtgJUFU/rqo3gc3ArjZsF3Bz298MPFgDzwArk6xe8M4lSac1ysz954Bp4A+TPJfkgSQXAVdU1VGAtr28jV8DHJ71/KlWO0GSbUkmk0xOT0+f05uQJJ1oxYhjrgY+X1V7k3yRd5dghsmQWp1SqNoB7ACYmJg45by0HKzf/vi4W5DmZZSZ+xQwVVV72/EjDML+tZnllrY9Nmv8ulnPXwscWZh2JUmjmDPcq+qvgcNJPtJKm4DvALuBLa22BXis7e8GbmtXzWwEjs8s30iSlsYoyzIAnwe+lOR84BXgdgb/MTycZCtwCLiljX0CuBE4CLzVxkqSltBI4V5VzwMTQ05tGjK2gDvOsS9J0jnwDlVJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0aKdyTvJrkxSTPJ5lstUuSPJnkQNte3OpJcl+Sg0leSHL1Yr4BSdKpzmbm/q+r6qqqmvldqtuBPVW1AdjTjgFuADa0xzbg/oVqVpI0mnNZltkM7Gr7u4CbZ9UfrIFngJVJVp/D60iSztKo4V7AN5PsS7Kt1a6oqqMAbXt5q68BDs967lSrnSDJtiSTSSanp6fn170kaagVI467tqqOJLkceDLJd88wNkNqdUqhagewA2BiYuKU85Kk+Rtp5l5VR9r2GPAocA3w2sxyS9sea8OngHWznr4WOLJQDUuS5jZnuCe5KMnPzOwDvwK8BOwGtrRhW4DH2v5u4LZ21cxG4PjM8o0kaWmMsixzBfBokpnxf1xV30jyF8DDSbYCh4Bb2vgngBuBg8BbwO0L3rUk6YzmDPeqegX4+JD63wKbhtQLuGNBupMkzYt3qEpShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHRg73JOcleS7J19vxlUn2JjmQ5CtJzm/197fjg+38+sVpXZJ0Omczc78T2D/r+B7g3qraALwBbG31rcAbVfVh4N42TpK0hEYK9yRrgZuAB9pxgOuBR9qQXcDNbX9zO6ad39TGS5KWyKgz998HfgP4x3Z8KfBmVb3djqeANW1/DXAYoJ0/3safIMm2JJNJJqenp+fZviRpmDnDPcmngWNVtW92ecjQGuHcu4WqHVU1UVUTq1atGqlZSdJoVoww5lrgM0luBC4APshgJr8yyYo2O18LHGnjp4B1wFSSFcCHgNcXvHNJ0mnNOXOvqt+qqrVVtR64FXiqqv4d8DTw2TZsC/BY29/djmnnn6qqU2bukqTFcy7Xuf8mcFeSgwzW1He2+k7g0la/C9h+bi1Kks7WKMsy76iqbwHfavuvANcMGfP3wC0L0JskaZ68Q1WSOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdeisPvJXkhbT+u2Pj+V1X737prG87mJy5i5JHTLcJalDc4Z7kguS/HmSbyd5OcnvtPqVSfYmOZDkK0nOb/X3t+OD7fz6xX0LkqSTjTJz/3/A9VX1ceAq4FNJNgL3APdW1QbgDWBrG78VeKOqPgzc28ZJkpbQnOFeAz9qh+9rjwKuBx5p9V3AzW1/czumnd+UJAvWsSRpTiOtuSc5L8nzwDHgSeB7wJtV9XYbMgWsaftrgMMA7fxx4NKFbFqSdGYjhXtV/UNVXQWsBa4BPjpsWNsOm6XXyYUk25JMJpmcnp4etV9J0gjO6jr3qnozybeAjcDKJCva7HwtcKQNmwLWAVNJVgAfAl4f8rV2ADsAJiYmTgl/abZxXf8svVeNcrXMqiQr2/4HgE8C+4Gngc+2YVuAx9r+7nZMO/9UVRnekrSERpm5rwZ2JTmPwX8GD1fV15N8B/hykv8KPAfsbON3Av89yUEGM/ZbF6FvSdIZzBnuVfUC8Ikh9VcYrL+fXP974JYF6U6SNC/eoSpJHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOj/ILsdUmeTrI/yctJ7mz1S5I8meRA217c6klyX5KDSV5IcvVivwlJ0olGmbm/DfznqvoosBG4I8nHgO3AnqraAOxpxwA3ABvaYxtw/4J3LUk6oznDvaqOVtWzbf/vgP3AGmAzsKsN2wXc3PY3Aw/WwDPAyiSrF7xzSdJpndWae5L1wCeAvcAVVXUUBv8BAJe3YWuAw7OeNtVqJ3+tbUkmk0xOT0+ffeeSpNMaOdyT/DTwVeALVfXDMw0dUqtTClU7qmqiqiZWrVo1ahuSpBGMFO5J3scg2L9UVV9r5ddmllva9lirTwHrZj19LXBkYdqVJI1ilKtlAuwE9lfV7806tRvY0va3AI/Nqt/WrprZCByfWb6RJC2NFSOMuRb4VeDFJM+32m8DdwMPJ9kKHAJuaeeeAG4EDgJvAbcvaMeSpDnNGe5V9WcMX0cH2DRkfAF3nGNfkqRz4B2qktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SerQKJ8KKb1j/fbHx92CpBE4c5ekDhnuktQhw12SOmS4S1KHRvkdqn+Q5FiSl2bVLknyZJIDbXtxqyfJfUkOJnkhydWL2bwkabhRZu5/BHzqpNp2YE9VbQD2tGOAG4AN7bENuH9h2pQknY05w72q/hfw+knlzcCutr8LuHlW/cEaeAZYmWT1QjUrSRrNfNfcr6iqowBte3mrrwEOzxo31WqnSLItyWSSyenp6Xm2IUkaZqF/oJohtRo2sKp2VNVEVU2sWrVqgduQpH/a5hvur80st7TtsVafAtbNGrcWODL/9iRJ8zHfcN8NbGn7W4DHZtVva1fNbASOzyzfSJKWzpyfLZPkIeBfAZclmQL+C3A38HCSrcAh4JY2/AngRuAg8BZw+yL0LEmaw5zhXlWfO82pTUPGFnDHuTYlSTo33qEqSR3yI3/fg/zYXUlzceYuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOuSlkJL+yRvn5cWv3n3TonxdZ+6S1CFn7ufAm4kkLVfO3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6tCiXOee5FPAF4HzgAeq6u7FeB3wWnNJGmbBZ+5JzgP+G3AD8DHgc0k+ttCvI0k6vcVYlrkGOFhVr1TVj4EvA5sX4XUkSaexGMsya4DDs46ngF84eVCSbcC2dvijJH+5CL0shMuAvxl3E6dhb/Njb/Njb/Nzxt5yzzl97X9+uhOLEe4ZUqtTClU7gB2L8PoLKslkVU2Mu49h7G1+7G1+7G1+xtXbYizLTAHrZh2vBY4swutIkk5jMcL9L4ANSa5Mcj5wK7B7EV5HknQaC74sU1VvJ/mPwJ8yuBTyD6rq5YV+nSW0nJeO7G1+7G1+7G1+xtJbqk5ZDpckvcd5h6okdchwl6QOGe5DJFmX5Okk+5O8nOTOcfc0I8kFSf48ybdbb78z7p5OluS8JM8l+fq4e5ktyatJXkzyfJLJcfczW5KVSR5J8t329+4Xx90TQJKPtD+vmccPk3xh3H3NSPLr7d/BS0keSnLBuHuakeTO1tfL4/gzc819iCSrgdVV9WySnwH2ATdX1XfG3BpJAlxUVT9K8j7gz4A7q+qZMbf2jiR3ARPAB6vq0+PuZ0aSV4GJqlp2N7sk2QX876p6oF1ldmFVvTnuvmZrHy3yA+AXqur7y6CfNQz+/n+sqv5vkoeBJ6rqj8bbGST5eQZ3518D/Bj4BvAfqurAUvXgzH2IqjpaVc+2/b8D9jO483bsauBH7fB97bFs/odOsha4CXhg3L28VyT5IHAdsBOgqn683IK92QR8bzkE+ywrgA8kWQFcyPK5p+ajwDNV9VZVvQ38T+DfLGUDhvsckqwHPgHsHW8n72rLHs8Dx4Anq2rZ9Ab8PvAbwD+Ou5EhCvhmkn3t4y+Wi58DpoE/bMtZDyS5aNxNDXEr8NC4m5hRVT8Afhc4BBwFjlfVN8fb1TteAq5LcmmSC4EbOfHmzkVnuJ9Bkp8Gvgp8oap+OO5+ZlTVP1TVVQzu/r2mfQs4dkk+DRyrqn3j7uU0rq2qqxl8YukdSa4bd0PNCuBq4P6q+gTwf4Dt423pRG2p6DPAn4y7lxlJLmbwoYRXAj8LXJTk34+3q4Gq2g/cAzzJYEnm28DbS9mD4X4abT37q8CXqupr4+5nmPat+7eAT425lRnXAp9pa9tfBq5P8j/G29K7qupI2x4DHmWwHrocTAFTs74De4RB2C8nNwDPVtVr425klk8Cf1VV01X1E+BrwC+Nuad3VNXOqrq6qq4DXgeWbL0dDPeh2g8tdwL7q+r3xt3PbElWJVnZ9j/A4C/4d8fb1UBV/VZVra2q9Qy+hX+qqpbFTCrJRe2H47Qlj19h8K3z2FXVXwOHk3yklTYBY//h/Uk+xzJakmkOARuTXNj+zW5i8POxZSHJ5W37z4B/yxL/+S3Kb2LqwLXArwIvtrVtgN+uqifG2NOM1cCuduXCTwEPV9WyuuRwmboCeHSQAawA/riqvjHelk7weeBLbfnjFeD2MffzjrZm/MvAr427l9mqam+SR4BnGSx5PMfy+hiCrya5FPgJcEdVvbGUL+6lkJLUIZdlJKlDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nq0P8HFgImXgFgiHcAAAAASUVORK5CYII=",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "tags": [],
+            "needs_background": "light"
+          }
+        }
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
         "id": "wECMi8FE_G_I",
         "outputId": "b6550d5f-e3ae-4ff0-bd84-7bb5476ecc57"
-      },
-      "source": [
-        "n_raw, bins_raw, patches = # ... \n",
-        "print(n_raw)\n",
-        "print(bins_raw)"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "[  9.  39.  76. 133. 293. 599. 784. 684. 323.  48.]\n",
-            "[1.4  2.18 2.96 3.74 4.52 5.3  6.08 6.86 7.64 8.42 9.2 ]\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD4CAYAAAAXUaZHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAS1ElEQVR4nO3db4yd5Xnn8e+vOIRAm5g/Brm2d00VK5uoUgg7om6R0C5OqwBRzK6CRLRbLGTJ1YrNkrJS6/bNqtK+AKkqDdIKycJtzW5KQkkQVkBpkCG72xe4HQPhT5zKDiX2xC6eFnCaZbsJ7bUvzj0wto89x+OZOcPd70c6ep7neu4z5zqW/fM99zzPmVQVkqS+/NS4G5AkLTzDXZI6ZLhLUocMd0nqkOEuSR1aMe4GAC677LJav379uNuQpPeUffv2/U1VrRp2blmE+/r165mcnBx3G5L0npLk+6c757KMJHVopHBP8utJXk7yUpKHklyQ5Moke5McSPKVJOe3se9vxwfb+fWL+QYkSaeaM9yTrAH+EzBRVT8PnAfcCtwD3FtVG4A3gK3tKVuBN6rqw8C9bZwkaQmNuiyzAvhAkhXAhcBR4HrgkXZ+F3Bz29/cjmnnNyXJwrQrSRrFnOFeVT8Afhc4xCDUjwP7gDer6u02bApY0/bXAIfbc99u4y89+esm2ZZkMsnk9PT0ub4PSdIsoyzLXMxgNn4l8LPARcANQ4bOfALZsFn6KZ9OVlU7qmqiqiZWrRp6JY8kaZ5GWZb5JPBXVTVdVT8Bvgb8ErCyLdMArAWOtP0pYB1AO/8h4PUF7VqSdEajhPshYGOSC9va+SbgO8DTwGfbmC3AY21/dzumnX+q/FxhSVpSo6y572Xwg9FngRfbc3YAvwncleQggzX1ne0pO4FLW/0uYPsi9C1JOoMsh0n1xMREeYeqdKL12x8fy+u+evdNY3ldnb0k+6pqYtg571CVpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktShOcM9yUeSPD/r8cMkX0hySZInkxxo24vb+CS5L8nBJC8kuXrx34YkabZRfkH2X1bVVVV1FfAvgbeARxn84us9VbUB2MO7vwj7BmBDe2wD7l+MxiVJp3e2yzKbgO9V1feBzcCuVt8F3Nz2NwMP1sAzwMokqxekW0nSSM423G8FHmr7V1TVUYC2vbzV1wCHZz1nqtVOkGRbkskkk9PT02fZhiTpTEYO9yTnA58B/mSuoUNqdUqhakdVTVTVxKpVq0ZtQ5I0grOZud8APFtVr7Xj12aWW9r2WKtPAetmPW8tcORcG5Ukje5swv1zvLskA7Ab2NL2twCPzarf1q6a2Qgcn1m+kSQtjRWjDEpyIfDLwK/NKt8NPJxkK3AIuKXVnwBuBA4yuLLm9gXrVtKiW7/98bG99qt33zS21+7NSOFeVW8Bl55U+1sGV8+cPLaAOxakO0nSvHiHqiR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHVopHBPsjLJI0m+m2R/kl9MckmSJ5McaNuL29gkuS/JwSQvJLl6cd+CJOlko87cvwh8o6r+BfBxYD+wHdhTVRuAPe0Y4AZgQ3tsA+5f0I4lSXOaM9yTfBC4DtgJUFU/rqo3gc3ArjZsF3Bz298MPFgDzwArk6xe8M4lSac1ysz954Bp4A+TPJfkgSQXAVdU1VGAtr28jV8DHJ71/KlWO0GSbUkmk0xOT0+f05uQJJ1oxYhjrgY+X1V7k3yRd5dghsmQWp1SqNoB7ACYmJg45by0HKzf/vi4W5DmZZSZ+xQwVVV72/EjDML+tZnllrY9Nmv8ulnPXwscWZh2JUmjmDPcq+qvgcNJPtJKm4DvALuBLa22BXis7e8GbmtXzWwEjs8s30iSlsYoyzIAnwe+lOR84BXgdgb/MTycZCtwCLiljX0CuBE4CLzVxkqSltBI4V5VzwMTQ05tGjK2gDvOsS9J0jnwDlVJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0aKdyTvJrkxSTPJ5lstUuSPJnkQNte3OpJcl+Sg0leSHL1Yr4BSdKpzmbm/q+r6qqqmvldqtuBPVW1AdjTjgFuADa0xzbg/oVqVpI0mnNZltkM7Gr7u4CbZ9UfrIFngJVJVp/D60iSztKo4V7AN5PsS7Kt1a6oqqMAbXt5q68BDs967lSrnSDJtiSTSSanp6fn170kaagVI467tqqOJLkceDLJd88wNkNqdUqhagewA2BiYuKU85Kk+Rtp5l5VR9r2GPAocA3w2sxyS9sea8OngHWznr4WOLJQDUuS5jZnuCe5KMnPzOwDvwK8BOwGtrRhW4DH2v5u4LZ21cxG4PjM8o0kaWmMsixzBfBokpnxf1xV30jyF8DDSbYCh4Bb2vgngBuBg8BbwO0L3rUk6YzmDPeqegX4+JD63wKbhtQLuGNBupMkzYt3qEpShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHRg73JOcleS7J19vxlUn2JjmQ5CtJzm/197fjg+38+sVpXZJ0Omczc78T2D/r+B7g3qraALwBbG31rcAbVfVh4N42TpK0hEYK9yRrgZuAB9pxgOuBR9qQXcDNbX9zO6ad39TGS5KWyKgz998HfgP4x3Z8KfBmVb3djqeANW1/DXAYoJ0/3safIMm2JJNJJqenp+fZviRpmDnDPcmngWNVtW92ecjQGuHcu4WqHVU1UVUTq1atGqlZSdJoVoww5lrgM0luBC4APshgJr8yyYo2O18LHGnjp4B1wFSSFcCHgNcXvHNJ0mnNOXOvqt+qqrVVtR64FXiqqv4d8DTw2TZsC/BY29/djmnnn6qqU2bukqTFcy7Xuf8mcFeSgwzW1He2+k7g0la/C9h+bi1Kks7WKMsy76iqbwHfavuvANcMGfP3wC0L0JskaZ68Q1WSOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdeisPvJXkhbT+u2Pj+V1X737prG87mJy5i5JHTLcJalDc4Z7kguS/HmSbyd5OcnvtPqVSfYmOZDkK0nOb/X3t+OD7fz6xX0LkqSTjTJz/3/A9VX1ceAq4FNJNgL3APdW1QbgDWBrG78VeKOqPgzc28ZJkpbQnOFeAz9qh+9rjwKuBx5p9V3AzW1/czumnd+UJAvWsSRpTiOtuSc5L8nzwDHgSeB7wJtV9XYbMgWsaftrgMMA7fxx4NKFbFqSdGYjhXtV/UNVXQWsBa4BPjpsWNsOm6XXyYUk25JMJpmcnp4etV9J0gjO6jr3qnozybeAjcDKJCva7HwtcKQNmwLWAVNJVgAfAl4f8rV2ADsAJiYmTgl/abZxXf8svVeNcrXMqiQr2/4HgE8C+4Gngc+2YVuAx9r+7nZMO/9UVRnekrSERpm5rwZ2JTmPwX8GD1fV15N8B/hykv8KPAfsbON3Av89yUEGM/ZbF6FvSdIZzBnuVfUC8Ikh9VcYrL+fXP974JYF6U6SNC/eoSpJHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOj/ILsdUmeTrI/yctJ7mz1S5I8meRA217c6klyX5KDSV5IcvVivwlJ0olGmbm/DfznqvoosBG4I8nHgO3AnqraAOxpxwA3ABvaYxtw/4J3LUk6oznDvaqOVtWzbf/vgP3AGmAzsKsN2wXc3PY3Aw/WwDPAyiSrF7xzSdJpndWae5L1wCeAvcAVVXUUBv8BAJe3YWuAw7OeNtVqJ3+tbUkmk0xOT0+ffeeSpNMaOdyT/DTwVeALVfXDMw0dUqtTClU7qmqiqiZWrVo1ahuSpBGMFO5J3scg2L9UVV9r5ddmllva9lirTwHrZj19LXBkYdqVJI1ilKtlAuwE9lfV7806tRvY0va3AI/Nqt/WrprZCByfWb6RJC2NFSOMuRb4VeDFJM+32m8DdwMPJ9kKHAJuaeeeAG4EDgJvAbcvaMeSpDnNGe5V9WcMX0cH2DRkfAF3nGNfkqRz4B2qktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SerQKJ8KKb1j/fbHx92CpBE4c5ekDhnuktQhw12SOmS4S1KHRvkdqn+Q5FiSl2bVLknyZJIDbXtxqyfJfUkOJnkhydWL2bwkabhRZu5/BHzqpNp2YE9VbQD2tGOAG4AN7bENuH9h2pQknY05w72q/hfw+knlzcCutr8LuHlW/cEaeAZYmWT1QjUrSRrNfNfcr6iqowBte3mrrwEOzxo31WqnSLItyWSSyenp6Xm2IUkaZqF/oJohtRo2sKp2VNVEVU2sWrVqgduQpH/a5hvur80st7TtsVafAtbNGrcWODL/9iRJ8zHfcN8NbGn7W4DHZtVva1fNbASOzyzfSJKWzpyfLZPkIeBfAZclmQL+C3A38HCSrcAh4JY2/AngRuAg8BZw+yL0LEmaw5zhXlWfO82pTUPGFnDHuTYlSTo33qEqSR3yI3/fg/zYXUlzceYuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOuSlkJL+yRvn5cWv3n3TonxdZ+6S1CFn7ufAm4kkLVfO3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6tCiXOee5FPAF4HzgAeq6u7FeB3wWnNJGmbBZ+5JzgP+G3AD8DHgc0k+ttCvI0k6vcVYlrkGOFhVr1TVj4EvA5sX4XUkSaexGMsya4DDs46ngF84eVCSbcC2dvijJH+5CL0shMuAvxl3E6dhb/Njb/Njb/Nzxt5yzzl97X9+uhOLEe4ZUqtTClU7gB2L8PoLKslkVU2Mu49h7G1+7G1+7G1+xtXbYizLTAHrZh2vBY4swutIkk5jMcL9L4ANSa5Mcj5wK7B7EV5HknQaC74sU1VvJ/mPwJ8yuBTyD6rq5YV+nSW0nJeO7G1+7G1+7G1+xtJbqk5ZDpckvcd5h6okdchwl6QOGe5DJFmX5Okk+5O8nOTOcfc0I8kFSf48ybdbb78z7p5OluS8JM8l+fq4e5ktyatJXkzyfJLJcfczW5KVSR5J8t329+4Xx90TQJKPtD+vmccPk3xh3H3NSPLr7d/BS0keSnLBuHuakeTO1tfL4/gzc819iCSrgdVV9WySnwH2ATdX1XfG3BpJAlxUVT9K8j7gz4A7q+qZMbf2jiR3ARPAB6vq0+PuZ0aSV4GJqlp2N7sk2QX876p6oF1ldmFVvTnuvmZrHy3yA+AXqur7y6CfNQz+/n+sqv5vkoeBJ6rqj8bbGST5eQZ3518D/Bj4BvAfqurAUvXgzH2IqjpaVc+2/b8D9jO483bsauBH7fB97bFs/odOsha4CXhg3L28VyT5IHAdsBOgqn683IK92QR8bzkE+ywrgA8kWQFcyPK5p+ajwDNV9VZVvQ38T+DfLGUDhvsckqwHPgHsHW8n72rLHs8Dx4Anq2rZ9Ab8PvAbwD+Ou5EhCvhmkn3t4y+Wi58DpoE/bMtZDyS5aNxNDXEr8NC4m5hRVT8Afhc4BBwFjlfVN8fb1TteAq5LcmmSC4EbOfHmzkVnuJ9Bkp8Gvgp8oap+OO5+ZlTVP1TVVQzu/r2mfQs4dkk+DRyrqn3j7uU0rq2qqxl8YukdSa4bd0PNCuBq4P6q+gTwf4Dt423pRG2p6DPAn4y7lxlJLmbwoYRXAj8LXJTk34+3q4Gq2g/cAzzJYEnm28DbS9mD4X4abT37q8CXqupr4+5nmPat+7eAT425lRnXAp9pa9tfBq5P8j/G29K7qupI2x4DHmWwHrocTAFTs74De4RB2C8nNwDPVtVr425klk8Cf1VV01X1E+BrwC+Nuad3VNXOqrq6qq4DXgeWbL0dDPeh2g8tdwL7q+r3xt3PbElWJVnZ9j/A4C/4d8fb1UBV/VZVra2q9Qy+hX+qqpbFTCrJRe2H47Qlj19h8K3z2FXVXwOHk3yklTYBY//h/Uk+xzJakmkOARuTXNj+zW5i8POxZSHJ5W37z4B/yxL/+S3Kb2LqwLXArwIvtrVtgN+uqifG2NOM1cCuduXCTwEPV9WyuuRwmboCeHSQAawA/riqvjHelk7weeBLbfnjFeD2MffzjrZm/MvAr427l9mqam+SR4BnGSx5PMfy+hiCrya5FPgJcEdVvbGUL+6lkJLUIZdlJKlDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nq0P8HFgImXgFgiHcAAAAASUVORK5CYII=\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": [],
-            "needs_background": "light"
-          }
-        }
-      ]
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "l_RFSwpF_G_I"
-      },
       "source": [
         "Here, `n_raw` contains the values of histograms, i.e., the number of movies in each of the 10 bins. Thus, the sum of the elements in `n_raw` should be equal to the total number of movies. \n",
         "\n",
         "**Q: Test whether the sum of values in `n_raw` is equal to the number of movies in the `movies` dataset**"
-      ]
+      ],
+      "metadata": {
+        "id": "l_RFSwpF_G_I"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "jupyter": {
-          "outputs_hidden": false
-        },
-        "id": "HF6S_I7l_G_I",
-        "outputId": "3674e82a-f322-4111-c820-b59f2bf75c8d"
-      },
+      "execution_count": null,
       "source": [
         "# TODO: test whether the sum of the numbers in n_raw is equal to the number of movies. \n"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
+          "name": "stdout",
           "text": [
             "2988.0\n",
             "2988\n"
-          ],
-          "name": "stdout"
+          ]
         },
         {
           "output_type": "execute_result",
@@ -926,30 +920,30 @@
           },
           "execution_count": 29
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5ROhZszP_G_J"
-      },
-      "source": [
-        "The second returned object (`bins_raw`) is a list containing the edges of the 10 bins: the first bin is \\[1.4, 2.18\\], the second \\[2.18, 2.96\\], and so on. What's the width of the bins?"
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "8TtA_llF_G_J",
-        "outputId": "fb8ac5b7-0560-4963-9bf6-6bbf6502f1c3"
-      },
+        "id": "HF6S_I7l_G_I",
+        "outputId": "3674e82a-f322-4111-c820-b59f2bf75c8d"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "The second returned object (`bins_raw`) is a list containing the edges of the 10 bins: the first bin is \\[1.4, 2.18\\], the second \\[2.18, 2.96\\], and so on. What's the width of the bins?"
+      ],
+      "metadata": {
+        "id": "5ROhZszP_G_J"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "np.diff(bins_raw)"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -963,82 +957,82 @@
           },
           "execution_count": 30
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "wr6fjCqJ_G_J"
-      },
-      "source": [
-        "The width is same as the maximum value minus minimum value, divided by 10. "
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "nDsPLuhs_G_K",
-        "outputId": "8e2a4473-35d8-4bd0-9595-11a3075f174e"
-      },
+        "id": "8TtA_llF_G_J",
+        "outputId": "fb8ac5b7-0560-4963-9bf6-6bbf6502f1c3"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "The width is same as the maximum value minus minimum value, divided by 10. "
+      ],
+      "metadata": {
+        "id": "wr6fjCqJ_G_J"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "min_rating = min(movies['IMDB_Rating'])\n",
         "max_rating = max(movies['IMDB_Rating'])\n",
         "print(min_rating, max_rating)\n",
         "print( (max_rating-min_rating) / 10 )"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
+          "name": "stdout",
           "text": [
             "1.4 9.2\n",
             "0.7799999999999999\n"
-          ],
-          "name": "stdout"
+          ]
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "9-kP893P_G_K"
-      },
-      "source": [
-        "Now, let's plot a normalized (density) histogram. "
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "Mkv5LHGH_G_K",
-        "outputId": "3fd60282-ab9d-4ff4-8477-7b46bd5694e8"
-      },
+        "id": "nDsPLuhs_G_K",
+        "outputId": "8e2a4473-35d8-4bd0-9595-11a3075f174e"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Now, let's plot a normalized (density) histogram. "
+      ],
+      "metadata": {
+        "id": "9-kP893P_G_K"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "n, bins, patches = plt.hist(movies['IMDB_Rating'], density=True)\n",
         "print(n)\n",
         "print(bins)"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
+          "name": "stdout",
           "text": [
             "[0.0038616  0.0167336  0.03260907 0.05706587 0.12571654 0.25701095\n",
             " 0.33638829 0.29348162 0.13858854 0.0205952 ]\n",
             "[1.4  2.18 2.96 3.74 4.52 5.3  6.08 6.86 7.64 8.42 9.2 ]\n"
-          ],
-          "name": "stdout"
+          ]
         },
         {
           "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXoAAAD6CAYAAACvZ4z8AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAASz0lEQVR4nO3dbYwd133f8e8vZCjHcpUo1rZwScqkHSYwEweSu6HaClGB6MFUFZBqYcNU4UIJBDBOxcapUDR0E8gogwCyU6TpC6YRYTN10yisLCXAImLCCPEDagSyuXqwFVJRtKIZaUO32piqXdeqZMr/vrhD9Wp9qR3uLveuTr4f4GJnzpwz87+L5W9nz50ZpqqQJLXru8ZdgCTpwjLoJalxBr0kNc6gl6TGGfSS1DiDXpIa1yvok2xP8mSSmSR7R2z/QJLHkzyW5HNJtnbtm5K80LU/luQ3l/sNSJJeWxa6jj7JGuAvgOuBWeAocEtVHR/qc0lVfb1b3gH8i6ranmQT8AdV9SN9C7rssstq06ZN5/k2JOlvtocffvivq2pi1La1PcZvA2aq6gRAkkPATuCVoD8b8p2LgUXfhbVp0yamp6cXO1yS/kZK8pfn2tZn6mY98OzQ+mzXNv8gtyd5Gvgo8HNDmzYneTTJZ5P8+DkK3J1kOsn03Nxcj5IkSX31CfqMaPuOM/aq2l9Vbwd+AfilrvkrwOVVdSVwB3BPkktGjD1QVZNVNTkxMfIvD0nSIvUJ+llg49D6BuDUa/Q/BNwMUFUvVtVXu+WHgaeBH1xcqZKkxegT9EeBLUk2J1kH7AKmhjsk2TK0ehPwVNc+0X2YS5K3AVuAE8tRuCSpnwU/jK2qM0n2AEeANcDBqjqWZB8wXVVTwJ4k1wHfAp4Hbu2GXwPsS3IGeBn4QFWdvhBvRJI02oKXV660ycnJ8qobSTo/SR6uqslR27wzVpIaZ9BLUuMMeklqXJ87YyWN2aa9D4zt2Cfvumlsx9by8Ixekhpn0EtS4wx6SWqcQS9JjTPoJalxBr0kNc6gl6TGGfSS1DiDXpIaZ9BLUuMMeklqnEEvSY0z6CWpcQa9JDXOoJekxhn0ktQ4g16SGmfQS1LjegV9ku1Jnkwyk2TviO0fSPJ4kseSfC7J1qFtH+rGPZnk3ctZvCRpYQsGfZI1wH7gRmArcMtwkHfuqap3VtUVwEeBX+vGbgV2AT8MbAd+o9ufJGmF9Dmj3wbMVNWJqnoJOATsHO5QVV8fWr0YqG55J3Coql6sqi8DM93+JEkrZG2PPuuBZ4fWZ4Gr5ndKcjtwB7AO+ImhsQ/NG7t+xNjdwG6Ayy+/vE/dkqSe+pzRZ0RbfUdD1f6qejvwC8AvnefYA1U1WVWTExMTPUqSJPXVJ+hngY1D6xuAU6/R/xBw8yLHSpKWWZ+gPwpsSbI5yToGH65ODXdIsmVo9SbgqW55CtiV5KIkm4EtwBeWXrYkqa8F5+ir6kySPcARYA1wsKqOJdkHTFfVFLAnyXXAt4DngVu7sceS3AscB84At1fVyxfovUi6ADbtfWAsxz15101jOW6L+nwYS1UdBg7Pa7tzaPmDrzH2V4BfWWyBkqSl8c5YSWqcQS9JjTPoJalxBr0kNc6gl6TGGfSS1DiDXpIaZ9BLUuMMeklqnEEvSY0z6CWpcQa9JDXOoJekxhn0ktQ4g16SGmfQS1LjDHpJapxBL0mNM+glqXEGvSQ1zqCXpMatHXcB0uvJpr0PjLsE6bz1OqNPsj3Jk0lmkuwdsf2OJMeTfCnJnyR569C2l5M81r2mlrN4SdLCFjyjT7IG2A9cD8wCR5NMVdXxoW6PApNV9c0kPwt8FHhft+2FqrpimeuWJPXU54x+GzBTVSeq6iXgELBzuENVfbqqvtmtPgRsWN4yJUmL1Sfo1wPPDq3Pdm3nchvwh0Prb0gyneShJDePGpBkd9dnem5urkdJkqS++nwYmxFtNbJj8n5gEvhHQ82XV9WpJG8DPpXk8ap6+lU7qzoAHACYnJwcuW9J0uL0OaOfBTYOrW8ATs3vlOQ64BeBHVX14tn2qjrVfT0BfAa4cgn1SpLOU5+gPwpsSbI5yTpgF/Cqq2eSXAnczSDknxtqvzTJRd3yZcDVwPCHuJKkC2zBqZuqOpNkD3AEWAMcrKpjSfYB01U1Bfwq8Cbgk0kAnqmqHcA7gLuTfJvBL5W75l2tI0m6wHrdMFVVh4HD89ruHFq+7hzj/hR451IKlCQtjY9AkKTGGfSS1DiDXpIaZ9BLUuMMeklqnEEvSY0z6CWpcQa9JDXOoJekxhn0ktQ4g16SGmfQS1LjDHpJapxBL0mNM+glqXEGvSQ1zqCXpMYZ9JLUOINekhpn0EtS4wx6SWqcQS9JjesV9Em2J3kyyUySvSO235HkeJIvJfmTJG8d2nZrkqe6163LWbwkaWELBn2SNcB+4EZgK3BLkq3zuj0KTFbVjwL3AR/txn4/8GHgKmAb8OEkly5f+ZKkhfQ5o98GzFTViap6CTgE7BzuUFWfrqpvdqsPARu65XcDD1bV6ap6HngQ2L48pUuS+ugT9OuBZ4fWZ7u2c7kN+MPzGZtkd5LpJNNzc3M9SpIk9dUn6DOirUZ2TN4PTAK/ej5jq+pAVU1W1eTExESPkiRJffUJ+llg49D6BuDU/E5JrgN+EdhRVS+ez1hJ0oXTJ+iPAluSbE6yDtgFTA13SHIlcDeDkH9uaNMR4IYkl3Yfwt7QtUmSVsjahTpU1ZkkexgE9BrgYFUdS7IPmK6qKQZTNW8CPpkE4Jmq2lFVp5P8MoNfFgD7qur0BXknkqSRFgx6gKo6DBye13bn0PJ1rzH2IHBwsQVKkpbGO2MlqXEGvSQ1zqCXpMYZ9JLUOINekhpn0EtS4wx6SWqcQS9JjTPoJalxBr0kNc6gl6TGGfSS1DiDXpIaZ9BLUuMMeklqnEEvSY0z6CWpcQa9JDXOoJekxhn0ktQ4g16SGtcr6JNsT/Jkkpkke0dsvybJI0nOJHnPvG0vJ3mse00tV+GSpH7WLtQhyRpgP3A9MAscTTJVVceHuj0D/BTwr0fs4oWqumIZapUkLcKCQQ9sA2aq6gRAkkPATuCVoK+qk922b1+AGiVJS9Bn6mY98OzQ+mzX1tcbkkwneSjJzaM6JNnd9Zmem5s7j11LkhbSJ+gzoq3O4xiXV9Uk8M+AX0/y9u/YWdWBqpqsqsmJiYnz2LUkaSF9gn4W2Di0vgE41fcAVXWq+3oC+Axw5XnUJ0laoj5BfxTYkmRzknXALqDX1TNJLk1yUbd8GXA1Q3P7kqQLb8Ggr6ozwB7gCPAEcG9VHUuyL8kOgCQ/lmQWeC9wd5Jj3fB3ANNJvgh8Grhr3tU6kqQLrM9VN1TVYeDwvLY7h5aPMpjSmT/uT4F3LrFGSdISeGesJDWu1xm9JK20TXsfGNuxT95109iOfSF4Ri9JjTPoJalxBr0kNc6gl6TGGfSS1DiDXpIaZ9BLUuO8jl6vO+O8vlp6PfKMXpIaZ9BLUuMMeklqnEEvSY0z6CWpcQa9JDXOoJekxhn0ktQ4g16SGmfQS1LjDHpJapxBL0mN6xX0SbYneTLJTJK9I7Zfk+SRJGeSvGfetluTPNW9bl2uwiVJ/SwY9EnWAPuBG4GtwC1Jts7r9gzwU8A988Z+P/Bh4CpgG/DhJJcuvWxJUl99zui3ATNVdaKqXgIOATuHO1TVyar6EvDteWPfDTxYVaer6nngQWD7MtQtSeqpT9CvB54dWp/t2vroNTbJ7iTTSabn5uZ67lqS1EefoM+Ituq5/15jq+pAVU1W1eTExETPXUuS+ugT9LPAxqH1DcCpnvtfylhJ0jLoE/RHgS1JNidZB+wCpnru/whwQ5JLuw9hb+jaJEkrZMGgr6ozwB4GAf0EcG9VHUuyL8kOgCQ/lmQWeC9wd5Jj3djTwC8z+GVxFNjXtUmSVkiv/xy8qg4Dh+e13Tm0fJTBtMyosQeBg0uoUZK0BN4ZK0mNM+glqXEGvSQ1zqCXpMYZ9JLUOINekhpn0EtS4wx6SWqcQS9JjTPoJalxBr0kNc6gl6TGGfSS1DiDXpIaZ9BLUuMMeklqnEEvSY0z6CWpcQa9JDXOoJekxhn0ktS4teMuQK9fm/Y+MO4SJPXQ64w+yfYkTyaZSbJ3xPaLkvy3bvvnk2zq2jcleSHJY93rN5e3fEnSQhY8o0+yBtgPXA/MAkeTTFXV8aFutwHPV9UPJNkFfAR4X7ft6aq6YpnrliT11OeMfhswU1Unquol4BCwc16fncAnuuX7gGuTZPnKlCQtVp+gXw88O7Q+27WN7FNVZ4CvAW/utm1O8miSzyb58VEHSLI7yXSS6bm5ufN6A5Kk19Yn6EedmVfPPl8BLq+qK4E7gHuSXPIdHasOVNVkVU1OTEz0KEmS1FefoJ8FNg6tbwBOnatPkrXA9wKnq+rFqvoqQFU9DDwN/OBSi5Yk9dcn6I8CW5JsTrIO2AVMzeszBdzaLb8H+FRVVZKJ7sNckrwN2AKcWJ7SJUl9LHjVTVWdSbIHOAKsAQ5W1bEk+4DpqpoCPg78dpIZ4DSDXwYA1wD7kpwBXgY+UFWnL8QbkSSN1uuGqao6DBye13bn0PL/Bd47Ytz9wP1LrFGStAQ+AkGSGmfQS1LjDHpJapxBL0mNM+glqXE+prgBPi5Y0mvxjF6SGmfQS1LjDHpJapxBL0mNM+glqXEGvSQ1zssrJWmecV2yfPKumy7Ifj2jl6TGeUa/TLxpSdJq5Rm9JDXOoJekxhn0ktQ4g16SGmfQS1LjDHpJapxBL0mN63UdfZLtwH8E1gAfq6q75m2/CPgvwN8Dvgq8r6pOdts+BNwGvAz8XFUdWbbqR/B6dkl6tQXP6JOsAfYDNwJbgVuSbJ3X7Tbg+ar6AeA/AB/pxm4FdgE/DGwHfqPbnyRphfSZutkGzFTViap6CTgE7JzXZyfwiW75PuDaJOnaD1XVi1X1ZWCm258kaYX0mbpZDzw7tD4LXHWuPlV1JsnXgDd37Q/NG7t+/gGS7AZ2d6vfSPJkr+pX3mXAX4+7iHOwtsWxtsWxtsV5zdrykSXt+63n2tAn6DOirXr26TOWqjoAHOhRy1glma6qyXHXMYq1LY61LY61Lc64auszdTMLbBxa3wCcOlefJGuB7wVO9xwrSbqA+gT9UWBLks1J1jH4cHVqXp8p4NZu+T3Ap6qquvZdSS5KshnYAnxheUqXJPWx4NRNN+e+BzjC4PLKg1V1LMk+YLqqpoCPA7+dZIbBmfyubuyxJPcCx4EzwO1V9fIFei8rYTVPL1nb4ljb4ljb4oyltgxOvCVJrfLOWElqnEEvSY0z6HtIsjHJp5M8keRYkg+Ou6azkrwhyReSfLGr7d+Nu6ZhSdYkeTTJH4y7lvmSnEzyeJLHkkyPu55hSb4vyX1J/rz7ufsH464JIMkPdd+vs6+vJ/n5cdd1VpJ/1f07+LMkv5vkDeOu6awkH+zqOrbS3zPn6HtI8hbgLVX1SJK/BTwM3FxVx8dcGt0dyBdX1TeSfDfwOeCDVfXQAkNXRJI7gEngkqr6yXHXMyzJSWCyqlbdzTVJPgH896r6WHe12xur6n+Nu65h3eNM/gq4qqr+chXUs57Bz//WqnqhuxDkcFX95/FWBkl+hMFTBbYBLwF/BPxsVT21Esf3jL6HqvpKVT3SLf9v4AlG3OE7DjXwjW71u7vXqvjtnWQDcBPwsXHX8nqS5BLgGgZXs1FVL622kO9cCzy9GkJ+yFrge7r7ed7I6rlv5x3AQ1X1zao6A3wW+CcrdXCD/jwl2QRcCXx+vJX8f930yGPAc8CDVbVaavt14N8A3x53IedQwB8nebh7DMdq8TZgDvitbtrrY0kuHndRI+wCfnfcRZxVVX8F/HvgGeArwNeq6o/HW9Ur/gy4Jsmbk7wR+Me8+mbSC8qgPw9J3gTcD/x8VX193PWcVVUvV9UVDO483tb9mThWSX4SeK6qHh53La/h6qp6F4Mns96e5JpxF9RZC7wL+E9VdSXwf4C94y3p1brppB3AJ8ddy1lJLmXwIMXNwN8FLk7y/vFWNVBVTzB4qu+DDKZtvsjg3qIVYdD31M1/3w/8TlX93rjrGaX78/4zDB4JPW5XAzu6efBDwE8k+a/jLenVqupU9/U54PdZPU9WnQVmh/4yu49B8K8mNwKPVNX/HHchQ64DvlxVc1X1LeD3gH845ppeUVUfr6p3VdU1DG4sXZH5eTDoe+k+8Pw48ERV/dq46xmWZCLJ93XL38Pgh/3Px1sVVNWHqmpDVW1i8Cf+p6pqVZxdASS5uPtgnW5a5AYGf16PXVX9D+DZJD/UNV3L4O7y1eQWVtG0TecZ4O8neWP3b/ZaBp+nrQpJ/nb39XLgn7KC379e/8OUuBr458Dj3Vw4wL+tqsNjrOmstwCf6K6A+C7g3qpadZcyrkJ/B/j9QR6wFrinqv5ovCW9yr8EfqebIjkB/PSY63lFN8d8PfAz465lWFV9Psl9wCMMpkUeZXU9DuH+JG8GvsXgcTDPr9SBvbxSkhrn1I0kNc6gl6TGGfSS1DiDXpIaZ9BLUuMMeklqnEEvSY37f2CVeWLbywVvAAAAAElFTkSuQmCC\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXoAAAD6CAYAAACvZ4z8AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAASz0lEQVR4nO3dbYwd133f8e8vZCjHcpUo1rZwScqkHSYwEweSu6HaClGB6MFUFZBqYcNU4UIJBDBOxcapUDR0E8gogwCyU6TpC6YRYTN10yisLCXAImLCCPEDagSyuXqwFVJRtKIZaUO32piqXdeqZMr/vrhD9Wp9qR3uLveuTr4f4GJnzpwz87+L5W9nz50ZpqqQJLXru8ZdgCTpwjLoJalxBr0kNc6gl6TGGfSS1DiDXpIa1yvok2xP8mSSmSR7R2z/QJLHkzyW5HNJtnbtm5K80LU/luQ3l/sNSJJeWxa6jj7JGuAvgOuBWeAocEtVHR/qc0lVfb1b3gH8i6ranmQT8AdV9SN9C7rssstq06ZN5/k2JOlvtocffvivq2pi1La1PcZvA2aq6gRAkkPATuCVoD8b8p2LgUXfhbVp0yamp6cXO1yS/kZK8pfn2tZn6mY98OzQ+mzXNv8gtyd5Gvgo8HNDmzYneTTJZ5P8+DkK3J1kOsn03Nxcj5IkSX31CfqMaPuOM/aq2l9Vbwd+AfilrvkrwOVVdSVwB3BPkktGjD1QVZNVNTkxMfIvD0nSIvUJ+llg49D6BuDUa/Q/BNwMUFUvVtVXu+WHgaeBH1xcqZKkxegT9EeBLUk2J1kH7AKmhjsk2TK0ehPwVNc+0X2YS5K3AVuAE8tRuCSpnwU/jK2qM0n2AEeANcDBqjqWZB8wXVVTwJ4k1wHfAp4Hbu2GXwPsS3IGeBn4QFWdvhBvRJI02oKXV660ycnJ8qobSTo/SR6uqslR27wzVpIaZ9BLUuMMeklqXJ87YyWN2aa9D4zt2Cfvumlsx9by8Ixekhpn0EtS4wx6SWqcQS9JjTPoJalxBr0kNc6gl6TGGfSS1DiDXpIaZ9BLUuMMeklqnEEvSY0z6CWpcQa9JDXOoJekxhn0ktQ4g16SGmfQS1LjegV9ku1Jnkwyk2TviO0fSPJ4kseSfC7J1qFtH+rGPZnk3ctZvCRpYQsGfZI1wH7gRmArcMtwkHfuqap3VtUVwEeBX+vGbgV2AT8MbAd+o9ufJGmF9Dmj3wbMVNWJqnoJOATsHO5QVV8fWr0YqG55J3Coql6sqi8DM93+JEkrZG2PPuuBZ4fWZ4Gr5ndKcjtwB7AO+ImhsQ/NG7t+xNjdwG6Ayy+/vE/dkqSe+pzRZ0RbfUdD1f6qejvwC8AvnefYA1U1WVWTExMTPUqSJPXVJ+hngY1D6xuAU6/R/xBw8yLHSpKWWZ+gPwpsSbI5yToGH65ODXdIsmVo9SbgqW55CtiV5KIkm4EtwBeWXrYkqa8F5+ir6kySPcARYA1wsKqOJdkHTFfVFLAnyXXAt4DngVu7sceS3AscB84At1fVyxfovUi6ADbtfWAsxz15101jOW6L+nwYS1UdBg7Pa7tzaPmDrzH2V4BfWWyBkqSl8c5YSWqcQS9JjTPoJalxBr0kNc6gl6TGGfSS1DiDXpIaZ9BLUuMMeklqnEEvSY0z6CWpcQa9JDXOoJekxhn0ktQ4g16SGmfQS1LjDHpJapxBL0mNM+glqXEGvSQ1zqCXpMatHXcB0uvJpr0PjLsE6bz1OqNPsj3Jk0lmkuwdsf2OJMeTfCnJnyR569C2l5M81r2mlrN4SdLCFjyjT7IG2A9cD8wCR5NMVdXxoW6PApNV9c0kPwt8FHhft+2FqrpimeuWJPXU54x+GzBTVSeq6iXgELBzuENVfbqqvtmtPgRsWN4yJUmL1Sfo1wPPDq3Pdm3nchvwh0Prb0gyneShJDePGpBkd9dnem5urkdJkqS++nwYmxFtNbJj8n5gEvhHQ82XV9WpJG8DPpXk8ap6+lU7qzoAHACYnJwcuW9J0uL0OaOfBTYOrW8ATs3vlOQ64BeBHVX14tn2qjrVfT0BfAa4cgn1SpLOU5+gPwpsSbI5yTpgF/Cqq2eSXAnczSDknxtqvzTJRd3yZcDVwPCHuJKkC2zBqZuqOpNkD3AEWAMcrKpjSfYB01U1Bfwq8Cbgk0kAnqmqHcA7gLuTfJvBL5W75l2tI0m6wHrdMFVVh4HD89ruHFq+7hzj/hR451IKlCQtjY9AkKTGGfSS1DiDXpIaZ9BLUuMMeklqnEEvSY0z6CWpcQa9JDXOoJekxhn0ktQ4g16SGmfQS1LjDHpJapxBL0mNM+glqXEGvSQ1zqCXpMYZ9JLUOINekhpn0EtS4wx6SWqcQS9JjesV9Em2J3kyyUySvSO235HkeJIvJfmTJG8d2nZrkqe6163LWbwkaWELBn2SNcB+4EZgK3BLkq3zuj0KTFbVjwL3AR/txn4/8GHgKmAb8OEkly5f+ZKkhfQ5o98GzFTViap6CTgE7BzuUFWfrqpvdqsPARu65XcDD1bV6ap6HngQ2L48pUuS+ugT9OuBZ4fWZ7u2c7kN+MPzGZtkd5LpJNNzc3M9SpIk9dUn6DOirUZ2TN4PTAK/ej5jq+pAVU1W1eTExESPkiRJffUJ+llg49D6BuDU/E5JrgN+EdhRVS+ez1hJ0oXTJ+iPAluSbE6yDtgFTA13SHIlcDeDkH9uaNMR4IYkl3Yfwt7QtUmSVsjahTpU1ZkkexgE9BrgYFUdS7IPmK6qKQZTNW8CPpkE4Jmq2lFVp5P8MoNfFgD7qur0BXknkqSRFgx6gKo6DBye13bn0PJ1rzH2IHBwsQVKkpbGO2MlqXEGvSQ1zqCXpMYZ9JLUOINekhpn0EtS4wx6SWqcQS9JjTPoJalxBr0kNc6gl6TGGfSS1DiDXpIaZ9BLUuMMeklqnEEvSY0z6CWpcQa9JDXOoJekxhn0ktQ4g16SGtcr6JNsT/Jkkpkke0dsvybJI0nOJHnPvG0vJ3mse00tV+GSpH7WLtQhyRpgP3A9MAscTTJVVceHuj0D/BTwr0fs4oWqumIZapUkLcKCQQ9sA2aq6gRAkkPATuCVoK+qk922b1+AGiVJS9Bn6mY98OzQ+mzX1tcbkkwneSjJzaM6JNnd9Zmem5s7j11LkhbSJ+gzoq3O4xiXV9Uk8M+AX0/y9u/YWdWBqpqsqsmJiYnz2LUkaSF9gn4W2Di0vgE41fcAVXWq+3oC+Axw5XnUJ0laoj5BfxTYkmRzknXALqDX1TNJLk1yUbd8GXA1Q3P7kqQLb8Ggr6ozwB7gCPAEcG9VHUuyL8kOgCQ/lmQWeC9wd5Jj3fB3ANNJvgh8Grhr3tU6kqQLrM9VN1TVYeDwvLY7h5aPMpjSmT/uT4F3LrFGSdISeGesJDWu1xm9JK20TXsfGNuxT95109iOfSF4Ri9JjTPoJalxBr0kNc6gl6TGGfSS1DiDXpIaZ9BLUuO8jl6vO+O8vlp6PfKMXpIaZ9BLUuMMeklqnEEvSY0z6CWpcQa9JDXOoJekxhn0ktQ4g16SGmfQS1LjDHpJapxBL0mN6xX0SbYneTLJTJK9I7Zfk+SRJGeSvGfetluTPNW9bl2uwiVJ/SwY9EnWAPuBG4GtwC1Jts7r9gzwU8A988Z+P/Bh4CpgG/DhJJcuvWxJUl99zui3ATNVdaKqXgIOATuHO1TVyar6EvDteWPfDTxYVaer6nngQWD7MtQtSeqpT9CvB54dWp/t2vroNTbJ7iTTSabn5uZ67lqS1EefoM+Ituq5/15jq+pAVU1W1eTExETPXUuS+ugT9LPAxqH1DcCpnvtfylhJ0jLoE/RHgS1JNidZB+wCpnru/whwQ5JLuw9hb+jaJEkrZMGgr6ozwB4GAf0EcG9VHUuyL8kOgCQ/lmQWeC9wd5Jj3djTwC8z+GVxFNjXtUmSVkiv/xy8qg4Dh+e13Tm0fJTBtMyosQeBg0uoUZK0BN4ZK0mNM+glqXEGvSQ1zqCXpMYZ9JLUOINekhpn0EtS4wx6SWqcQS9JjTPoJalxBr0kNc6gl6TGGfSS1DiDXpIaZ9BLUuMMeklqnEEvSY0z6CWpcQa9JDXOoJekxhn0ktS4teMuQK9fm/Y+MO4SJPXQ64w+yfYkTyaZSbJ3xPaLkvy3bvvnk2zq2jcleSHJY93rN5e3fEnSQhY8o0+yBtgPXA/MAkeTTFXV8aFutwHPV9UPJNkFfAR4X7ft6aq6YpnrliT11OeMfhswU1Unquol4BCwc16fncAnuuX7gGuTZPnKlCQtVp+gXw88O7Q+27WN7FNVZ4CvAW/utm1O8miSzyb58VEHSLI7yXSS6bm5ufN6A5Kk19Yn6EedmVfPPl8BLq+qK4E7gHuSXPIdHasOVNVkVU1OTEz0KEmS1FefoJ8FNg6tbwBOnatPkrXA9wKnq+rFqvoqQFU9DDwN/OBSi5Yk9dcn6I8CW5JsTrIO2AVMzeszBdzaLb8H+FRVVZKJ7sNckrwN2AKcWJ7SJUl9LHjVTVWdSbIHOAKsAQ5W1bEk+4DpqpoCPg78dpIZ4DSDXwYA1wD7kpwBXgY+UFWnL8QbkSSN1uuGqao6DBye13bn0PL/Bd47Ytz9wP1LrFGStAQ+AkGSGmfQS1LjDHpJapxBL0mNM+glqXE+prgBPi5Y0mvxjF6SGmfQS1LjDHpJapxBL0mNM+glqXEGvSQ1zssrJWmecV2yfPKumy7Ifj2jl6TGeUa/TLxpSdJq5Rm9JDXOoJekxhn0ktQ4g16SGmfQS1LjDHpJapxBL0mN63UdfZLtwH8E1gAfq6q75m2/CPgvwN8Dvgq8r6pOdts+BNwGvAz8XFUdWbbqR/B6dkl6tQXP6JOsAfYDNwJbgVuSbJ3X7Tbg+ar6AeA/AB/pxm4FdgE/DGwHfqPbnyRphfSZutkGzFTViap6CTgE7JzXZyfwiW75PuDaJOnaD1XVi1X1ZWCm258kaYX0mbpZDzw7tD4LXHWuPlV1JsnXgDd37Q/NG7t+/gGS7AZ2d6vfSPJkr+pX3mXAX4+7iHOwtsWxtsWxtsV5zdrykSXt+63n2tAn6DOirXr26TOWqjoAHOhRy1glma6qyXHXMYq1LY61LY61Lc64auszdTMLbBxa3wCcOlefJGuB7wVO9xwrSbqA+gT9UWBLks1J1jH4cHVqXp8p4NZu+T3Ap6qquvZdSS5KshnYAnxheUqXJPWx4NRNN+e+BzjC4PLKg1V1LMk+YLqqpoCPA7+dZIbBmfyubuyxJPcCx4EzwO1V9fIFei8rYTVPL1nb4ljb4ljb4oyltgxOvCVJrfLOWElqnEEvSY0z6HtIsjHJp5M8keRYkg+Ou6azkrwhyReSfLGr7d+Nu6ZhSdYkeTTJH4y7lvmSnEzyeJLHkkyPu55hSb4vyX1J/rz7ufsH464JIMkPdd+vs6+vJ/n5cdd1VpJ/1f07+LMkv5vkDeOu6awkH+zqOrbS3zPn6HtI8hbgLVX1SJK/BTwM3FxVx8dcGt0dyBdX1TeSfDfwOeCDVfXQAkNXRJI7gEngkqr6yXHXMyzJSWCyqlbdzTVJPgH896r6WHe12xur6n+Nu65h3eNM/gq4qqr+chXUs57Bz//WqnqhuxDkcFX95/FWBkl+hMFTBbYBLwF/BPxsVT21Esf3jL6HqvpKVT3SLf9v4AlG3OE7DjXwjW71u7vXqvjtnWQDcBPwsXHX8nqS5BLgGgZXs1FVL622kO9cCzy9GkJ+yFrge7r7ed7I6rlv5x3AQ1X1zao6A3wW+CcrdXCD/jwl2QRcCXx+vJX8f930yGPAc8CDVbVaavt14N8A3x53IedQwB8nebh7DMdq8TZgDvitbtrrY0kuHndRI+wCfnfcRZxVVX8F/HvgGeArwNeq6o/HW9Ur/gy4Jsmbk7wR+Me8+mbSC8qgPw9J3gTcD/x8VX193PWcVVUvV9UVDO483tb9mThWSX4SeK6qHh53La/h6qp6F4Mns96e5JpxF9RZC7wL+E9VdSXwf4C94y3p1brppB3AJ8ddy1lJLmXwIMXNwN8FLk7y/vFWNVBVTzB4qu+DDKZtvsjg3qIVYdD31M1/3w/8TlX93rjrGaX78/4zDB4JPW5XAzu6efBDwE8k+a/jLenVqupU9/U54PdZPU9WnQVmh/4yu49B8K8mNwKPVNX/HHchQ64DvlxVc1X1LeD3gH845ppeUVUfr6p3VdU1DG4sXZH5eTDoe+k+8Pw48ERV/dq46xmWZCLJ93XL38Pgh/3Px1sVVNWHqmpDVW1i8Cf+p6pqVZxdASS5uPtgnW5a5AYGf16PXVX9D+DZJD/UNV3L4O7y1eQWVtG0TecZ4O8neWP3b/ZaBp+nrQpJ/nb39XLgn7KC379e/8OUuBr458Dj3Vw4wL+tqsNjrOmstwCf6K6A+C7g3qpadZcyrkJ/B/j9QR6wFrinqv5ovCW9yr8EfqebIjkB/PSY63lFN8d8PfAz465lWFV9Psl9wCMMpkUeZXU9DuH+JG8GvsXgcTDPr9SBvbxSkhrn1I0kNc6gl6TGGfSS1DiDXpIaZ9BLUuMMeklqnEEvSY37f2CVeWLbywVvAAAAAElFTkSuQmCC",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
@@ -1048,34 +1042,34 @@
             "needs_background": "light"
           }
         }
-      ]
+      ],
+      "metadata": {
+        "jupyter": {
+          "outputs_hidden": false
+        },
+        "id": "Mkv5LHGH_G_K",
+        "outputId": "3fd60282-ab9d-4ff4-8477-7b46bd5694e8"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "zvztNYNs_G_L"
-      },
       "source": [
         "The ten bins do not change. But now `n` represents the density of the data inside each bin. In other words, the sum of the area of each bar will equal to 1. \n",
         "\n",
         "**Q: Can you verify this?**\n",
         "\n",
         "Hint: the area of each bar is calculated as height * width. You may get something like 0.99999999999999978 instead of 1."
-      ]
+      ],
+      "metadata": {
+        "id": "zvztNYNs_G_L"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "jupyter": {
-          "outputs_hidden": false
-        },
-        "id": "Ldt8Eoj8_G_L",
-        "outputId": "f2b1095b-7b04-4e88-f126-b0fc6a70a2b8"
-      },
+      "execution_count": null,
       "source": [
         "# TODO\n"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1089,38 +1083,32 @@
           },
           "execution_count": 34
         }
-      ]
+      ],
+      "metadata": {
+        "jupyter": {
+          "outputs_hidden": false
+        },
+        "id": "Ldt8Eoj8_G_L",
+        "outputId": "f2b1095b-7b04-4e88-f126-b0fc6a70a2b8"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "pQXojeqp_G_L"
-      },
       "source": [
         "Anyway, these data generated from the `hist` function is calculated from `numpy`'s `histogram` function. https://docs.scipy.org/doc/numpy/reference/generated/numpy.histogram.html \n",
         "\n",
         "Note that the result of `np.histogram()` is same as that of `plt.hist()`. "
-      ]
+      ],
+      "metadata": {
+        "id": "pQXojeqp_G_L"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2020-06-14T19:57:14.303Z",
-          "iopub.status.busy": "2020-06-14T19:57:14.287Z",
-          "iopub.status.idle": "2020-06-14T19:57:14.334Z",
-          "shell.execute_reply": "2020-06-14T19:57:14.349Z"
-        },
-        "jupyter": {
-          "outputs_hidden": false
-        },
-        "id": "NDSkwiqc_G_M",
-        "outputId": "156c2de8-8522-45bc-cca1-aade8503585d"
-      },
+      "execution_count": null,
       "source": [
         "np.histogram(movies['IMDB_Rating'])"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1135,21 +1123,27 @@
           },
           "execution_count": 26
         }
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
+        "execution": {
+          "iopub.execute_input": "2020-06-14T19:57:14.303Z",
+          "iopub.status.busy": "2020-06-14T19:57:14.287Z",
+          "iopub.status.idle": "2020-06-14T19:57:14.334Z",
+          "shell.execute_reply": "2020-06-14T19:57:14.349Z"
+        },
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "5hU0Bt2a_G_M",
-        "outputId": "467ab41d-1a19-49e3-ba78-a16a4755ba4b"
-      },
+        "id": "NDSkwiqc_G_M",
+        "outputId": "156c2de8-8522-45bc-cca1-aade8503585d"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "plt.hist(movies['IMDB_Rating'])"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1168,7 +1162,7 @@
         {
           "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD4CAYAAAAXUaZHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAS1ElEQVR4nO3db4yd5Xnn8e+vOIRAm5g/Brm2d00VK5uoUgg7om6R0C5OqwBRzK6CRLRbLGTJ1YrNkrJS6/bNqtK+AKkqDdIKycJtzW5KQkkQVkBpkCG72xe4HQPhT5zKDiX2xC6eFnCaZbsJ7bUvzj0wto89x+OZOcPd70c6ep7neu4z5zqW/fM99zzPmVQVkqS+/NS4G5AkLTzDXZI6ZLhLUocMd0nqkOEuSR1aMe4GAC677LJav379uNuQpPeUffv2/U1VrRp2blmE+/r165mcnBx3G5L0npLk+6c757KMJHVopHBP8utJXk7yUpKHklyQ5Moke5McSPKVJOe3se9vxwfb+fWL+QYkSaeaM9yTrAH+EzBRVT8PnAfcCtwD3FtVG4A3gK3tKVuBN6rqw8C9bZwkaQmNuiyzAvhAkhXAhcBR4HrgkXZ+F3Bz29/cjmnnNyXJwrQrSRrFnOFeVT8Afhc4xCDUjwP7gDer6u02bApY0/bXAIfbc99u4y89+esm2ZZkMsnk9PT0ub4PSdIsoyzLXMxgNn4l8LPARcANQ4bOfALZsFn6KZ9OVlU7qmqiqiZWrRp6JY8kaZ5GWZb5JPBXVTVdVT8Bvgb8ErCyLdMArAWOtP0pYB1AO/8h4PUF7VqSdEajhPshYGOSC9va+SbgO8DTwGfbmC3AY21/dzumnX+q/FxhSVpSo6y572Xwg9FngRfbc3YAvwncleQggzX1ne0pO4FLW/0uYPsi9C1JOoMsh0n1xMREeYeqdKL12x8fy+u+evdNY3ldnb0k+6pqYtg571CVpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktShOcM9yUeSPD/r8cMkX0hySZInkxxo24vb+CS5L8nBJC8kuXrx34YkabZRfkH2X1bVVVV1FfAvgbeARxn84us9VbUB2MO7vwj7BmBDe2wD7l+MxiVJp3e2yzKbgO9V1feBzcCuVt8F3Nz2NwMP1sAzwMokqxekW0nSSM423G8FHmr7V1TVUYC2vbzV1wCHZz1nqtVOkGRbkskkk9PT02fZhiTpTEYO9yTnA58B/mSuoUNqdUqhakdVTVTVxKpVq0ZtQ5I0grOZud8APFtVr7Xj12aWW9r2WKtPAetmPW8tcORcG5Ukje5swv1zvLskA7Ab2NL2twCPzarf1q6a2Qgcn1m+kSQtjRWjDEpyIfDLwK/NKt8NPJxkK3AIuKXVnwBuBA4yuLLm9gXrVtKiW7/98bG99qt33zS21+7NSOFeVW8Bl55U+1sGV8+cPLaAOxakO0nSvHiHqiR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHVopHBPsjLJI0m+m2R/kl9MckmSJ5McaNuL29gkuS/JwSQvJLl6cd+CJOlko87cvwh8o6r+BfBxYD+wHdhTVRuAPe0Y4AZgQ3tsA+5f0I4lSXOaM9yTfBC4DtgJUFU/rqo3gc3ArjZsF3Bz298MPFgDzwArk6xe8M4lSac1ysz954Bp4A+TPJfkgSQXAVdU1VGAtr28jV8DHJ71/KlWO0GSbUkmk0xOT0+f05uQJJ1oxYhjrgY+X1V7k3yRd5dghsmQWp1SqNoB7ACYmJg45by0HKzf/vi4W5DmZZSZ+xQwVVV72/EjDML+tZnllrY9Nmv8ulnPXwscWZh2JUmjmDPcq+qvgcNJPtJKm4DvALuBLa22BXis7e8GbmtXzWwEjs8s30iSlsYoyzIAnwe+lOR84BXgdgb/MTycZCtwCLiljX0CuBE4CLzVxkqSltBI4V5VzwMTQ05tGjK2gDvOsS9J0jnwDlVJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0aKdyTvJrkxSTPJ5lstUuSPJnkQNte3OpJcl+Sg0leSHL1Yr4BSdKpzmbm/q+r6qqqmvldqtuBPVW1AdjTjgFuADa0xzbg/oVqVpI0mnNZltkM7Gr7u4CbZ9UfrIFngJVJVp/D60iSztKo4V7AN5PsS7Kt1a6oqqMAbXt5q68BDs967lSrnSDJtiSTSSanp6fn170kaagVI467tqqOJLkceDLJd88wNkNqdUqhagewA2BiYuKU85Kk+Rtp5l5VR9r2GPAocA3w2sxyS9sea8OngHWznr4WOLJQDUuS5jZnuCe5KMnPzOwDvwK8BOwGtrRhW4DH2v5u4LZ21cxG4PjM8o0kaWmMsixzBfBokpnxf1xV30jyF8DDSbYCh4Bb2vgngBuBg8BbwO0L3rUk6YzmDPeqegX4+JD63wKbhtQLuGNBupMkzYt3qEpShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHRg73JOcleS7J19vxlUn2JjmQ5CtJzm/197fjg+38+sVpXZJ0Omczc78T2D/r+B7g3qraALwBbG31rcAbVfVh4N42TpK0hEYK9yRrgZuAB9pxgOuBR9qQXcDNbX9zO6ad39TGS5KWyKgz998HfgP4x3Z8KfBmVb3djqeANW1/DXAYoJ0/3safIMm2JJNJJqenp+fZviRpmDnDPcmngWNVtW92ecjQGuHcu4WqHVU1UVUTq1atGqlZSdJoVoww5lrgM0luBC4APshgJr8yyYo2O18LHGnjp4B1wFSSFcCHgNcXvHNJ0mnNOXOvqt+qqrVVtR64FXiqqv4d8DTw2TZsC/BY29/djmnnn6qqU2bukqTFcy7Xuf8mcFeSgwzW1He2+k7g0la/C9h+bi1Kks7WKMsy76iqbwHfavuvANcMGfP3wC0L0JskaZ68Q1WSOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdeisPvJXkhbT+u2Pj+V1X737prG87mJy5i5JHTLcJalDc4Z7kguS/HmSbyd5OcnvtPqVSfYmOZDkK0nOb/X3t+OD7fz6xX0LkqSTjTJz/3/A9VX1ceAq4FNJNgL3APdW1QbgDWBrG78VeKOqPgzc28ZJkpbQnOFeAz9qh+9rjwKuBx5p9V3AzW1/czumnd+UJAvWsSRpTiOtuSc5L8nzwDHgSeB7wJtV9XYbMgWsaftrgMMA7fxx4NKFbFqSdGYjhXtV/UNVXQWsBa4BPjpsWNsOm6XXyYUk25JMJpmcnp4etV9J0gjO6jr3qnozybeAjcDKJCva7HwtcKQNmwLWAVNJVgAfAl4f8rV2ADsAJiYmTgl/abZxXf8svVeNcrXMqiQr2/4HgE8C+4Gngc+2YVuAx9r+7nZMO/9UVRnekrSERpm5rwZ2JTmPwX8GD1fV15N8B/hykv8KPAfsbON3Av89yUEGM/ZbF6FvSdIZzBnuVfUC8Ikh9VcYrL+fXP974JYF6U6SNC/eoSpJHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOj/ILsdUmeTrI/yctJ7mz1S5I8meRA217c6klyX5KDSV5IcvVivwlJ0olGmbm/DfznqvoosBG4I8nHgO3AnqraAOxpxwA3ABvaYxtw/4J3LUk6oznDvaqOVtWzbf/vgP3AGmAzsKsN2wXc3PY3Aw/WwDPAyiSrF7xzSdJpndWae5L1wCeAvcAVVXUUBv8BAJe3YWuAw7OeNtVqJ3+tbUkmk0xOT0+ffeeSpNMaOdyT/DTwVeALVfXDMw0dUqtTClU7qmqiqiZWrVo1ahuSpBGMFO5J3scg2L9UVV9r5ddmllva9lirTwHrZj19LXBkYdqVJI1ilKtlAuwE9lfV7806tRvY0va3AI/Nqt/WrprZCByfWb6RJC2NFSOMuRb4VeDFJM+32m8DdwMPJ9kKHAJuaeeeAG4EDgJvAbcvaMeSpDnNGe5V9WcMX0cH2DRkfAF3nGNfkqRz4B2qktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SerQKJ8KKb1j/fbHx92CpBE4c5ekDhnuktQhw12SOmS4S1KHRvkdqn+Q5FiSl2bVLknyZJIDbXtxqyfJfUkOJnkhydWL2bwkabhRZu5/BHzqpNp2YE9VbQD2tGOAG4AN7bENuH9h2pQknY05w72q/hfw+knlzcCutr8LuHlW/cEaeAZYmWT1QjUrSRrNfNfcr6iqowBte3mrrwEOzxo31WqnSLItyWSSyenp6Xm2IUkaZqF/oJohtRo2sKp2VNVEVU2sWrVqgduQpH/a5hvur80st7TtsVafAtbNGrcWODL/9iRJ8zHfcN8NbGn7W4DHZtVva1fNbASOzyzfSJKWzpyfLZPkIeBfAZclmQL+C3A38HCSrcAh4JY2/AngRuAg8BZw+yL0LEmaw5zhXlWfO82pTUPGFnDHuTYlSTo33qEqSR3yI3/fg/zYXUlzceYuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOuSlkJL+yRvn5cWv3n3TonxdZ+6S1CFn7ufAm4kkLVfO3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6tCiXOee5FPAF4HzgAeq6u7FeB3wWnNJGmbBZ+5JzgP+G3AD8DHgc0k+ttCvI0k6vcVYlrkGOFhVr1TVj4EvA5sX4XUkSaexGMsya4DDs46ngF84eVCSbcC2dvijJH+5CL0shMuAvxl3E6dhb/Njb/Njb/Nzxt5yzzl97X9+uhOLEe4ZUqtTClU7gB2L8PoLKslkVU2Mu49h7G1+7G1+7G1+xtXbYizLTAHrZh2vBY4swutIkk5jMcL9L4ANSa5Mcj5wK7B7EV5HknQaC74sU1VvJ/mPwJ8yuBTyD6rq5YV+nSW0nJeO7G1+7G1+7G1+xtJbqk5ZDpckvcd5h6okdchwl6QOGe5DJFmX5Okk+5O8nOTOcfc0I8kFSf48ybdbb78z7p5OluS8JM8l+fq4e5ktyatJXkzyfJLJcfczW5KVSR5J8t329+4Xx90TQJKPtD+vmccPk3xh3H3NSPLr7d/BS0keSnLBuHuakeTO1tfL4/gzc819iCSrgdVV9WySnwH2ATdX1XfG3BpJAlxUVT9K8j7gz4A7q+qZMbf2jiR3ARPAB6vq0+PuZ0aSV4GJqlp2N7sk2QX876p6oF1ldmFVvTnuvmZrHy3yA+AXqur7y6CfNQz+/n+sqv5vkoeBJ6rqj8bbGST5eQZ3518D/Bj4BvAfqurAUvXgzH2IqjpaVc+2/b8D9jO483bsauBH7fB97bFs/odOsha4CXhg3L28VyT5IHAdsBOgqn683IK92QR8bzkE+ywrgA8kWQFcyPK5p+ajwDNV9VZVvQ38T+DfLGUDhvsckqwHPgHsHW8n72rLHs8Dx4Anq2rZ9Ab8PvAbwD+Ou5EhCvhmkn3t4y+Wi58DpoE/bMtZDyS5aNxNDXEr8NC4m5hRVT8Afhc4BBwFjlfVN8fb1TteAq5LcmmSC4EbOfHmzkVnuJ9Bkp8Gvgp8oap+OO5+ZlTVP1TVVQzu/r2mfQs4dkk+DRyrqn3j7uU0rq2qqxl8YukdSa4bd0PNCuBq4P6q+gTwf4Dt423pRG2p6DPAn4y7lxlJLmbwoYRXAj8LXJTk34+3q4Gq2g/cAzzJYEnm28DbS9mD4X4abT37q8CXqupr4+5nmPat+7eAT425lRnXAp9pa9tfBq5P8j/G29K7qupI2x4DHmWwHrocTAFTs74De4RB2C8nNwDPVtVr425klk8Cf1VV01X1E+BrwC+Nuad3VNXOqrq6qq4DXgeWbL0dDPeh2g8tdwL7q+r3xt3PbElWJVnZ9j/A4C/4d8fb1UBV/VZVra2q9Qy+hX+qqpbFTCrJRe2H47Qlj19h8K3z2FXVXwOHk3yklTYBY//h/Uk+xzJakmkOARuTXNj+zW5i8POxZSHJ5W37z4B/yxL/+S3Kb2LqwLXArwIvtrVtgN+uqifG2NOM1cCuduXCTwEPV9WyuuRwmboCeHSQAawA/riqvjHelk7weeBLbfnjFeD2MffzjrZm/MvAr427l9mqam+SR4BnGSx5PMfy+hiCrya5FPgJcEdVvbGUL+6lkJLUIZdlJKlDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nq0P8HFgImXgFgiHcAAAAASUVORK5CYII=\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD4CAYAAAAXUaZHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAS1ElEQVR4nO3db4yd5Xnn8e+vOIRAm5g/Brm2d00VK5uoUgg7om6R0C5OqwBRzK6CRLRbLGTJ1YrNkrJS6/bNqtK+AKkqDdIKycJtzW5KQkkQVkBpkCG72xe4HQPhT5zKDiX2xC6eFnCaZbsJ7bUvzj0wto89x+OZOcPd70c6ep7neu4z5zqW/fM99zzPmVQVkqS+/NS4G5AkLTzDXZI6ZLhLUocMd0nqkOEuSR1aMe4GAC677LJav379uNuQpPeUffv2/U1VrRp2blmE+/r165mcnBx3G5L0npLk+6c757KMJHVopHBP8utJXk7yUpKHklyQ5Moke5McSPKVJOe3se9vxwfb+fWL+QYkSaeaM9yTrAH+EzBRVT8PnAfcCtwD3FtVG4A3gK3tKVuBN6rqw8C9bZwkaQmNuiyzAvhAkhXAhcBR4HrgkXZ+F3Bz29/cjmnnNyXJwrQrSRrFnOFeVT8Afhc4xCDUjwP7gDer6u02bApY0/bXAIfbc99u4y89+esm2ZZkMsnk9PT0ub4PSdIsoyzLXMxgNn4l8LPARcANQ4bOfALZsFn6KZ9OVlU7qmqiqiZWrRp6JY8kaZ5GWZb5JPBXVTVdVT8Bvgb8ErCyLdMArAWOtP0pYB1AO/8h4PUF7VqSdEajhPshYGOSC9va+SbgO8DTwGfbmC3AY21/dzumnX+q/FxhSVpSo6y572Xwg9FngRfbc3YAvwncleQggzX1ne0pO4FLW/0uYPsi9C1JOoMsh0n1xMREeYeqdKL12x8fy+u+evdNY3ldnb0k+6pqYtg571CVpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktShOcM9yUeSPD/r8cMkX0hySZInkxxo24vb+CS5L8nBJC8kuXrx34YkabZRfkH2X1bVVVV1FfAvgbeARxn84us9VbUB2MO7vwj7BmBDe2wD7l+MxiVJp3e2yzKbgO9V1feBzcCuVt8F3Nz2NwMP1sAzwMokqxekW0nSSM423G8FHmr7V1TVUYC2vbzV1wCHZz1nqtVOkGRbkskkk9PT02fZhiTpTEYO9yTnA58B/mSuoUNqdUqhakdVTVTVxKpVq0ZtQ5I0grOZud8APFtVr7Xj12aWW9r2WKtPAetmPW8tcORcG5Ukje5swv1zvLskA7Ab2NL2twCPzarf1q6a2Qgcn1m+kSQtjRWjDEpyIfDLwK/NKt8NPJxkK3AIuKXVnwBuBA4yuLLm9gXrVtKiW7/98bG99qt33zS21+7NSOFeVW8Bl55U+1sGV8+cPLaAOxakO0nSvHiHqiR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHVopHBPsjLJI0m+m2R/kl9MckmSJ5McaNuL29gkuS/JwSQvJLl6cd+CJOlko87cvwh8o6r+BfBxYD+wHdhTVRuAPe0Y4AZgQ3tsA+5f0I4lSXOaM9yTfBC4DtgJUFU/rqo3gc3ArjZsF3Bz298MPFgDzwArk6xe8M4lSac1ysz954Bp4A+TPJfkgSQXAVdU1VGAtr28jV8DHJ71/KlWO0GSbUkmk0xOT0+f05uQJJ1oxYhjrgY+X1V7k3yRd5dghsmQWp1SqNoB7ACYmJg45by0HKzf/vi4W5DmZZSZ+xQwVVV72/EjDML+tZnllrY9Nmv8ulnPXwscWZh2JUmjmDPcq+qvgcNJPtJKm4DvALuBLa22BXis7e8GbmtXzWwEjs8s30iSlsYoyzIAnwe+lOR84BXgdgb/MTycZCtwCLiljX0CuBE4CLzVxkqSltBI4V5VzwMTQ05tGjK2gDvOsS9J0jnwDlVJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0aKdyTvJrkxSTPJ5lstUuSPJnkQNte3OpJcl+Sg0leSHL1Yr4BSdKpzmbm/q+r6qqqmvldqtuBPVW1AdjTjgFuADa0xzbg/oVqVpI0mnNZltkM7Gr7u4CbZ9UfrIFngJVJVp/D60iSztKo4V7AN5PsS7Kt1a6oqqMAbXt5q68BDs967lSrnSDJtiSTSSanp6fn170kaagVI467tqqOJLkceDLJd88wNkNqdUqhagewA2BiYuKU85Kk+Rtp5l5VR9r2GPAocA3w2sxyS9sea8OngHWznr4WOLJQDUuS5jZnuCe5KMnPzOwDvwK8BOwGtrRhW4DH2v5u4LZ21cxG4PjM8o0kaWmMsixzBfBokpnxf1xV30jyF8DDSbYCh4Bb2vgngBuBg8BbwO0L3rUk6YzmDPeqegX4+JD63wKbhtQLuGNBupMkzYt3qEpShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHRg73JOcleS7J19vxlUn2JjmQ5CtJzm/197fjg+38+sVpXZJ0Omczc78T2D/r+B7g3qraALwBbG31rcAbVfVh4N42TpK0hEYK9yRrgZuAB9pxgOuBR9qQXcDNbX9zO6ad39TGS5KWyKgz998HfgP4x3Z8KfBmVb3djqeANW1/DXAYoJ0/3safIMm2JJNJJqenp+fZviRpmDnDPcmngWNVtW92ecjQGuHcu4WqHVU1UVUTq1atGqlZSdJoVoww5lrgM0luBC4APshgJr8yyYo2O18LHGnjp4B1wFSSFcCHgNcXvHNJ0mnNOXOvqt+qqrVVtR64FXiqqv4d8DTw2TZsC/BY29/djmnnn6qqU2bukqTFcy7Xuf8mcFeSgwzW1He2+k7g0la/C9h+bi1Kks7WKMsy76iqbwHfavuvANcMGfP3wC0L0JskaZ68Q1WSOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdeisPvJXkhbT+u2Pj+V1X737prG87mJy5i5JHTLcJalDc4Z7kguS/HmSbyd5OcnvtPqVSfYmOZDkK0nOb/X3t+OD7fz6xX0LkqSTjTJz/3/A9VX1ceAq4FNJNgL3APdW1QbgDWBrG78VeKOqPgzc28ZJkpbQnOFeAz9qh+9rjwKuBx5p9V3AzW1/czumnd+UJAvWsSRpTiOtuSc5L8nzwDHgSeB7wJtV9XYbMgWsaftrgMMA7fxx4NKFbFqSdGYjhXtV/UNVXQWsBa4BPjpsWNsOm6XXyYUk25JMJpmcnp4etV9J0gjO6jr3qnozybeAjcDKJCva7HwtcKQNmwLWAVNJVgAfAl4f8rV2ADsAJiYmTgl/abZxXf8svVeNcrXMqiQr2/4HgE8C+4Gngc+2YVuAx9r+7nZMO/9UVRnekrSERpm5rwZ2JTmPwX8GD1fV15N8B/hykv8KPAfsbON3Av89yUEGM/ZbF6FvSdIZzBnuVfUC8Ikh9VcYrL+fXP974JYF6U6SNC/eoSpJHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOj/ILsdUmeTrI/yctJ7mz1S5I8meRA217c6klyX5KDSV5IcvVivwlJ0olGmbm/DfznqvoosBG4I8nHgO3AnqraAOxpxwA3ABvaYxtw/4J3LUk6oznDvaqOVtWzbf/vgP3AGmAzsKsN2wXc3PY3Aw/WwDPAyiSrF7xzSdJpndWae5L1wCeAvcAVVXUUBv8BAJe3YWuAw7OeNtVqJ3+tbUkmk0xOT0+ffeeSpNMaOdyT/DTwVeALVfXDMw0dUqtTClU7qmqiqiZWrVo1ahuSpBGMFO5J3scg2L9UVV9r5ddmllva9lirTwHrZj19LXBkYdqVJI1ilKtlAuwE9lfV7806tRvY0va3AI/Nqt/WrprZCByfWb6RJC2NFSOMuRb4VeDFJM+32m8DdwMPJ9kKHAJuaeeeAG4EDgJvAbcvaMeSpDnNGe5V9WcMX0cH2DRkfAF3nGNfkqRz4B2qktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SerQKJ8KKb1j/fbHx92CpBE4c5ekDhnuktQhw12SOmS4S1KHRvkdqn+Q5FiSl2bVLknyZJIDbXtxqyfJfUkOJnkhydWL2bwkabhRZu5/BHzqpNp2YE9VbQD2tGOAG4AN7bENuH9h2pQknY05w72q/hfw+knlzcCutr8LuHlW/cEaeAZYmWT1QjUrSRrNfNfcr6iqowBte3mrrwEOzxo31WqnSLItyWSSyenp6Xm2IUkaZqF/oJohtRo2sKp2VNVEVU2sWrVqgduQpH/a5hvur80st7TtsVafAtbNGrcWODL/9iRJ8zHfcN8NbGn7W4DHZtVva1fNbASOzyzfSJKWzpyfLZPkIeBfAZclmQL+C3A38HCSrcAh4JY2/AngRuAg8BZw+yL0LEmaw5zhXlWfO82pTUPGFnDHuTYlSTo33qEqSR3yI3/fg/zYXUlzceYuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOuSlkJL+yRvn5cWv3n3TonxdZ+6S1CFn7ufAm4kkLVfO3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6tCiXOee5FPAF4HzgAeq6u7FeB3wWnNJGmbBZ+5JzgP+G3AD8DHgc0k+ttCvI0k6vcVYlrkGOFhVr1TVj4EvA5sX4XUkSaexGMsya4DDs46ngF84eVCSbcC2dvijJH+5CL0shMuAvxl3E6dhb/Njb/Njb/Nzxt5yzzl97X9+uhOLEe4ZUqtTClU7gB2L8PoLKslkVU2Mu49h7G1+7G1+7G1+xtXbYizLTAHrZh2vBY4swutIkk5jMcL9L4ANSa5Mcj5wK7B7EV5HknQaC74sU1VvJ/mPwJ8yuBTyD6rq5YV+nSW0nJeO7G1+7G1+7G1+xtJbqk5ZDpckvcd5h6okdchwl6QOGe5DJFmX5Okk+5O8nOTOcfc0I8kFSf48ybdbb78z7p5OluS8JM8l+fq4e5ktyatJXkzyfJLJcfczW5KVSR5J8t329+4Xx90TQJKPtD+vmccPk3xh3H3NSPLr7d/BS0keSnLBuHuakeTO1tfL4/gzc819iCSrgdVV9WySnwH2ATdX1XfG3BpJAlxUVT9K8j7gz4A7q+qZMbf2jiR3ARPAB6vq0+PuZ0aSV4GJqlp2N7sk2QX876p6oF1ldmFVvTnuvmZrHy3yA+AXqur7y6CfNQz+/n+sqv5vkoeBJ6rqj8bbGST5eQZ3518D/Bj4BvAfqurAUvXgzH2IqjpaVc+2/b8D9jO483bsauBH7fB97bFs/odOsha4CXhg3L28VyT5IHAdsBOgqn683IK92QR8bzkE+ywrgA8kWQFcyPK5p+ajwDNV9VZVvQ38T+DfLGUDhvsckqwHPgHsHW8n72rLHs8Dx4Anq2rZ9Ab8PvAbwD+Ou5EhCvhmkn3t4y+Wi58DpoE/bMtZDyS5aNxNDXEr8NC4m5hRVT8Afhc4BBwFjlfVN8fb1TteAq5LcmmSC4EbOfHmzkVnuJ9Bkp8Gvgp8oap+OO5+ZlTVP1TVVQzu/r2mfQs4dkk+DRyrqn3j7uU0rq2qqxl8YukdSa4bd0PNCuBq4P6q+gTwf4Dt423pRG2p6DPAn4y7lxlJLmbwoYRXAj8LXJTk34+3q4Gq2g/cAzzJYEnm28DbS9mD4X4abT37q8CXqupr4+5nmPat+7eAT425lRnXAp9pa9tfBq5P8j/G29K7qupI2x4DHmWwHrocTAFTs74De4RB2C8nNwDPVtVr425klk8Cf1VV01X1E+BrwC+Nuad3VNXOqrq6qq4DXgeWbL0dDPeh2g8tdwL7q+r3xt3PbElWJVnZ9j/A4C/4d8fb1UBV/VZVra2q9Qy+hX+qqpbFTCrJRe2H47Qlj19h8K3z2FXVXwOHk3yklTYBY//h/Uk+xzJakmkOARuTXNj+zW5i8POxZSHJ5W37z4B/yxL/+S3Kb2LqwLXArwIvtrVtgN+uqifG2NOM1cCuduXCTwEPV9WyuuRwmboCeHSQAawA/riqvjHelk7weeBLbfnjFeD2MffzjrZm/MvAr427l9mqam+SR4BnGSx5PMfy+hiCrya5FPgJcEdVvbGUL+6lkJLUIZdlJKlDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nq0P8HFgImXgFgiHcAAAAASUVORK5CYII=",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
@@ -1178,68 +1172,69 @@
             "needs_background": "light"
           }
         }
-      ]
+      ],
+      "metadata": {
+        "jupyter": {
+          "outputs_hidden": false
+        },
+        "id": "5hU0Bt2a_G_M",
+        "outputId": "467ab41d-1a19-49e3-ba78-a16a4755ba4b"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "CeFQkji4_G_M"
-      },
       "source": [
         "If you look at the documentation, you can see that `numpy` uses simply 10 as the default number of bins. But you can set it manually or set it to be `auto`, which is the \"Maximum of the `sturges` and `fd` estimators.\". Let's try this `auto` option. "
-      ]
+      ],
+      "metadata": {
+        "id": "CeFQkji4_G_M"
+      }
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "_ = plt.hist(movies['IMDB_Rating'], bins='auto')"
+      ],
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD4CAYAAAAXUaZHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAQfklEQVR4nO3dfYylZXnH8e9PwBdQC8pA1t1tl9qtEU1cyARpSYgVtbwYF5vSQFJLDOmaBlpoTRrkHzUpCSYKrUlLsgJ1bRHc8hI2SlSKWOsfgLOIwLIaVlxh3C07FgSsrbrr1T/OMzjsnt05OzNnzuzN95OcnOe5z33mXDPZ/c0913me56SqkCS15WWjLkCStPAMd0lqkOEuSQ0y3CWpQYa7JDXo8FEXAHDsscfWqlWrRl2GJB1SNm/e/OOqGuv32JII91WrVjExMTHqMiTpkJLkh/t7zLaMJDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1aEmcoSpp+FZd/qVZ52y/6pxFqESLwZW7JDXIcJekBhnuktQgw12SGmS4S1KDZg33JK9Mcn+S7yTZkuTj3fgJSe5L8liSLyR5eTf+im5/W/f4quF+C5KkvQ2ycv858M6qehuwBjgzyanAJ4Brqmo18AxwUTf/IuCZqvod4JpuniRpEc0a7tXz0273iO5WwDuBW7rxDcC53fbabp/u8TOSZMEqliTNaqCee5LDkjwI7ALuAr4P/KSqdndTJoHl3fZy4EmA7vFngdf3+ZrrkkwkmZiamprfdyFJepGBwr2q9lTVGmAFcArw5n7Tuvt+q/TaZ6BqfVWNV9X42Fjfz3eVJM3RQR0tU1U/Ab4OnAocnWT68gUrgB3d9iSwEqB7/DeApxeiWEnSYAY5WmYsydHd9quAdwFbgXuAP+6mXQjc0W1v6vbpHv9aVe2zcpckDc8gFw5bBmxIchi9XwYbq+qLSR4Fbk7yd8C3geu7+dcD/5JkG70V+/lDqFuSdACzhntVPQSc1Gf8cXr9973H/w84b0GqkyTNiWeoSlKDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGjRruCdZmeSeJFuTbElyaTf+sSQ/SvJgdzt7xnM+kmRbku8l+cNhfgOSpH0dPsCc3cCHq+qBJK8BNie5q3vsmqr65MzJSU4EzgfeArwB+Pckv1tVexaycEnS/s26cq+qnVX1QLf9PLAVWH6Ap6wFbq6qn1fVD4BtwCkLUawkaTAH1XNPsgo4CbivG7okyUNJbkhyTDe2HHhyxtMm6fPLIMm6JBNJJqampg66cEnS/g0c7kleDdwKXFZVzwHXAm8E1gA7gU9NT+3z9NpnoGp9VY1X1fjY2NhBFy5J2r+Bwj3JEfSC/caqug2gqp6qqj1V9SvgM/y69TIJrJzx9BXAjoUrWZI0m0GOlglwPbC1qq6eMb5sxrT3A49025uA85O8IskJwGrg/oUrWZI0m0GOljkN+ADwcJIHu7ErgAuSrKHXctkOfAigqrYk2Qg8Su9Im4s9UkaSFtes4V5V36R/H/3OAzznSuDKedQlSZoHz1CVpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1aNZwT7IyyT1JtibZkuTSbvx1Se5K8lh3f0w3niSfTrItyUNJTh72NyFJerFBVu67gQ9X1ZuBU4GLk5wIXA7cXVWrgbu7fYCzgNXdbR1w7YJXLUk6oFnDvap2VtUD3fbzwFZgObAW2NBN2wCc222vBT5XPfcCRydZtuCVS5L266B67klWAScB9wHHV9VO6P0CAI7rpi0HnpzxtMlubO+vtS7JRJKJqampg69ckrRfA4d7klcDtwKXVdVzB5raZ6z2GahaX1XjVTU+NjY2aBmSpAEMFO5JjqAX7DdW1W3d8FPT7Zbuflc3PgmsnPH0FcCOhSlXkjSIw2ebkCTA9cDWqrp6xkObgAuBq7r7O2aMX5LkZuDtwLPT7RtJ/a26/EsHfHz7VecsUiVqxazhDpwGfAB4OMmD3dgV9EJ9Y5KLgCeA87rH7gTOBrYBPwM+uKAVS5JmNWu4V9U36d9HBzijz/wCLp5nXZKkeRhk5S69pNky0aHIcJf0An+RtcNry0hSg1y5SxrYbCt7cHW/VBju0iFgkFCVZrItI0kNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CCvCilpQfmBH0uDK3dJapDhLkkNMtwlqUH23KVF4CcpabG5cpekBs26ck9yA/BeYFdVvbUb+xjw58BUN+2Kqrqze+wjwEXAHuCvquorQ6hbWjJclWspGmTl/lngzD7j11TVmu42HewnAucDb+me809JDluoYiVJg5k13KvqG8DTA369tcDNVfXzqvoBsA04ZR71SZLmYD4990uSPJTkhiTHdGPLgSdnzJnsxvaRZF2SiSQTU1NT/aZIkuZoruF+LfBGYA2wE/hUN54+c6vfF6iq9VU1XlXjY2NjcyxDktTPnMK9qp6qqj1V9SvgM/y69TIJrJwxdQWwY34lSpIO1pyOc0+yrKp2drvvBx7ptjcBn09yNfAGYDVw/7yrlNSMQY4u8voz8zfIoZA3Ae8Ajk0yCXwUeEeSNfRaLtuBDwFU1ZYkG4FHgd3AxVW1ZzilS5L2Z9Zwr6oL+gxff4D5VwJXzqcoSdL8eIaqJDXIcJekBhnuktQgw12SGmS4S1KDDHdJapAf1iHpkOOJULNz5S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIa8tIWnIGuXaMDsyVuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSg2YN9yQ3JNmV5JEZY69LcleSx7r7Y7rxJPl0km1JHkpy8jCLlyT1N8jK/bPAmXuNXQ7cXVWrgbu7fYCzgNXdbR1w7cKUKUk6GLOGe1V9A3h6r+G1wIZuewNw7ozxz1XPvcDRSZYtVLGSpMHMted+fFXtBOjuj+vGlwNPzpg32Y3tI8m6JBNJJqampuZYhiSpn4V+QzV9xqrfxKpaX1XjVTU+Nja2wGVI0kvbXMP9qel2S3e/qxufBFbOmLcC2DH38iRJczHXcN8EXNhtXwjcMWP8z7qjZk4Fnp1u30iSFs+sFw5LchPwDuDYJJPAR4GrgI1JLgKeAM7rpt8JnA1sA34GfHAINUuSZjFruFfVBft56Iw+cwu4eL5FSZLmxzNUJalBhrskNcgP69BLmh8KoVYZ7mqa4a2XKsNdhyyDW9o/e+6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAb5YR1asvwwDmnuXLlLUoMMd0lq0LzaMkm2A88De4DdVTWe5HXAF4BVwHbgT6rqmfmVKUkHZ7a23varzlmkSkZjIVbuf1BVa6pqvNu/HLi7qlYDd3f7kqRFNIy2zFpgQ7e9ATh3CK8hSTqA+YZ7AV9NsjnJum7s+KraCdDdH9fviUnWJZlIMjE1NTXPMiRJM833UMjTqmpHkuOAu5J8d9AnVtV6YD3A+Ph4zbMOSdIM8wr3qtrR3e9KcjtwCvBUkmVVtTPJMmDXAtSpxngMuzRcc27LJDkqyWumt4H3AI8Am4ALu2kXAnfMt0hJ0sGZz8r9eOD2JNNf5/NV9eUk3wI2JrkIeAI4b/5lSpIOxpzDvaoeB97WZ/y/gTPmU5QkaX48Q1WSGuSFwzQUvmEqjZbhLuklqfXLE9iWkaQGGe6S1CDDXZIaZM/9Jaj1XqMkV+6S1CTDXZIaZLhLUoMMd0lqkG+o6qB59qm09Llyl6QGGe6S1CDbMo2xZSIJDHf14S8I6dBnuEtSH4Mscpby2dz23CWpQa7cl5BDfaUgvdQs5es0Ge6LyF62pMViW0aSGmS4S1KDbMsMaKm0VJZKHZKWNlfuktSgoa3ck5wJ/ANwGHBdVV01rNeSpKVolEfADSXckxwG/CPwbmAS+FaSTVX16EK/lm0KSdrXsNoypwDbqurxqvoFcDOwdkivJUnay7DaMsuBJ2fsTwJvnzkhyTpgXbf70yTfG1It83Us8ONRF7Ef1jY31jY31jY3B6wtn5jX1/6t/T0wrHBPn7F60U7VemD9kF5/wSSZqKrxUdfRj7XNjbXNjbXNzahqG1ZbZhJYOWN/BbBjSK8lSdrLsML9W8DqJCckeTlwPrBpSK8lSdrLUNoyVbU7ySXAV+gdCnlDVW0ZxmstgqXcOrK2ubG2ubG2uRlJbamq2WdJkg4pnqEqSQ0y3CWpQYZ7H0lWJrknydYkW5JcOuqapiV5ZZL7k3ynq+3jo65pb0kOS/LtJF8cdS17S7I9ycNJHkwyMep6piU5OsktSb7b/bv7vVHXNC3Jm7qf1/TtuSSXjbougCR/3f0/eCTJTUleOeqapiW5tKtryyh+Xvbc+0iyDFhWVQ8keQ2wGTh3GJdPOFhJAhxVVT9NcgTwTeDSqrp3xKW9IMnfAOPAa6vqvaOuZ6Yk24HxqlpSJ7wk2QD8Z1Vd1x1hdmRV/WTUde2tu7TIj4C3V9UPR1zLcnr//k+sqv9NshG4s6o+O8q6AJK8ld6Z+acAvwC+DPxFVT22WDW4cu+jqnZW1QPd9vPAVnpn3Y5c9fy02z2iuy2Z39BJVgDnANeNupZDRZLXAqcD1wNU1S+WYrB3zgC+P+pgn+Fw4FVJDgeOZOmcT/Nm4N6q+llV7Qb+A3j/YhZguM8iySrgJOC+0Vbya13b40FgF3BXVS2Z2oC/B/4W+NWoC9mPAr6aZHN3CYyl4LeBKeCfu3bWdUmOGnVR+3E+cNOoiwCoqh8BnwSeAHYCz1bVV0db1QseAU5P8vokRwJn8+ITO4fOcD+AJK8GbgUuq6rnRl3PtKraU1Vr6J35e0r3J+DIJXkvsKuqNo+6lgM4rapOBs4CLk5y+qgLorf6PBm4tqpOAv4HuHy0Je2raxe9D/i3UdcCkOQYehckPAF4A3BUkj8dbVU9VbUV+ARwF72WzHeA3YtZg+G+H10/+1bgxqq6bdT19NP96f514MwRlzLtNOB9XV/7ZuCdSf51tCW9WFXt6O53AbfT64mO2iQwOeMvsFvohf1ScxbwQFU9NepCOu8CflBVU1X1S+A24PdHXNMLqur6qjq5qk4HngYWrd8Ohntf3ZuW1wNbq+rqUdczU5KxJEd326+i9w/8u6OtqqeqPlJVK6pqFb0/379WVUtiJQWQ5KjuDXK6tsd76P35PFJV9V/Ak0ne1A2dAYz8zfs+LmCJtGQ6TwCnJjmy+z97Br33x5aEJMd1978J/BGL/LPzM1T7Ow34APBw19sGuKKq7hxhTdOWARu6oxZeBmysqiV3yOESdTxwey8HOBz4fFV9ebQlveAvgRu71sfjwAdHXM+LdH3jdwMfGnUt06rqviS3AA/Qa3l8m6V1GYJbk7we+CVwcVU9s5gv7qGQktQg2zKS1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXo/wEZioAfGKaK4wAAAABJRU5ErkJggg==",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "tags": [],
+            "needs_background": "light"
+          }
+        }
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
         "id": "ZRD_UKiD_G_N",
         "outputId": "f664ee31-d2de-46c2-d30c-89b58992a785"
-      },
-      "source": [
-        "_ = plt.hist(movies['IMDB_Rating'], bins='auto')"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD4CAYAAAAXUaZHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAQfklEQVR4nO3dfYylZXnH8e9PwBdQC8pA1t1tl9qtEU1cyARpSYgVtbwYF5vSQFJLDOmaBlpoTRrkHzUpCSYKrUlLsgJ1bRHc8hI2SlSKWOsfgLOIwLIaVlxh3C07FgSsrbrr1T/OMzjsnt05OzNnzuzN95OcnOe5z33mXDPZ/c0913me56SqkCS15WWjLkCStPAMd0lqkOEuSQ0y3CWpQYa7JDXo8FEXAHDsscfWqlWrRl2GJB1SNm/e/OOqGuv32JII91WrVjExMTHqMiTpkJLkh/t7zLaMJDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1aEmcoSpp+FZd/qVZ52y/6pxFqESLwZW7JDXIcJekBhnuktQgw12SGmS4S1KDZg33JK9Mcn+S7yTZkuTj3fgJSe5L8liSLyR5eTf+im5/W/f4quF+C5KkvQ2ycv858M6qehuwBjgzyanAJ4Brqmo18AxwUTf/IuCZqvod4JpuniRpEc0a7tXz0273iO5WwDuBW7rxDcC53fbabp/u8TOSZMEqliTNaqCee5LDkjwI7ALuAr4P/KSqdndTJoHl3fZy4EmA7vFngdf3+ZrrkkwkmZiamprfdyFJepGBwr2q9lTVGmAFcArw5n7Tuvt+q/TaZ6BqfVWNV9X42Fjfz3eVJM3RQR0tU1U/Ab4OnAocnWT68gUrgB3d9iSwEqB7/DeApxeiWEnSYAY5WmYsydHd9quAdwFbgXuAP+6mXQjc0W1v6vbpHv9aVe2zcpckDc8gFw5bBmxIchi9XwYbq+qLSR4Fbk7yd8C3geu7+dcD/5JkG70V+/lDqFuSdACzhntVPQSc1Gf8cXr9973H/w84b0GqkyTNiWeoSlKDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGjRruCdZmeSeJFuTbElyaTf+sSQ/SvJgdzt7xnM+kmRbku8l+cNhfgOSpH0dPsCc3cCHq+qBJK8BNie5q3vsmqr65MzJSU4EzgfeArwB+Pckv1tVexaycEnS/s26cq+qnVX1QLf9PLAVWH6Ap6wFbq6qn1fVD4BtwCkLUawkaTAH1XNPsgo4CbivG7okyUNJbkhyTDe2HHhyxtMm6fPLIMm6JBNJJqampg66cEnS/g0c7kleDdwKXFZVzwHXAm8E1gA7gU9NT+3z9NpnoGp9VY1X1fjY2NhBFy5J2r+Bwj3JEfSC/caqug2gqp6qqj1V9SvgM/y69TIJrJzx9BXAjoUrWZI0m0GOlglwPbC1qq6eMb5sxrT3A49025uA85O8IskJwGrg/oUrWZI0m0GOljkN+ADwcJIHu7ErgAuSrKHXctkOfAigqrYk2Qg8Su9Im4s9UkaSFtes4V5V36R/H/3OAzznSuDKedQlSZoHz1CVpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1aNZwT7IyyT1JtibZkuTSbvx1Se5K8lh3f0w3niSfTrItyUNJTh72NyFJerFBVu67gQ9X1ZuBU4GLk5wIXA7cXVWrgbu7fYCzgNXdbR1w7YJXLUk6oFnDvap2VtUD3fbzwFZgObAW2NBN2wCc222vBT5XPfcCRydZtuCVS5L266B67klWAScB9wHHV9VO6P0CAI7rpi0HnpzxtMlubO+vtS7JRJKJqampg69ckrRfA4d7klcDtwKXVdVzB5raZ6z2GahaX1XjVTU+NjY2aBmSpAEMFO5JjqAX7DdW1W3d8FPT7Zbuflc3PgmsnPH0FcCOhSlXkjSIw2ebkCTA9cDWqrp6xkObgAuBq7r7O2aMX5LkZuDtwLPT7RtJ/a26/EsHfHz7VecsUiVqxazhDpwGfAB4OMmD3dgV9EJ9Y5KLgCeA87rH7gTOBrYBPwM+uKAVS5JmNWu4V9U36d9HBzijz/wCLp5nXZKkeRhk5S69pNky0aHIcJf0An+RtcNry0hSg1y5SxrYbCt7cHW/VBju0iFgkFCVZrItI0kNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CCvCilpQfmBH0uDK3dJapDhLkkNMtwlqUH23KVF4CcpabG5cpekBs26ck9yA/BeYFdVvbUb+xjw58BUN+2Kqrqze+wjwEXAHuCvquorQ6hbWjJclWspGmTl/lngzD7j11TVmu42HewnAucDb+me809JDluoYiVJg5k13KvqG8DTA369tcDNVfXzqvoBsA04ZR71SZLmYD4990uSPJTkhiTHdGPLgSdnzJnsxvaRZF2SiSQTU1NT/aZIkuZoruF+LfBGYA2wE/hUN54+c6vfF6iq9VU1XlXjY2NjcyxDktTPnMK9qp6qqj1V9SvgM/y69TIJrJwxdQWwY34lSpIO1pyOc0+yrKp2drvvBx7ptjcBn09yNfAGYDVw/7yrlNSMQY4u8voz8zfIoZA3Ae8Ajk0yCXwUeEeSNfRaLtuBDwFU1ZYkG4FHgd3AxVW1ZzilS5L2Z9Zwr6oL+gxff4D5VwJXzqcoSdL8eIaqJDXIcJekBhnuktQgw12SGmS4S1KDDHdJapAf1iHpkOOJULNz5S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIa8tIWnIGuXaMDsyVuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSg2YN9yQ3JNmV5JEZY69LcleSx7r7Y7rxJPl0km1JHkpy8jCLlyT1N8jK/bPAmXuNXQ7cXVWrgbu7fYCzgNXdbR1w7cKUKUk6GLOGe1V9A3h6r+G1wIZuewNw7ozxz1XPvcDRSZYtVLGSpMHMted+fFXtBOjuj+vGlwNPzpg32Y3tI8m6JBNJJqampuZYhiSpn4V+QzV9xqrfxKpaX1XjVTU+Nja2wGVI0kvbXMP9qel2S3e/qxufBFbOmLcC2DH38iRJczHXcN8EXNhtXwjcMWP8z7qjZk4Fnp1u30iSFs+sFw5LchPwDuDYJJPAR4GrgI1JLgKeAM7rpt8JnA1sA34GfHAINUuSZjFruFfVBft56Iw+cwu4eL5FSZLmxzNUJalBhrskNcgP69BLmh8KoVYZ7mqa4a2XKsNdhyyDW9o/e+6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAb5YR1asvwwDmnuXLlLUoMMd0lq0LzaMkm2A88De4DdVTWe5HXAF4BVwHbgT6rqmfmVKUkHZ7a23varzlmkSkZjIVbuf1BVa6pqvNu/HLi7qlYDd3f7kqRFNIy2zFpgQ7e9ATh3CK8hSTqA+YZ7AV9NsjnJum7s+KraCdDdH9fviUnWJZlIMjE1NTXPMiRJM833UMjTqmpHkuOAu5J8d9AnVtV6YD3A+Ph4zbMOSdIM8wr3qtrR3e9KcjtwCvBUkmVVtTPJMmDXAtSpxngMuzRcc27LJDkqyWumt4H3AI8Am4ALu2kXAnfMt0hJ0sGZz8r9eOD2JNNf5/NV9eUk3wI2JrkIeAI4b/5lSpIOxpzDvaoeB97WZ/y/gTPmU5QkaX48Q1WSGuSFwzQUvmEqjZbhLuklqfXLE9iWkaQGGe6S1CDDXZIaZM/9Jaj1XqMkV+6S1CTDXZIaZLhLUoMMd0lqkG+o6qB59qm09Llyl6QGGe6S1CDbMo2xZSIJDHf14S8I6dBnuEtSH4Mscpby2dz23CWpQa7cl5BDfaUgvdQs5es0Ge6LyF62pMViW0aSGmS4S1KDbMsMaKm0VJZKHZKWNlfuktSgoa3ck5wJ/ANwGHBdVV01rNeSpKVolEfADSXckxwG/CPwbmAS+FaSTVX16EK/lm0KSdrXsNoypwDbqurxqvoFcDOwdkivJUnay7DaMsuBJ2fsTwJvnzkhyTpgXbf70yTfG1It83Us8ONRF7Ef1jY31jY31jY3B6wtn5jX1/6t/T0wrHBPn7F60U7VemD9kF5/wSSZqKrxUdfRj7XNjbXNjbXNzahqG1ZbZhJYOWN/BbBjSK8lSdrLsML9W8DqJCckeTlwPrBpSK8lSdrLUNoyVbU7ySXAV+gdCnlDVW0ZxmstgqXcOrK2ubG2ubG2uRlJbamq2WdJkg4pnqEqSQ0y3CWpQYZ7H0lWJrknydYkW5JcOuqapiV5ZZL7k3ynq+3jo65pb0kOS/LtJF8cdS17S7I9ycNJHkwyMep6piU5OsktSb7b/bv7vVHXNC3Jm7qf1/TtuSSXjbougCR/3f0/eCTJTUleOeqapiW5tKtryyh+Xvbc+0iyDFhWVQ8keQ2wGTh3GJdPOFhJAhxVVT9NcgTwTeDSqrp3xKW9IMnfAOPAa6vqvaOuZ6Yk24HxqlpSJ7wk2QD8Z1Vd1x1hdmRV/WTUde2tu7TIj4C3V9UPR1zLcnr//k+sqv9NshG4s6o+O8q6AJK8ld6Z+acAvwC+DPxFVT22WDW4cu+jqnZW1QPd9vPAVnpn3Y5c9fy02z2iuy2Z39BJVgDnANeNupZDRZLXAqcD1wNU1S+WYrB3zgC+P+pgn+Fw4FVJDgeOZOmcT/Nm4N6q+llV7Qb+A3j/YhZguM8iySrgJOC+0Vbya13b40FgF3BXVS2Z2oC/B/4W+NWoC9mPAr6aZHN3CYyl4LeBKeCfu3bWdUmOGnVR+3E+cNOoiwCoqh8BnwSeAHYCz1bVV0db1QseAU5P8vokRwJn8+ITO4fOcD+AJK8GbgUuq6rnRl3PtKraU1Vr6J35e0r3J+DIJXkvsKuqNo+6lgM4rapOBs4CLk5y+qgLorf6PBm4tqpOAv4HuHy0Je2raxe9D/i3UdcCkOQYehckPAF4A3BUkj8dbVU9VbUV+ARwF72WzHeA3YtZg+G+H10/+1bgxqq6bdT19NP96f514MwRlzLtNOB9XV/7ZuCdSf51tCW9WFXt6O53AbfT64mO2iQwOeMvsFvohf1ScxbwQFU9NepCOu8CflBVU1X1S+A24PdHXNMLqur6qjq5qk4HngYWrd8Ohntf3ZuW1wNbq+rqUdczU5KxJEd326+i9w/8u6OtqqeqPlJVK6pqFb0/379WVUtiJQWQ5KjuDXK6tsd76P35PFJV9V/Ak0ne1A2dAYz8zfs+LmCJtGQ6TwCnJjmy+z97Br33x5aEJMd1978J/BGL/LPzM1T7Ow34APBw19sGuKKq7hxhTdOWARu6oxZeBmysqiV3yOESdTxwey8HOBz4fFV9ebQlveAvgRu71sfjwAdHXM+LdH3jdwMfGnUt06rqviS3AA/Qa3l8m6V1GYJbk7we+CVwcVU9s5gv7qGQktQg2zKS1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXo/wEZioAfGKaK4wAAAABJRU5ErkJggg==\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": [],
-            "needs_background": "light"
-          }
-        }
-      ]
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "GwPlFvHn_G_N"
-      },
       "source": [
         "## Consequences of the binning parameter\n",
         "\n",
         "Let's explore the effect of bin size using small multiples. In `matplotlib`, you can use [subplot](https://www.google.com/search?client=safari&rls=en&q=matplotlib+subplot&ie=UTF-8&oe=UTF-8) to put multiple plots into a single figure. \n",
         "\n",
         "For instance, you can do something like:"
-      ]
+      ],
+      "metadata": {
+        "id": "GwPlFvHn_G_N"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "jupyter": {
-          "outputs_hidden": false
-        },
-        "id": "hDnPdqBU_G_N",
-        "outputId": "e20b169b-58e0-4bc3-96dd-7bceced52569"
-      },
+      "execution_count": null,
       "source": [
         "plt.figure(figsize=(10,5))\n",
         "plt.subplot(1,2,1)\n",
@@ -1247,7 +1242,6 @@
         "plt.subplot(1,2,2)\n",
         "movies['IMDB_Rating'].hist(bins=20)"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1264,7 +1258,7 @@
         {
           "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAlwAAAEvCAYAAACQQh9CAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nO3df5BlZX3n8fdnGUXURFC0dzIztUPWSaJxSqW6kISqVC8kyg9LSJWmsFgFQtUkVZhgnGwczFaRxFiFFRF/bJbaiRBhlxVZ1GJKScwEuGVZtaCCyICjxSzOQssouvzQllW3zXf/uM9IM/TM9HT3ubf73ver6laf85znnPN9uD2Hbz/nnOdJVSFJkqTu/KthByBJkjTqTLgkSZI6ZsIlSZLUMRMuSZKkjplwSZIkdcyES5IkqWNrhh3AoRx//PG1cePGgZ/3Rz/6ES94wQsGft5hsK2jaTW39a677vp+Vb102HEsh2Fcw1bzd3+kbOtoWs1tPdT1a0UnXBs3buQrX/nKwM/b6/WYmpoa+HmHwbaOptXc1iT/e9gxLJdhXMNW83d/pGzraFrNbT3U9ctbipIkSR0z4ZIkSeqYCZckSVLHTLgkSZI6ZsIlSZLUMRMuSZKkjplwSRprSY5K8tUkn23rJyS5M8kDST6Z5Lmt/Oi2vqdt3zjMuCWtLiZcksbdJcDuOevvB66sqk3A48BFrfwi4PGqejlwZasnSQtiwiVpbCVZD5wFfKytBzgVuKlVuRY4py2f3dZp209r9SXpsEy4JI2zDwF/BvxLW38J8ERVzbb1aWBdW14HPAzQtj/Z6kvSYa3oqX0kqStJ3gg8WlV3JZnaXzxP1VrAtrnH3QJsAZiYmKDX6y092CMwMzMz8HMOi20dTaPaVhOuMbfr209ywbbPDTuMgdi6eXZZ2rr38rOWIRqtAKcAb0pyJvA84Bfp93gdm2RN68VaDzzS6k8DG4DpJGuAFwGPHXjQqtoObAeYnJysQc8Jt5rnoTtStvXwNh7hNW8lXN9G9Xv1lqKksVRVl1bV+qraCJwL3FZV5wG3A29u1c4Hbm7LO9o6bfttVfWsHi5Jmo8JlyQ907uBdyXZQ/8Zratb+dXAS1r5u4BtQ4pP0irkLUVJY6+qekCvLT8InDRPnR8DbxloYJJGhj1ckiRJHTPhkiRJ6pgJlyRJUsdMuCRJkjpmwiVJktSxw76lmOQaYP+IzK86YNufAn8DvLSqvt/mFfswcCbwFHBBVd3d6p4P/Me2619X1bVIkqQjcqSDmWplWEgP18eB0w8sTLIB+B3goTnFZwCb2mcLcFWr+2LgMuB19F+3vizJcUsJXJIkabU4bMJVVV9gnukrgCvpT/o6d6Tls4Hrqu8O+lNkrAXeAOysqseq6nFgJ/MkcZIkSaNoUQOfJnkT8O2q+lr/LuLPrQMenrM+3coOVj7fsYc68SuM7sSZ85k4pj/H4DhYrrauht+NcfodlqTV4IgTriTPB/4ceP18m+cpq0OUP7twyBO/wuhOnDmfj15/M1fsGo8JB7Zunl2Wtu49b2rpwXRsnH6HJWk1WMxbiv8WOAH4WpK9wHrg7iT/mn7P1YY5ddcDjxyiXJIkaeQdccJVVbuq6mVVtbGqNtJPpk6squ8AO4C3p+9k4Mmq2gd8Hnh9kuPaw/Kvb2WSJEkjbyHDQnwCmAKOTzINXFZVVx+k+i30h4TYQ39YiAsBquqxJO8Fvtzq/VVVzfcgviRJGpIjGXJi7+VndRjJ6DlswlVVbz3M9o1zlgu4+CD1rgGuOcL4JEmSVr3xeFpaWkarYdDBrZtnuWAFxelfwpLGnVP7SJIkdcyES5IkqWMmXJIkSR0z4ZIkSeqYCZckSVLHTLgkSZI6ZsIlSZLUMRMuSZKkjplwSZIkdcyES9JYSvK8JF9K8rUk9yf5y1b+8STfSnJP+7ymlSfJR5LsSXJvkhOH2wJJq4lT+0gaVz8BTq2qmSTPAb6Y5B/atv9QVTcdUP8MYFP7vA64qv2UpMOyh0vSWKq+mbb6nPapQ+xyNnBd2+8O4Ngka7uOU9JoMOGSNLaSHJXkHuBRYGdV3dk2va/dNrwyydGtbB3w8Jzdp1uZJB2WtxQlja2q+hnwmiTHAp9J8irgUuA7wHOB7cC7gb8CMt8hDixIsgXYAjAxMUGv1+sm+IOYmZkZ+DmHZVzbunXz7HCDabr6bz+q36sJl6SxV1VPJOkBp1fVB1rxT5L8PfCnbX0a2DBnt/XAI/Mcazv9RI3JycmamprqKux59Xo9Bn3OYRnXtl6w7XPDDabZe95UJ8cd1e/VW4qSxlKSl7aeLZIcA/w28I39z2UlCXAOcF/bZQfw9va24snAk1W1bwihS1qF7OGSNK7WAtcmOYr+H583VtVnk9yW5KX0byHeA/xhq38LcCawB3gKuHAIMUtapUy4JI2lqroXeO085acepH4BF3cdl6TR5C1FSZKkjplwSZIkdcyES5IkqWMmXJIkSR0z4ZIkSeqYCZckSVLHTLgkSZI6dtiEK8k1SR5Nct+csr9J8o02uetn9o/W3LZdmmRPkm8mecOc8tNb2Z4k25a/KZIkSSvTQgY+/Tjwn4Dr5pTtBC6tqtkk76c/2eu7k7wSOBf4deCXgH9O8ittn78Ffof+fGRfTrKjqr6+PM2QJGl12riAuRG3bp5dMXMoanEO28NVVV8AHjug7J+qav905XfQn8QV4Gzghqr6SVV9i/4UGCe1z56qerCqfgrc0OpKkiSNvOV4huv3gX9oy+uAh+dsm25lByuXJEkaeUuaSzHJnwOzwPX7i+apVsyf2NVBjrkF2AIwMTFBr9dbSoiLMjMzM5TzDsPEMf2u6nFgW4dnXP49SdLBLDrhSnI+8EbgtDapK/R7rjbMqbYeeKQtH6z8GapqO7AdYHJysqamphYb4qL1ej2Gcd5h+Oj1N3PFrvGYw3zr5lnbOiR7z5sadgiSNFSLuqWY5HTg3cCbquqpOZt2AOcmOTrJCcAm4EvAl4FNSU5I8lz6D9bvWFrokiRJq8Nh/wRO8glgCjg+yTRwGf23Eo8GdiYBuKOq/rCq7k9yI/B1+rcaL66qn7XjvAP4PHAUcE1V3d9BeyRJklacwyZcVfXWeYqvPkT99wHvm6f8FuCWI4pOkiRpBDjSvCRJUsdMuCRJkjpmwiVJktQxEy5JkqSOmXBJkiR1bOWMjChJklaNhUy6Pdfey8/qKJLVwR4uSZKkjplwSRpLSZ6X5EtJvpbk/iR/2cpPSHJnkgeSfLLNjkGbQeOTSfa07RuHGb+k1cWES9K4+glwalW9GngNcHqSk4H3A1dW1SbgceCiVv8i4PGqejlwZasnSQtiwiVpLFXfTFt9TvsUcCpwUyu/FjinLZ/d1mnbT0ub20ySDseES9LYSnJUknuAR4GdwP8Cnqiq2VZlGljXltcBDwO07U8CLxlsxJJWK99SlDS2qupnwGuSHAt8BnjFfNXaz/l6s+rAgiRbgC0AExMT9Hq95Ql2gWZmZgZ+zmEZlbZu3Tx72DoTxyys3kq20O9qVL7XA5lwSRp7VfVEkh5wMnBskjWtF2s98EirNg1sAKaTrAFeBDw2z7G2A9sBJicna2pqqvsGzNHr9Rj0OYdlVNp6wQKGV9i6eZYrdq3u/2XvPW9qQfVG5Xs9kLcUJY2lJC9tPVskOQb4bWA3cDvw5lbtfODmtryjrdO231ZVz+rhkqT5rO50WZIWby1wbZKj6P/xeWNVfTbJ14Ebkvw18FXg6lb/auC/JtlDv2fr3GEELWl1MuGSNJaq6l7gtfOUPwicNE/5j4G3DCA0SSPIW4qSJEkdM+GSJEnqmAmXJElSx0y4JEmSOmbCJUmS1DETLkmSpI6ZcEmSJHXMhEuSJKljJlySJEkdM+GSJEnq2GETriTXJHk0yX1zyl6cZGeSB9rP41p5knwkyZ4k9yY5cc4+57f6DyQ5f75zSZIkjaKF9HB9HDj9gLJtwK1VtQm4ta0DnAFsap8twFXQT9CAy4DX0Z+j7LL9SZokSdKoO2zCVVVfAB47oPhs4Nq2fC1wzpzy66rvDuDYJGuBNwA7q+qxqnoc2MmzkzhJkqSRtNhnuCaqah9A+/myVr4OeHhOvelWdrBySZKkkbdmmY+XecrqEOXPPkCyhf7tSCYmJuj1essW3ELNzMwM5bzDMHEMbN08O+wwBsK2Ds+4/HuSpINZbML13SRrq2pfu2X4aCufBjbMqbceeKSVTx1Q3pvvwFW1HdgOMDk5WVNTU/NV61Sv12MY5x2Gj15/M1fsWu68e2XaunnWtg7J3vOmhh2CNFAbt31u2CFohVnsLcUdwP43Dc8Hbp5T/vb2tuLJwJPtluPngdcnOa49LP/6ViZJkjTyDvsncJJP0O+dOj7JNP23DS8HbkxyEfAQ8JZW/RbgTGAP8BRwIUBVPZbkvcCXW72/qqoDH8SXJEkaSYdNuKrqrQfZdNo8dQu4+CDHuQa45oiikyRJGgGONC9JktQxEy5JkqSOmXBJkiR1zIRLkiSpYyZckiRJHTPhkjSWkmxIcnuS3UnuT3JJK/+LJN9Ock/7nDlnn0uT7EnyzSRvGF70klablTMUtSQN1iywtaruTvILwF1JdrZtV1bVB+ZWTvJK4Fzg14FfAv45ya9U1c8GGrWkVckeLkljqar2VdXdbfmHwG5g3SF2ORu4oap+UlXfoj/A80ndRyppFJhwSRp7STYCrwXubEXvSHJvkmvadGTQT8YenrPbNIdO0CTp57ylKGmsJXkh8CngnVX1gyRXAe8Fqv28Avh9IPPsXvMcbwuwBWBiYoJer9dR5PObmZkZ+DmHZSW3devm2WU93sQxy3/MQVvod7WSv9elMOGSNLaSPId+snV9VX0aoKq+O2f73wGfbavTwIY5u68HHjnwmFW1HdgOMDk5WVNTU53EfjC9Xo9Bn3NYVnJbL9j2uWU93tbNs1yxa3X/L3vveVMLqreSv9el8JaipLGUJMDVwO6q+uCc8rVzqv0ucF9b3gGcm+ToJCcAm4AvDSpeSavb6k6XJWnxTgHeBuxKck8rew/w1iSvoX+7cC/wBwBVdX+SG4Gv03/D8WLfUJS0UCZcksZSVX2R+Z/LuuUQ+7wPeF9nQUkaWd5SlCRJ6pgJlyRJUsdMuCRJkjpmwiVJktQxEy5JkqSOmXBJkiR1zIRLkiSpYyZckiRJHTPhkiRJ6pgJlyRJUsdMuCRJkjpmwiVJktSxJSVcSf4kyf1J7kvyiSTPS3JCkjuTPJDkk0me2+oe3db3tO0bl6MBkiRJK92iE64k64A/Biar6lXAUcC5wPuBK6tqE/A4cFHb5SLg8ap6OXBlqydJkjTylnpLcQ1wTJI1wPOBfcCpwE1t+7XAOW357LZO235akizx/JIkSSveohOuqvo28AHgIfqJ1pPAXcATVTXbqk0D69ryOuDhtu9sq/+SxZ5fkiRptViz2B2THEe/1+oE4AngfwBnzFO19u9yiG1zj7sF2AIwMTFBr9dbbIiLNjMzM5TzDsPEMbB18+zhK44A2zo84/LvSZIOZtEJF/DbwLeq6nsAST4N/CZwbJI1rRdrPfBIqz8NbACm2y3IFwGPHXjQqtoObAeYnJysqampJYS4OL1ej2Gcdxg+ev3NXLFrKb8Gq8fWzbO2dUj2njc17BAkaaiWckV+CDg5yfOB/wucBnwFuB14M3ADcD5wc6u/o63/z7b9tqp6Vg+XJEkaPRu3fW5B9bZunmWq21CGYinPcN1J/+H3u4Fd7VjbgXcD70qyh/4zWle3Xa4GXtLK3wVsW0LckiRJq8aS7jlU1WXAZQcUPwicNE/dHwNvWcr5JEmSViNHmpckSeqYCZckSVLHTLgkjaUkG5LcnmR3m6Lsklb+4iQ72/RkO9sQOKTvI216snuTnDjcFkhaTUy4JI2rWWBrVb0COBm4OMkr6b/Qc2ubnuxWnn7B5wxgU/tsAa4afMiSVisTLkljqar2VdXdbfmHwG76M2LMnYbswOnJrqu+O+iPObh2wGFLWqVMuCSNvSQbgdcCdwITVbUP+kkZ8LJW7efTkzVzpy6TpENaOUNRS9IQJHkh8CngnVX1g2S+Wcj6VecpW3HTk43T1GQrua3LPbXWSpuuq0sTx4zmdGAmXJLGVpLn0E+2rq+qT7fi7yZZW1X72i3DR1v5/unJ9ps7ddnPDXt6snGammwlt/WCBY6qvlArbbquLm3dPMvvrdDvdSm8pShpLKXflXU1sLuqPjhn0/5pyODZ05O9vb2teDLw5P5bj5J0OOORLkvSs50CvA3YleSeVvYe4HLgxiQX0Z8zdv8MGbcAZwJ7gKeACwcbrqTVzIRL0liqqi8y/3NZAKfNU7+AizsNStLI8paiJElSx0y4JEmSOmbCJUmS1DETLkmSpI6ZcEmSJHXMhEuSJKljJlySJEkdM+GSJEnqmAmXJElSx0y4JEmSOmbCJUmS1DETLkmSpI6ZcEmSJHXMhEuSJKljJlySJEkdW1LCleTYJDcl+UaS3Ul+I8mLk+xM8kD7eVyrmyQfSbInyb1JTlyeJkiSJK1sS+3h+jDwj1X1a8Crgd3ANuDWqtoE3NrWAc4ANrXPFuCqJZ5bkiRpVVh0wpXkF4HfAq4GqKqfVtUTwNnAta3atcA5bfls4LrquwM4NsnaRUcuSZK0SqxZwr6/DHwP+PskrwbuAi4BJqpqH0BV7UvyslZ/HfDwnP2nW9m+JcQgSdKibNz2uQXX3Xv5WR1GonGwlIRrDXAi8EdVdWeSD/P07cP5ZJ6yelalZAv9W45MTEzQ6/WWEOLizMzMDOW8wzBxDGzdPDvsMAbCtg7PuPx7kqSDWUrCNQ1MV9Wdbf0m+gnXd5Osbb1ba4FH59TfMGf/9cAjBx60qrYD2wEmJydrampqCSEuTq/XYxjnHYaPXn8zV+xayq/B6rF186xtHZK9500NOwRJGqpFP8NVVd8BHk7yq63oNODrwA7g/FZ2PnBzW94BvL29rXgy8OT+W4+SJEmjbKl/Av8RcH2S5wIPAhfST+JuTHIR8BDwllb3FuBMYA/wVKsrSZI08paUcFXVPcDkPJtOm6duARcv5XySJEmrkSPNSxpLSa5J8miS++aU/UWSbye5p33OnLPt0jZw8zeTvGE4UUtarUy4JI2rjwOnz1N+ZVW9pn1uAUjySuBc4NfbPv85yVEDi1TSqmfCJWksVdUXgMcWWP1s4Iaq+klVfYv+s6gndRacpJGzct4bl6SV4R1J3g58BdhaVY/TH6T5jjl19g/c/CzDHktwnMYRXGpbj2SsuiM9z3KPg7fSxtbr0sQxozl2nwmXJD3tKuC99Adlfi9wBfD7LHDgZhj+WILjNI7gUtt6wZGMNH+EY8kdybEXYqWNrdelrZtn+b0R/B32lqIkNVX13ar6WVX9C/B3PH3bcEEDN0vSwZhwSVLTZsfY73eB/W8w7gDOTXJ0khOATcCXBh2fpNVrPPonJekAST4BTAHHJ5kGLgOmkryG/u3CvcAfAFTV/UlupD+bxixwcVX9bBhxS1qdTLgkjaWqeus8xVcfov77gPd1F5GkUeYtRUmSpI6ZcEmSJHXMhEuSJKljJlySJEkdM+GSJEnqmAmXJElSx0y4JEmSOmbCJUmS1DEHPpUk6TA2LvNk1Bo/9nBJkiR1zIRLkiSpYyZckiRJHTPhkiRJ6pgJlyRJUsdMuCRJkjpmwiVJktQxEy5JkqSOmXBJkiR1bMkJV5Kjknw1yWfb+glJ7kzyQJJPJnluKz+6re9p2zcu9dySJEmrwXL0cF0C7J6z/n7gyqraBDwOXNTKLwIer6qXA1e2epIkSSNvSQlXkvXAWcDH2nqAU4GbWpVrgXPa8tltnbb9tFZfkiRppC118uoPAX8G/EJbfwnwRFXNtvVpYF1bXgc8DFBVs0mebPW/P/eASbYAWwAmJibo9XpLDPHIzczMDOW8wzBxDGzdPHv4iiPAtg7PuPx7krQ8jnSy8L2Xn9VRJMtn0QlXkjcCj1bVXUmm9hfPU7UWsO3pgqrtwHaAycnJmpqaOrBK53q9HsM47zB89PqbuWLXUvPu1WHr5lnbOiR7z5sadgiSNFRLuaV4CvCmJHuBG+jfSvwQcGyS/Vf69cAjbXka2ADQtr8IeGwJ55ekRUtyTZJHk9w3p+zFSXa2l352JjmulSfJR9pLP/cmOXF4kUtajRadcFXVpVW1vqo2AucCt1XVecDtwJtbtfOBm9vyjrZO235bVT2rh0uSBuTjwOkHlG0Dbm0v/dza1gHOADa1zxbgqgHFKGlEdDEO17uBdyXZQ/8Zratb+dXAS1r5u3j6QiZJA1dVX+DZvexzX+458KWf66rvDvo9+WsHE6mkUbAsD3lUVQ/oteUHgZPmqfNj4C3LcT5J6shEVe0DqKp9SV7Wyn/+0k+z/4WgfQOOT9IqtXKeqpWklWtBL/3A8N+0Hqe3rJfa1pX0Ju/hrLQ3j7u0mLauht95Ey5Jetp3k6xtvVtrgUdb+c9f+mnmvhD0DMN+03qc3rJealsvOMKhB4Zppb153KXFtHU1vAntXIqS9LS5L/cc+NLP29vbiicDT+6/9ShJCzEe6bIkHSDJJ4Ap4Pgk08BlwOXAjUkuAh7i6edObwHOBPYATwEXDjxgSauaCZeksVRVbz3IptPmqVvAxd1GJGmUeUtRkiSpYyZckiRJHTPhkiRJ6pgJlyRJUsdMuCRJkjpmwiVJktQxEy5JkqSOmXBJkiR1zIRLkiSpY440L0kaCRtX0WTUGj/2cEmSJHXMhEuSJKljJlySJEkdM+GSJEnqmAmXJElSx0y4JEmSOmbCJUmS1DETLkmSpI6ZcEmSJHXMhEuSJKljJlySJEkdW3TClWRDktuT7E5yf5JLWvmLk+xM8kD7eVwrT5KPJNmT5N4kJy5XIyRJklaypfRwzQJbq+oVwMnAxUleCWwDbq2qTcCtbR3gDGBT+2wBrlrCuSVJklaNRSdcVbWvqu5uyz8EdgPrgLOBa1u1a4Fz2vLZwHXVdwdwbJK1i45ckiRplVizHAdJshF4LXAnMFFV+6CflCV5Wau2Dnh4zm7TrWzfcsQgScslyV7gh8DPgNmqmkzyYuCTwEZgL/B7VfX4sGIcFxu3fe6g27ZunuWCQ2yXVpIlJ1xJXgh8CnhnVf0gyUGrzlNW8xxvC/1bjkxMTNDr9ZYa4hGbmZkZynmHYeKY/kVrHNjW4Vml/57+XVV9f876/sclLk+yra2/ezihSVptlpRwJXkO/WTr+qr6dCv+bpK1rXdrLfBoK58GNszZfT3wyIHHrKrtwHaAycnJmpqaWkqIi9Lr9RjGeYfho9ffzBW7lqWjc8XbunnWtg7J3vOmhh3CcjgbmGrL1wI9TLgkLdCir8jpd2VdDeyuqg/O2bQDOB+4vP28eU75O5LcALwOeHL/rUdJWmEK+KckBfyX9ofgwR6XeIZh99KPWg/9oXpqV1pPbpds66Gtht/5pfwJfArwNmBXknta2XvoJ1o3JrkIeAh4S9t2C3AmsAd4CrhwCeeWpC6dUlWPtKRqZ5JvLHTHYffSr/Qe+kM9kzW/g/9vaqX15HbJth7aauhFX/S3V1VfZP7nsgBOm6d+ARcv9nySNChV9Uj7+WiSzwAncfDHJSTpsBxpXpLmSPKCJL+wfxl4PXAfTz8uAc98XEKSDms8+iclaeEmgM+0N67XAP+9qv4xyZeZ/3EJSTosEy5JmqOqHgRePU/5/2GexyUkaSG8pShJktSxkerhOvK3X+Y3TqMXb9087AgkSRp9I5VwSZKk8XMkHS57Lz+rw0gOzluKkiRJHTPhkiRJ6pgJlyRJUsdMuCRJkjpmwiVJktQxEy5JkqSOOSyEJGnRlmv8Q2nU2cMlSZLUMRMuSZKkjplwSZIkdcxnuCRJz+BzWdLys4dLkiSpY/ZwSdKIs8dKGj57uCRJkjpmwiVJktQxEy5JkqSOmXBJkiR1zIfmJUnS2DjSl0j2Xn7WspzXHi5JkqSOmXBJkiR1bOAJV5LTk3wzyZ4k2wZ9fklaLK9fkhZroM9wJTkK+Fvgd4Bp4MtJdlTV1wcZhyQdqa6vX8s1OOnWzbNc4ECn0ooz6B6uk4A9VfVgVf0UuAE4e8AxSNJieP2StGiDTrjWAQ/PWZ9uZZK00nn9krRogx4WIvOU1TMqJFuALW11Jsk3O4/qAH8MxwPfH/R5h8G2jqaV1ta8/4iq/5uOwliqw16/YPjXsJX23XfJto6mldbW5bp+DTrhmgY2zFlfDzwyt0JVbQe2DzKoAyX5SlVNDjOGQbGto2mc2jpAh71+wfCvYeP03dvW0TSqbR30LcUvA5uSnJDkucC5wI4BxyBJi+H1S9KiDbSHq6pmk7wD+DxwFHBNVd0/yBgkaTG8fklaioFP7VNVtwC3DPq8R2iotzQHzLaOpnFq68B4/VpxbOtoGsm2pupZz3xKkiRpGTm1jyRJUsdMuJokG5LcnmR3kvuTXDLsmLqW5KgkX03y2WHH0rUkxya5Kck32nf8G8OOqStJ/qT9Dt+X5BNJnjfsmNQ9r2Gjy+vXaDDhetossLWqXgGcDFyc5JVDjqlrlwC7hx3EgHwY+Meq+jXg1Yxou5OsA/4YmKyqV9F/uPvc4UalAfEaNrq8fo0AE66mqvZV1d1t+Yf0f6FHdhTpJOuBs4CPDTuWriX5ReC3gKsBquqnVfXEcKPq1BrgmCRrgOczz1hRGj1ew0aT16/RuX6ZcM0jyUbgtcCdw42kUx8C/gz4l2EHMgC/DHwP+Pt2++FjSV4w7KC6UFXfBj4APATsA56sqn8ablQaNK9hI8Xr14gw4TpAkhcCnwLeWVU/GHY8XUjyRuDRqrpr2LEMyBrgROCqqnot8CNg23BD6kaS4+hPqHwC8EvAC5L8++FGpUHyGjZyvH6NCBOuOZI8h/6F6vqq+vSw4+nQKcCbkuwFbgBOTfLfhhtSp6aB6ara/9f+TfQvYKPot4FvVdX3qur/AZ8GfnPIMWlAvIaNJK9fI8KEq0kS+vfId1fVB4cdT5eq6tKqWl9VG+k/kHhbVY3MXxEHqqrvAA8n+dVWdBrw9SGG1KWHgJOTPL/9TnpH3foAAACPSURBVJ/GiD5gq2fyGjaa1zCvX6Nz/Rr4SPMr2CnA24BdSe5pZe9pI0tr9fsj4Po2B96DwIVDjqcTVXVnkpuAu+m/tfZVRnTUZj2L17DR5fVrBDjSvCRJUse8pShJktQxEy5JkqSOmXBJkiR1zIRLkiSpYyZckiRJHTPhkiRJ6pgJlyRJUsdMuCRJkjr2/wHBwq1/nxP6mwAAAABJRU5ErkJggg==\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAlwAAAEvCAYAAACQQh9CAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nO3df5BlZX3n8fdnGUXURFC0dzIztUPWSaJxSqW6kISqVC8kyg9LSJWmsFgFQtUkVZhgnGwczFaRxFiFFRF/bJbaiRBhlxVZ1GJKScwEuGVZtaCCyICjxSzOQssouvzQllW3zXf/uM9IM/TM9HT3ubf73ver6laf85znnPN9uD2Hbz/nnOdJVSFJkqTu/KthByBJkjTqTLgkSZI6ZsIlSZLUMRMuSZKkjplwSZIkdcyES5IkqWNrhh3AoRx//PG1cePGgZ/3Rz/6ES94wQsGft5hsK2jaTW39a677vp+Vb102HEsh2Fcw1bzd3+kbOtoWs1tPdT1a0UnXBs3buQrX/nKwM/b6/WYmpoa+HmHwbaOptXc1iT/e9gxLJdhXMNW83d/pGzraFrNbT3U9ctbipIkSR0z4ZIkSeqYCZckSVLHTLgkSZI6ZsIlSZLUMRMuSZKkjplwSRprSY5K8tUkn23rJyS5M8kDST6Z5Lmt/Oi2vqdt3zjMuCWtLiZcksbdJcDuOevvB66sqk3A48BFrfwi4PGqejlwZasnSQtiwiVpbCVZD5wFfKytBzgVuKlVuRY4py2f3dZp209r9SXpsEy4JI2zDwF/BvxLW38J8ERVzbb1aWBdW14HPAzQtj/Z6kvSYa3oqX0kqStJ3gg8WlV3JZnaXzxP1VrAtrnH3QJsAZiYmKDX6y092CMwMzMz8HMOi20dTaPaVhOuMbfr209ywbbPDTuMgdi6eXZZ2rr38rOWIRqtAKcAb0pyJvA84Bfp93gdm2RN68VaDzzS6k8DG4DpJGuAFwGPHXjQqtoObAeYnJysQc8Jt5rnoTtStvXwNh7hNW8lXN9G9Xv1lqKksVRVl1bV+qraCJwL3FZV5wG3A29u1c4Hbm7LO9o6bfttVfWsHi5Jmo8JlyQ907uBdyXZQ/8Zratb+dXAS1r5u4BtQ4pP0irkLUVJY6+qekCvLT8InDRPnR8DbxloYJJGhj1ckiRJHTPhkiRJ6pgJlyRJUsdMuCRJkjpmwiVJktSxw76lmOQaYP+IzK86YNufAn8DvLSqvt/mFfswcCbwFHBBVd3d6p4P/Me2619X1bVIkqQjcqSDmWplWEgP18eB0w8sTLIB+B3goTnFZwCb2mcLcFWr+2LgMuB19F+3vizJcUsJXJIkabU4bMJVVV9gnukrgCvpT/o6d6Tls4Hrqu8O+lNkrAXeAOysqseq6nFgJ/MkcZIkSaNoUQOfJnkT8O2q+lr/LuLPrQMenrM+3coOVj7fsYc68SuM7sSZ85k4pj/H4DhYrrauht+NcfodlqTV4IgTriTPB/4ceP18m+cpq0OUP7twyBO/wuhOnDmfj15/M1fsGo8JB7Zunl2Wtu49b2rpwXRsnH6HJWk1WMxbiv8WOAH4WpK9wHrg7iT/mn7P1YY5ddcDjxyiXJIkaeQdccJVVbuq6mVVtbGqNtJPpk6squ8AO4C3p+9k4Mmq2gd8Hnh9kuPaw/Kvb2WSJEkjbyHDQnwCmAKOTzINXFZVVx+k+i30h4TYQ39YiAsBquqxJO8Fvtzq/VVVzfcgviRJGpIjGXJi7+VndRjJ6DlswlVVbz3M9o1zlgu4+CD1rgGuOcL4JEmSVr3xeFpaWkarYdDBrZtnuWAFxelfwpLGnVP7SJIkdcyES5IkqWMmXJIkSR0z4ZIkSeqYCZckSVLHTLgkSZI6ZsIlSZLUMRMuSZKkjplwSZIkdcyES9JYSvK8JF9K8rUk9yf5y1b+8STfSnJP+7ymlSfJR5LsSXJvkhOH2wJJq4lT+0gaVz8BTq2qmSTPAb6Y5B/atv9QVTcdUP8MYFP7vA64qv2UpMOyh0vSWKq+mbb6nPapQ+xyNnBd2+8O4Ngka7uOU9JoMOGSNLaSHJXkHuBRYGdV3dk2va/dNrwyydGtbB3w8Jzdp1uZJB2WtxQlja2q+hnwmiTHAp9J8irgUuA7wHOB7cC7gb8CMt8hDixIsgXYAjAxMUGv1+sm+IOYmZkZ+DmHZVzbunXz7HCDabr6bz+q36sJl6SxV1VPJOkBp1fVB1rxT5L8PfCnbX0a2DBnt/XAI/Mcazv9RI3JycmamprqKux59Xo9Bn3OYRnXtl6w7XPDDabZe95UJ8cd1e/VW4qSxlKSl7aeLZIcA/w28I39z2UlCXAOcF/bZQfw9va24snAk1W1bwihS1qF7OGSNK7WAtcmOYr+H583VtVnk9yW5KX0byHeA/xhq38LcCawB3gKuHAIMUtapUy4JI2lqroXeO085acepH4BF3cdl6TR5C1FSZKkjplwSZIkdcyES5IkqWMmXJIkSR0z4ZIkSeqYCZckSVLHTLgkSZI6dtiEK8k1SR5Nct+csr9J8o02uetn9o/W3LZdmmRPkm8mecOc8tNb2Z4k25a/KZIkSSvTQgY+/Tjwn4Dr5pTtBC6tqtkk76c/2eu7k7wSOBf4deCXgH9O8ittn78Ffof+fGRfTrKjqr6+PM2QJGl12riAuRG3bp5dMXMoanEO28NVVV8AHjug7J+qav905XfQn8QV4Gzghqr6SVV9i/4UGCe1z56qerCqfgrc0OpKkiSNvOV4huv3gX9oy+uAh+dsm25lByuXJEkaeUuaSzHJnwOzwPX7i+apVsyf2NVBjrkF2AIwMTFBr9dbSoiLMjMzM5TzDsPEMf2u6nFgW4dnXP49SdLBLDrhSnI+8EbgtDapK/R7rjbMqbYeeKQtH6z8GapqO7AdYHJysqamphYb4qL1ej2Gcd5h+Oj1N3PFrvGYw3zr5lnbOiR7z5sadgiSNFSLuqWY5HTg3cCbquqpOZt2AOcmOTrJCcAm4EvAl4FNSU5I8lz6D9bvWFrokiRJq8Nh/wRO8glgCjg+yTRwGf23Eo8GdiYBuKOq/rCq7k9yI/B1+rcaL66qn7XjvAP4PHAUcE1V3d9BeyRJklacwyZcVfXWeYqvPkT99wHvm6f8FuCWI4pOkiRpBDjSvCRJUsdMuCRJkjpmwiVJktQxEy5JkqSOmXBJkiR1bOWMjChJklaNhUy6Pdfey8/qKJLVwR4uSZKkjplwSRpLSZ6X5EtJvpbk/iR/2cpPSHJnkgeSfLLNjkGbQeOTSfa07RuHGb+k1cWES9K4+glwalW9GngNcHqSk4H3A1dW1SbgceCiVv8i4PGqejlwZasnSQtiwiVpLFXfTFt9TvsUcCpwUyu/FjinLZ/d1mnbT0ub20ySDseES9LYSnJUknuAR4GdwP8Cnqiq2VZlGljXltcBDwO07U8CLxlsxJJWK99SlDS2qupnwGuSHAt8BnjFfNXaz/l6s+rAgiRbgC0AExMT9Hq95Ql2gWZmZgZ+zmEZlbZu3Tx72DoTxyys3kq20O9qVL7XA5lwSRp7VfVEkh5wMnBskjWtF2s98EirNg1sAKaTrAFeBDw2z7G2A9sBJicna2pqqvsGzNHr9Rj0OYdlVNp6wQKGV9i6eZYrdq3u/2XvPW9qQfVG5Xs9kLcUJY2lJC9tPVskOQb4bWA3cDvw5lbtfODmtryjrdO231ZVz+rhkqT5rO50WZIWby1wbZKj6P/xeWNVfTbJ14Ebkvw18FXg6lb/auC/JtlDv2fr3GEELWl1MuGSNJaq6l7gtfOUPwicNE/5j4G3DCA0SSPIW4qSJEkdM+GSJEnqmAmXJElSx0y4JEmSOmbCJUmS1DETLkmSpI6ZcEmSJHXMhEuSJKljJlySJEkdM+GSJEnq2GETriTXJHk0yX1zyl6cZGeSB9rP41p5knwkyZ4k9yY5cc4+57f6DyQ5f75zSZIkjaKF9HB9HDj9gLJtwK1VtQm4ta0DnAFsap8twFXQT9CAy4DX0Z+j7LL9SZokSdKoO2zCVVVfAB47oPhs4Nq2fC1wzpzy66rvDuDYJGuBNwA7q+qxqnoc2MmzkzhJkqSRtNhnuCaqah9A+/myVr4OeHhOvelWdrBySZKkkbdmmY+XecrqEOXPPkCyhf7tSCYmJuj1essW3ELNzMwM5bzDMHEMbN08O+wwBsK2Ds+4/HuSpINZbML13SRrq2pfu2X4aCufBjbMqbceeKSVTx1Q3pvvwFW1HdgOMDk5WVNTU/NV61Sv12MY5x2Gj15/M1fsWu68e2XaunnWtg7J3vOmhh2CNFAbt31u2CFohVnsLcUdwP43Dc8Hbp5T/vb2tuLJwJPtluPngdcnOa49LP/6ViZJkjTyDvsncJJP0O+dOj7JNP23DS8HbkxyEfAQ8JZW/RbgTGAP8BRwIUBVPZbkvcCXW72/qqoDH8SXJEkaSYdNuKrqrQfZdNo8dQu4+CDHuQa45oiikyRJGgGONC9JktQxEy5JkqSOmXBJkiR1zIRLkiSpYyZckiRJHTPhkjSWkmxIcnuS3UnuT3JJK/+LJN9Ock/7nDlnn0uT7EnyzSRvGF70klablTMUtSQN1iywtaruTvILwF1JdrZtV1bVB+ZWTvJK4Fzg14FfAv45ya9U1c8GGrWkVckeLkljqar2VdXdbfmHwG5g3SF2ORu4oap+UlXfoj/A80ndRyppFJhwSRp7STYCrwXubEXvSHJvkmvadGTQT8YenrPbNIdO0CTp57ylKGmsJXkh8CngnVX1gyRXAe8Fqv28Avh9IPPsXvMcbwuwBWBiYoJer9dR5PObmZkZ+DmHZSW3devm2WU93sQxy3/MQVvod7WSv9elMOGSNLaSPId+snV9VX0aoKq+O2f73wGfbavTwIY5u68HHjnwmFW1HdgOMDk5WVNTU53EfjC9Xo9Bn3NYVnJbL9j2uWU93tbNs1yxa3X/L3vveVMLqreSv9el8JaipLGUJMDVwO6q+uCc8rVzqv0ucF9b3gGcm+ToJCcAm4AvDSpeSavb6k6XJWnxTgHeBuxKck8rew/w1iSvoX+7cC/wBwBVdX+SG4Gv03/D8WLfUJS0UCZcksZSVX2R+Z/LuuUQ+7wPeF9nQUkaWd5SlCRJ6pgJlyRJUsdMuCRJkjpmwiVJktQxEy5JkqSOmXBJkiR1zIRLkiSpYyZckiRJHTPhkiRJ6pgJlyRJUsdMuCRJkjpmwiVJktSxJSVcSf4kyf1J7kvyiSTPS3JCkjuTPJDkk0me2+oe3db3tO0bl6MBkiRJK92iE64k64A/Biar6lXAUcC5wPuBK6tqE/A4cFHb5SLg8ap6OXBlqydJkjTylnpLcQ1wTJI1wPOBfcCpwE1t+7XAOW357LZO235akizx/JIkSSveohOuqvo28AHgIfqJ1pPAXcATVTXbqk0D69ryOuDhtu9sq/+SxZ5fkiRptViz2B2THEe/1+oE4AngfwBnzFO19u9yiG1zj7sF2AIwMTFBr9dbbIiLNjMzM5TzDsPEMbB18+zhK44A2zo84/LvSZIOZtEJF/DbwLeq6nsAST4N/CZwbJI1rRdrPfBIqz8NbACm2y3IFwGPHXjQqtoObAeYnJysqampJYS4OL1ej2Gcdxg+ev3NXLFrKb8Gq8fWzbO2dUj2njc17BAkaaiWckV+CDg5yfOB/wucBnwFuB14M3ADcD5wc6u/o63/z7b9tqp6Vg+XJEkaPRu3fW5B9bZunmWq21CGYinPcN1J/+H3u4Fd7VjbgXcD70qyh/4zWle3Xa4GXtLK3wVsW0LckiRJq8aS7jlU1WXAZQcUPwicNE/dHwNvWcr5JEmSViNHmpckSeqYCZckSVLHTLgkjaUkG5LcnmR3m6Lsklb+4iQ72/RkO9sQOKTvI216snuTnDjcFkhaTUy4JI2rWWBrVb0COBm4OMkr6b/Qc2ubnuxWnn7B5wxgU/tsAa4afMiSVisTLkljqar2VdXdbfmHwG76M2LMnYbswOnJrqu+O+iPObh2wGFLWqVMuCSNvSQbgdcCdwITVbUP+kkZ8LJW7efTkzVzpy6TpENaOUNRS9IQJHkh8CngnVX1g2S+Wcj6VecpW3HTk43T1GQrua3LPbXWSpuuq0sTx4zmdGAmXJLGVpLn0E+2rq+qT7fi7yZZW1X72i3DR1v5/unJ9ps7ddnPDXt6snGammwlt/WCBY6qvlArbbquLm3dPMvvrdDvdSm8pShpLKXflXU1sLuqPjhn0/5pyODZ05O9vb2teDLw5P5bj5J0OOORLkvSs50CvA3YleSeVvYe4HLgxiQX0Z8zdv8MGbcAZwJ7gKeACwcbrqTVzIRL0liqqi8y/3NZAKfNU7+AizsNStLI8paiJElSx0y4JEmSOmbCJUmS1DETLkmSpI6ZcEmSJHXMhEuSJKljJlySJEkdM+GSJEnqmAmXJElSx0y4JEmSOmbCJUmS1DETLkmSpI6ZcEmSJHXMhEuSJKljJlySJEkdW1LCleTYJDcl+UaS3Ul+I8mLk+xM8kD7eVyrmyQfSbInyb1JTlyeJkiSJK1sS+3h+jDwj1X1a8Crgd3ANuDWqtoE3NrWAc4ANrXPFuCqJZ5bkiRpVVh0wpXkF4HfAq4GqKqfVtUTwNnAta3atcA5bfls4LrquwM4NsnaRUcuSZK0SqxZwr6/DHwP+PskrwbuAi4BJqpqH0BV7UvyslZ/HfDwnP2nW9m+JcQgSdKibNz2uQXX3Xv5WR1GonGwlIRrDXAi8EdVdWeSD/P07cP5ZJ6yelalZAv9W45MTEzQ6/WWEOLizMzMDOW8wzBxDGzdPDvsMAbCtg7PuPx7kqSDWUrCNQ1MV9Wdbf0m+gnXd5Osbb1ba4FH59TfMGf/9cAjBx60qrYD2wEmJydrampqCSEuTq/XYxjnHYaPXn8zV+xayq/B6rF186xtHZK9500NOwRJGqpFP8NVVd8BHk7yq63oNODrwA7g/FZ2PnBzW94BvL29rXgy8OT+W4+SJEmjbKl/Av8RcH2S5wIPAhfST+JuTHIR8BDwllb3FuBMYA/wVKsrSZI08paUcFXVPcDkPJtOm6duARcv5XySJEmrkSPNSxpLSa5J8miS++aU/UWSbye5p33OnLPt0jZw8zeTvGE4UUtarUy4JI2rjwOnz1N+ZVW9pn1uAUjySuBc4NfbPv85yVEDi1TSqmfCJWksVdUXgMcWWP1s4Iaq+klVfYv+s6gndRacpJGzct4bl6SV4R1J3g58BdhaVY/TH6T5jjl19g/c/CzDHktwnMYRXGpbj2SsuiM9z3KPg7fSxtbr0sQxozl2nwmXJD3tKuC99Adlfi9wBfD7LHDgZhj+WILjNI7gUtt6wZGMNH+EY8kdybEXYqWNrdelrZtn+b0R/B32lqIkNVX13ar6WVX9C/B3PH3bcEEDN0vSwZhwSVLTZsfY73eB/W8w7gDOTXJ0khOATcCXBh2fpNVrPPonJekAST4BTAHHJ5kGLgOmkryG/u3CvcAfAFTV/UlupD+bxixwcVX9bBhxS1qdTLgkjaWqeus8xVcfov77gPd1F5GkUeYtRUmSpI6ZcEmSJHXMhEuSJKljJlySJEkdM+GSJEnqmAmXJElSx0y4JEmSOmbCJUmS1DEHPpUk6TA2LvNk1Bo/9nBJkiR1zIRLkiSpYyZckiRJHTPhkiRJ6pgJlyRJUsdMuCRJkjpmwiVJktQxEy5JkqSOmXBJkiR1bMkJV5Kjknw1yWfb+glJ7kzyQJJPJnluKz+6re9p2zcu9dySJEmrwXL0cF0C7J6z/n7gyqraBDwOXNTKLwIer6qXA1e2epIkSSNvSQlXkvXAWcDH2nqAU4GbWpVrgXPa8tltnbb9tFZfkiRppC118uoPAX8G/EJbfwnwRFXNtvVpYF1bXgc8DFBVs0mebPW/P/eASbYAWwAmJibo9XpLDPHIzczMDOW8wzBxDGzdPHv4iiPAtg7PuPx7krQ8jnSy8L2Xn9VRJMtn0QlXkjcCj1bVXUmm9hfPU7UWsO3pgqrtwHaAycnJmpqaOrBK53q9HsM47zB89PqbuWLXUvPu1WHr5lnbOiR7z5sadgiSNFRLuaV4CvCmJHuBG+jfSvwQcGyS/Vf69cAjbXka2ADQtr8IeGwJ55ekRUtyTZJHk9w3p+zFSXa2l352JjmulSfJR9pLP/cmOXF4kUtajRadcFXVpVW1vqo2AucCt1XVecDtwJtbtfOBm9vyjrZO235bVT2rh0uSBuTjwOkHlG0Dbm0v/dza1gHOADa1zxbgqgHFKGlEdDEO17uBdyXZQ/8Zratb+dXAS1r5u3j6QiZJA1dVX+DZvexzX+458KWf66rvDvo9+WsHE6mkUbAsD3lUVQ/oteUHgZPmqfNj4C3LcT5J6shEVe0DqKp9SV7Wyn/+0k+z/4WgfQOOT9IqtXKeqpWklWtBL/3A8N+0Hqe3rJfa1pX0Ju/hrLQ3j7u0mLauht95Ey5Jetp3k6xtvVtrgUdb+c9f+mnmvhD0DMN+03qc3rJealsvOMKhB4Zppb153KXFtHU1vAntXIqS9LS5L/cc+NLP29vbiicDT+6/9ShJCzEe6bIkHSDJJ4Ap4Pgk08BlwOXAjUkuAh7i6edObwHOBPYATwEXDjxgSauaCZeksVRVbz3IptPmqVvAxd1GJGmUeUtRkiSpYyZckiRJHTPhkiRJ6pgJlyRJUsdMuCRJkjpmwiVJktQxEy5JkqSOmXBJkiR1zIRLkiSpY440L0kaCRtX0WTUGj/2cEmSJHXMhEuSJKljJlySJEkdM+GSJEnqmAmXJElSx0y4JEmSOmbCJUmS1DETLkmSpI6ZcEmSJHXMhEuSJKljJlySJEkdW3TClWRDktuT7E5yf5JLWvmLk+xM8kD7eVwrT5KPJNmT5N4kJy5XIyRJklaypfRwzQJbq+oVwMnAxUleCWwDbq2qTcCtbR3gDGBT+2wBrlrCuSVJklaNRSdcVbWvqu5uyz8EdgPrgLOBa1u1a4Fz2vLZwHXVdwdwbJK1i45ckiRplVizHAdJshF4LXAnMFFV+6CflCV5Wau2Dnh4zm7TrWzfcsQgScslyV7gh8DPgNmqmkzyYuCTwEZgL/B7VfX4sGIcFxu3fe6g27ZunuWCQ2yXVpIlJ1xJXgh8CnhnVf0gyUGrzlNW8xxvC/1bjkxMTNDr9ZYa4hGbmZkZynmHYeKY/kVrHNjW4Vml/57+XVV9f876/sclLk+yra2/ezihSVptlpRwJXkO/WTr+qr6dCv+bpK1rXdrLfBoK58GNszZfT3wyIHHrKrtwHaAycnJmpqaWkqIi9Lr9RjGeYfho9ffzBW7lqWjc8XbunnWtg7J3vOmhh3CcjgbmGrL1wI9TLgkLdCir8jpd2VdDeyuqg/O2bQDOB+4vP28eU75O5LcALwOeHL/rUdJWmEK+KckBfyX9ofgwR6XeIZh99KPWg/9oXpqV1pPbpds66Gtht/5pfwJfArwNmBXknta2XvoJ1o3JrkIeAh4S9t2C3AmsAd4CrhwCeeWpC6dUlWPtKRqZ5JvLHTHYffSr/Qe+kM9kzW/g/9vaqX15HbJth7aauhFX/S3V1VfZP7nsgBOm6d+ARcv9nySNChV9Uj7+WiSzwAncfDHJSTpsBxpXpLmSPKCJL+wfxl4PXAfTz8uAc98XEKSDms8+iclaeEmgM+0N67XAP+9qv4xyZeZ/3EJSTosEy5JmqOqHgRePU/5/2GexyUkaSG8pShJktSxkerhOvK3X+Y3TqMXb9087AgkSRp9I5VwSZKk8XMkHS57Lz+rw0gOzluKkiRJHTPhkiRJ6pgJlyRJUsdMuCRJkjpmwiVJktQxEy5JkqSOOSyEJGnRlmv8Q2nU2cMlSZLUMRMuSZKkjplwSZIkdcxnuCRJz+BzWdLys4dLkiSpY/ZwSdKIs8dKGj57uCRJkjpmwiVJktQxEy5JkqSOmXBJkiR1zIfmJUnS2DjSl0j2Xn7WspzXHi5JkqSOmXBJkiR1bOAJV5LTk3wzyZ4k2wZ9fklaLK9fkhZroM9wJTkK+Fvgd4Bp4MtJdlTV1wcZhyQdqa6vX8s1OOnWzbNc4ECn0ooz6B6uk4A9VfVgVf0UuAE4e8AxSNJieP2StGiDTrjWAQ/PWZ9uZZK00nn9krRogx4WIvOU1TMqJFuALW11Jsk3O4/qAH8MxwPfH/R5h8G2jqaV1ta8/4iq/5uOwliqw16/YPjXsJX23XfJto6mldbW5bp+DTrhmgY2zFlfDzwyt0JVbQe2DzKoAyX5SlVNDjOGQbGto2mc2jpAh71+wfCvYeP03dvW0TSqbR30LcUvA5uSnJDkucC5wI4BxyBJi+H1S9KiDbSHq6pmk7wD+DxwFHBNVd0/yBgkaTG8fklaioFP7VNVtwC3DPq8R2iotzQHzLaOpnFq68B4/VpxbOtoGsm2pupZz3xKkiRpGTm1jyRJUsdMuJokG5LcnmR3kvuTXDLsmLqW5KgkX03y2WHH0rUkxya5Kck32nf8G8OOqStJ/qT9Dt+X5BNJnjfsmNQ9r2Gjy+vXaDDhetossLWqXgGcDFyc5JVDjqlrlwC7hx3EgHwY+Meq+jXg1Yxou5OsA/4YmKyqV9F/uPvc4UalAfEaNrq8fo0AE66mqvZV1d1t+Yf0f6FHdhTpJOuBs4CPDTuWriX5ReC3gKsBquqnVfXEcKPq1BrgmCRrgOczz1hRGj1ew0aT16/RuX6ZcM0jyUbgtcCdw42kUx8C/gz4l2EHMgC/DHwP+Pt2++FjSV4w7KC6UFXfBj4APATsA56sqn8ablQaNK9hI8Xr14gw4TpAkhcCnwLeWVU/GHY8XUjyRuDRqrpr2LEMyBrgROCqqnot8CNg23BD6kaS4+hPqHwC8EvAC5L8++FGpUHyGjZyvH6NCBOuOZI8h/6F6vqq+vSw4+nQKcCbkuwFbgBOTfLfhhtSp6aB6ara/9f+TfQvYKPot4FvVdX3qur/AZ8GfnPIMWlAvIaNJK9fI8KEq0kS+vfId1fVB4cdT5eq6tKqWl9VG+k/kHhbVY3MXxEHqqrvAA8n+dVWdBrw9SGG1KWHgJOTPL/9TnpH3foAAACPSURBVJ/GiD5gq2fyGjaa1zCvX6Nz/Rr4SPMr2CnA24BdSe5pZe9pI0tr9fsj4Po2B96DwIVDjqcTVXVnkpuAu+m/tfZVRnTUZj2L17DR5fVrBDjSvCRJUse8pShJktQxEy5JkqSOmXBJkiR1zIRLkiSpYyZckiRJHTPhkiRJ6pgJlyRJUsdMuCRJkjr2/wHBwq1/nxP6mwAAAABJRU5ErkJggg==",
             "text/plain": [
               "<Figure size 720x360 with 2 Axes>"
             ]
@@ -1274,40 +1268,40 @@
             "needs_background": "light"
           }
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "7uzX4QWE_G_O"
-      },
-      "source": [
-        "What does the argument in `plt.subplot(1,2,1)` mean? If you're not sure, check out: http://stackoverflow.com/questions/3584805/in-matplotlib-what-does-the-argument-mean-in-fig-add-subplot111\n",
-        "\n",
-        "**Q: create 8 subplots (2 rows and 4 columns) with the following `binsizes`.**"
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "NbM-6DjA_G_O",
-        "outputId": "d4276bd5-de15-4431-a2d8-e7336373709e"
-      },
+        "id": "hDnPdqBU_G_N",
+        "outputId": "e20b169b-58e0-4bc3-96dd-7bceced52569"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "What does the argument in `plt.subplot(1,2,1)` mean? If you're not sure, check out: http://stackoverflow.com/questions/3584805/in-matplotlib-what-does-the-argument-mean-in-fig-add-subplot111\n",
+        "\n",
+        "**Q: create 8 subplots (2 rows and 4 columns) with the following `binsizes`.**"
+      ],
+      "metadata": {
+        "id": "7uzX4QWE_G_O"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "nbins = [2, 3, 5, 10, 30, 40, 60, 100 ]\n",
         "figsize = (18, 10)\n",
         "\n",
         "# TODO\n"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAABBsAAAJcCAYAAAC4z6wqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nOzdf5RlZX3n+/dHWhRFbZBQkoaxSewxoh2V1EUMszIVSRDQscmKTDBEG0NWmzWYaOys2GZWLk7ULJwEfxtMJxAhQ0SCGnqEqAQtvd4bCKJI80NDD7bQ0NIq0FrirzLf+8fZhceiurp+7Drn1Kn3a61adfazn7P38+1T9e063/PsZ6eqkCRJkiRJasuj+j0ASZIkSZI0XCw2SJIkSZKkVllskCRJkiRJrbLYIEmSJEmSWmWxQZIkSZIktcpigyRJkiRJapXFBu1Tkvcl+ZN+j0PS4DAvSJrOvCDJPKCZpKr6PQb1UZKdwAjwI+CHwP8H/G5V3d3jcRwPvAn4hWYs48DvV9XuXo5D0kDlhWOAS4CfbZpupJMXbuvlOCQNVF5YC3wF+E5X81ur6k29HIe0Eg1QHjgQ+HtgFHgq8MtVNd61P8B5wO80TRcCry/f+PacMxsE8F+q6mDgCOA+4N19GMMhwFZgLZ2k8W3gb/swDkkdg5AX7gVeChwKHAZsAy7rwzgkdQxCXpiyuqoObr4sNEi9Myh54LPAbwFfm2HfJuA04NnAzwMvBl7Vu6FpisUGPayqvgdcARwDkOT9Sd7cPB5LsivJ5iR7kuxO8sqp5yY5NcltSb6d5J4kfzjPc/9TVf1DVX2rqh4C3gOc0F50khaiz3nhwara2XwSETqfpDytteAkLUg/84KkwdDnvw9+UFXvqKrP0vnbYLqNwPlVtauq7gHOB85aWKRaDIsNeliSxwG/AVy3jy5PAZ4ErAHOBt6b5JBm34XAq6rqCcCzgE82x/wPSR6c5es393GuXwJubSk0SQs0CHkhyYPA9+h8evJnbccoaX4GIS8AX23ezPxtksPajlHS7AYkD+zLM4Evdm1/sWlTj63q9wA0EP4xySRwMLAHeOE++v0Q+NOqmgSuTjIBPJ1OkvkhcEySL1bVA8ADAFV1F7B6PoNJ8vPA/w1sWEgwkloxMHmhqlYneTydTyq+utCAJC3aIOSFbwD/F3AT8GTgvcCls4xFUrsGIQ/sz8HA3q7tvcDBSeK6Db3lzAYBnFZVq4HHAK8GPp3kKTP0+2aTMKY8ROeXGeDXgVPpfNLw6STPX8hAkjwN+CfgNVX1/yzkGJJaMTB5AaCqvgO8D7gkyeELPY6kRel7Xqiqiar6XFVNVtV9zThOSvLEeUcjaSH6ngfmYALozglPBCYsNPSexQY9rKp+VFUfpnPt03+a53NvqKoNwOHAPwKXw8PToSZm+Tpz6hhJngr8M/Cmqvq71gKTtGD9zgvTPAp4HJ0pmZL6ZMDywtSbhywwHEkLMGB5YLpb6SwOOeXZeHl2X3gZhR6WJMBL6NwZ4nY6K7fO5XkHAqcDH62qvUm+RbNYSzMd6uDZnt8cYw2d67XeW1XvW1gEktrW57zwq3SmTN8MPB54M52plrfPPxJJbelzXnge8CBwR3P+dwHjVbV31idKalU/80BznMfw4yLjgUkeC3y/mb1wCfC6JFfTKUhupr93z1mxLDYI4H8n+RGdX8avAhur6tZODpmzlwPvSXIA8GU6t6KZj98BfgY4N8m5U43NrXUk9d4g5IXVdP44OBL4LnADcHKzArak3huEvPAzdBaKPRz4FnAN8LJ5HkPSwg1CHqB53lObxx9vvh8N7AT+ik6u2N60/03Tph6Ll65IkiRJkqQ2uWaDJEmSJElqlcUGSZIkSZLUKosNkiRJkiSpVRYbJEmSJElSqwb6bhSHHXZYrV27dsnP853vfIfHP/7xS36eXhiWWIYlDlgesdx4443fqKqf6vc45sK8MH/DEsuwxAHLIxbzwiMth9dtroYllmGJA5ZHLMspL0BvcsNyeN3malhiGZY4YHnEMlteGOhiw9q1a/nc5z635OcZHx9nbGxsyc/TC8MSy7DEAcsjliRf7fcY5sq8MH/DEsuwxAHLIxbzwiMth9dtroYllmGJA5ZHLMspL0BvcsNyeN3malhiGZY4YHnEMlte8DIKSZIkSZLUqv0WG5IcleRTSW5PcmuS1zTtb0xyT5Kbmq9Tu57zhiQ7knw5yQu72k9u2nYk2bI0IUmSJEmSpH6ay8yGSWBzVT0DOB44J8kxzb63V9Vzmq+rAZp9ZwDPBE4G/jLJAUkOAN4LnAIcA7ys6ziSJEmSVogkf9B8kHlLkg8keWySo5Ncn+SOJB9McmDT9zHN9o5m/9r+jl7SXOy32FBVu6vq883jbwO3A2tmecoG4LKq+n5VfQXYARzXfO2oqjur6gfAZU1fSZIkSStEkjXA7wOjVfUs4AA6H1a+lc6HmeuAB4Czm6ecDTxQVU8D3t70kzTg5rVAZFNFfC5wPXAC8OokrwA+R2f2wwN0ChHXdT1tFz8uTtw9rf15M5xjE7AJYGRkhPHx8fkMcUEmJiZ6cp5eGJZYhiUOGK5YJEmSWrIKOCjJD4HHAbuBFwC/2ey/GHgjcAGdDyjf2LRfAbwnSaqqejlgSfMz52JDkoOBDwGvrapvJbkAeBNQzffzgd8GMsPTi5lnUTwiQVTVVmArwOjoaPVi9c3lsMrnXA1LLMMSBwxXLJIkSYtVVfck+QvgLuC7wCeAG4EHq2qy6db9geUamg8tq2oyyV7gycA3ph+71x9cDtOHSsMSy7DEAcs/ljkVG5I8mk6h4dKq+jBAVd3Xtf+vgY82m7uAo7qefiRwb/N4X+2SJEmSVoAkh9CZrXA08CDwD3TWdZtu6oPJfX2Y+cjGHn9wOUwfKg1LLMMSByz/WOZyN4oAFwK3V9XbutqP6Or2a8AtzeNtwBnNQi5HA+uAfwVuANY1C78cSOe6rG3thCFJkiRpmfgV4CtV9fWq+iHwYeAXgdVJpj4M7f5g8uEPM5v9TwLu7+2QJc3XXGY2nAC8HNie5Kam7Y/p3E3iOXSqijuBVwFU1a1JLgduo3Mni3Oq6kcASV4NfJzOIjAXVdWtLcYiSZIkafDdBRyf5HF0LqM4kc4acJ8CXkpnIfmNwJVN/23N9r80+z/peg3S4NtvsaGqPsvMU5eunuU5bwHeMkP71bM9T5IkSdJwq6rrk1wBfJ7Oh5NfoHPpw1XAZUne3LRd2DzlQuDvkuygM6PhjN6PWtJ8zetuFNJcrN1y1aKPsXn9JGe1cJxB0M9Ydp73or6cV4Nl+z17h+L3abG/S/4+SMOtjb8/lor555Gq6lzg3GnNdwLHzdD3e8DpvRiXhkubecHf4/nb75oNkiRJkiRJ82GxQZIkSZIktcpigyRJkiRJapXFBkmSJEmS1CqLDZIkSZIkqVUWGyRJkiRJUqssNkiSJEmSpFZZbJA0b0kuSrInyS0z7PvDJJXksGY7Sd6VZEeSm5Mc29V3Y5I7mq+NvYxBUrvMC5IkqZvFBkkL8X7g5OmNSY4CfhW4q6v5FGBd87UJuKDpeyhwLvA84Djg3CSHLOmoJS2l92NekCRJDYsNkuatqj4D3D/DrrcDfwRUV9sG4JLquA5YneQI4IXANVV1f1U9AFzDDG9UJC0P5gVJktRtVb8HIGk4JHkJcE9VfTFJ9641wN1d27uatn21z3TsTXQ+/WRkZITx8fH2Br4PExMTPTlPL4wcBJvXT/Z7GIu22DgG6fUcpp+v2ZgXBtewxNIdxyDnubn8Ww/LayJJUyw2SFq0JI8D/jtw0ky7Z2irWdof2Vi1FdgKMDo6WmNjYwsb6DyMj4/Ti/P0wrsvvZLzty//dL95/eSi4th55lh7g1mkYfr52hfzwmAblli64zhry1X9Hcws5pJ/huU1kaQpXkYhqQ0/CxwNfDHJTuBI4PNJnkLnk8mjuvoeCdw7S7uk4WBekCRpBbPYIGnRqmp7VR1eVWurai2dNwzHVtXXgG3AK5rV548H9lbVbuDjwElJDmkWgDupaZM0BMwLkiStbBYbJM1bkg8A/wI8PcmuJGfP0v1q4E5gB/DXwH8DqKr7gTcBNzRff9q0SVqGzAuSJKnb8r+IV1LPVdXL9rN/bdfjAs7ZR7+LgItaHZy0D2sH6Hruzesn+3Z9+c7zXrQkxzUvSJKkbs5skCRJkiRJrbLYIEmSJEmSWmWxQZIkSZIktcpigyRJkiRJapXFBkmSJEmS1CqLDZIkSZJ6JsnTk9zU9fWtJK9NcmiSa5Lc0Xw/pOmfJO9KsiPJzUmO7XcMkvbPYoMkSZKknqmqL1fVc6rqOcAvAA8BHwG2ANdW1Trg2mYb4BRgXfO1Cbig96OWNF8WGyRJkiT1y4nA/6mqrwIbgIub9ouB05rHG4BLquM6YHWSI3o/VEnzsarfA5AkSZK0Yp0BfKB5PFJVuwGqaneSw5v2NcDdXc/Z1bTtnn6wJJvozH5gZGSE8fHxJRp2x8TExJKfo1eGJZbuODavn2ztuP34t1nur4nFBkmSJEk9l+RA4CXAG/bXdYa2mqljVW0FtgKMjo7W2NjYYoa4X+Pj4yz1OXplWGLpjuOsLVe1dtydZ461dqy5Wu6viZdRSJIkSeqHU4DPV9V9zfZ9U5dHNN/3NO27gKO6nnckcG/PRilpQSw2SJIkSeqHl/HjSygAtgEbm8cbgSu72l/R3JXieGDv1OUWkgaXl1FIkiRJ6qkkjwN+FXhVV/N5wOVJzgbuAk5v2q8GTgV20LlzxSt7OFRJC2SxQZIkSVJPVdVDwJOntX2Tzt0ppvct4JweDU2a0doW138A2Hnei1o93iDyMgpJkiRJktQqiw2SJEmSJKlVFhskSZIkSVKrLDZIkiRJkqRWWWyQJEmSJEmtstggSZIkSZJaZbFBkiRJkiS1ymKDJEmSJElq1X6LDUmOSvKpJLcnuTXJa5r2Q5Nck+SO5vshTXuSvCvJjiQ3Jzm261gbm/53JNm4dGFJkiRJkqR+mcvMhklgc1U9AzgeOCfJMcAW4NqqWgdc22wDnAKsa742ARdApzgBnAs8DzgOOHeqQCFpeUlyUZI9SW7pavvzJF9qiowfSbK6a98bmgLkl5O8sKv95KZtR5It088jafkwL0iSpG77LTZU1e6q+nzz+NvA7cAaYANwcdPtYuC05vEG4JLquA5YneQI4IXANVV1f1U9AFwDnNxqNJJ65f088vf3GuBZVfXzwL8BbwBoipNnAM9snvOXSQ5IcgDwXjoFymOAlzV9JS1P78e8IEmSGqvm0znJWuC5wPXASFXthk5BIsnhTbc1wN1dT9vVtO2rffo5NtGZEcHIyAjj4+PzGeKCTExM9OQ8vTAIsWxeP7noY4wc1M5xBkE/Y1mqn4Wq+kyTD7rbPtG1eR3w0ubxBuCyqvo+8JUkO+jMbgLYUVV3AiS5rOl725IMWtKSMi9IkqRucy42JDkY+BDw2qr6VpJ9dp2hrWZp/8mGqq3AVoDR0dEaGxub6xAXbHx8nF6cpxcGIZaztly16GNsXj/J+dvnVQsbWP2MZeeZY305L/DbwAebx2vovMmY0l1onF6AfN5MB7MIuTjDUrwbljhgOIuQc2BeGCDDEkt3HIOcH+bybz0sr4kkTZnTO6Akj6ZTaLi0qj7cNN+X5IhmVsMRwJ6mfRdwVNfTjwTubdrHprWPL3zokgZRkv9OZ62XS6eaZuhWzHwZ1yMKkGARcrHefemVQ1G8swjZjn4UIc0Lg2dYYumOo40PO5bKXH7vhuU1kaQpc7kbRYALgdur6m1du7YBU3eU2Ahc2dX+iuauFMcDe5vLLT4OnJTkkGZhyJOaNklDornLzIuBM6tq6g3CbAXImdolDRHzgiRJK9NcPlY5AXg5sD3JTU3bHwPnAZcnORu4Czi92Xc1cCqwA3gIeCVAVd2f5E3ADU2/P62q+1uJQlLfJTkZeD3wn6vqoa5d24C/T/I24Kfp3KnmX+l8srkuydHAPXQWi/vN3o5a0lIyL0iStHLtt9hQVZ9l5umOACfO0L+Ac/ZxrIuAi+YzQEmDJ8kH6FwWdViSXXRua/sG4DHANc2aLtdV1e9W1a1JLqezwNskcE5V/ag5zqvpzHA6ALioqm7teTCSWmFekCRJ3Ybj4ldJPVVVL5uh+cJZ+r8FeMsM7VfTmQ0laZkzL0iSpG77XbNBkiRJkiRpPiw2SJIkSZKkVllskCRJkiRJrbLYIEmSJKmnkqxOckWSLyW5Pcnzkxya5JokdzTfD2n6Jsm7kuxIcnOSY/s9fkn7Z7FBkiRJUq+9E/hYVf0c8GzgdmALcG1VrQOubbYBTqFzi9x1wCbggt4PV9J8WWyQJEmS1DNJngj8Es0da6rqB1X1ILABuLjpdjFwWvN4A3BJdVwHrE5yRI+HLWmevPWlJEmSpF76GeDrwN8meTZwI/AaYKSqdgNU1e4khzf91wB3dz1/V9O2e/qBk2yiM/uBkZERxsfHlyoGACYmJpb8HL0yCLFsv2fvoo8xchC8+9IrAdi8ftGHWzJz+bcehNdkMSw2SJIkSeqlVcCxwO9V1fVJ3smPL5mYSWZoq5k6VtVWYCvA6OhojY2NLXKosxsfH2epz9ErgxDLWVuuWvQxNq+f5Pztg/82d+eZY/vtMwivyWJ4GYUkSZKkXtoF7Kqq65vtK+gUH+6bujyi+b6nq/9RXc8/Eri3R2OVtEAWGyRJkiT1TFV9Dbg7ydObphOB24BtwMambSNwZfN4G/CK5q4UxwN7py63kDS4Bn9+iSRJkqRh83vApUkOBO4EXknng9DLk5wN3AWc3vS9GjgV2AE81PSVNOAsNkiSJEnqqaq6CRidYdeJM/Qt4JwlH5SkVnkZhSRJkiRJapXFBkmSJEmS1CqLDZIkSZIkqVUWGyRJkiRJUqssNkiSJEmSpFZZbJAkSZIkSa2y2CBJkiRJklplsUGSJEmSJLXKYoMkSZIkSWqVxQZJkiRJktQqiw2SJEmSJKlVFhskzVuSi5LsSXJLV9uhSa5Jckfz/ZCmPUnelWRHkpuTHNv1nI1N/zuSbOxHLJLaYV6QJEndLDZIWoj3AydPa9sCXFtV64Brm22AU4B1zdcm4ALovAkBzgWeBxwHnDv1RkTSsvR+zAuSJKlhsUHSvFXVZ4D7pzVvAC5uHl8MnNbVfkl1XAesTnIE8ELgmqq6v6oeAK7hkW9UJC0T5gVJktRtVb8HIGlojFTVboCq2p3k8KZ9DXB3V79dTdu+2h8hySY6n34yMjLC+Ph4uyOfwcTERE/O0wsjB8Hm9ZP9HsaiDUsc0N9YevxzbV4YUMMSS3ccg5wf5vJvPSyviSRNsdggaallhraapf2RjVVbga0Ao6OjNTY21trg9mV8fJxenKcX3n3plZy/ffmn+83rJ4ciDuhvLDvPHOvLeacxL/TZsMTSHcdZW67q72BmMZffu2F5TSRpipdRSGrLfc00aJrve5r2XcBRXf2OBO6dpV3S8DAvSJK0QllskNSWbcDUyvEbgSu72l/RrD5/PLC3mVb9ceCkJIc0C8Cd1LRJGh7mBUmSVqjhmI8qqaeSfAAYAw5LsovO6vHnAZcnORu4Czi96X41cCqwA3gIeCVAVd2f5E3ADU2/P62q6YvLSVomzAuSJKmbxQZJ81ZVL9vHrhNn6FvAOfs4zkXARS0OTVKfmBckSVI3L6OQJEmSJEmtstggSZIkqaeS7EyyPclNST7XtB2a5JokdzTfD2nak+RdSXYkuTnJsf0dvaS5sNggSZIkqR9+uaqeU1WjzfYW4NqqWgdc22wDnAKsa742ARf0fKSS5s1igyRJkqRBsAG4uHl8MXBaV/sl1XEdsHrqtrqSBpcLREqSJEnqtQI+kaSAv6qqrcBIcxtcqmp3ksObvmuAu7ueu6tp2z39oEk20Zn9wMjICOPj40sXATAxMbHk5+iVQYhl8/rJRR9j5KB2jrPU5vJvPQivyWJYbJAkSZLUaydU1b1NQeGaJF+apW9maKuZOjZFi60Ao6OjNTY2tuiBzmZ8fJylPkevDEIsZ225atHH2Lx+kvO3D/7b3J1nju23zyC8JovhZRSSJEmSeqqq7m2+7wE+AhwH3Dd1eUTzfU/TfRdwVNfTjwTu7d1oJS3EfosNSS5KsifJLV1tb0xyT7N67E1JTu3a94ZmpdgvJ3lhV/vJTduOJFumn0eSJEnS8Evy+CRPmHoMnATcAmwDNjbdNgJXNo+3Aa9o7kpxPLB36nILSYNrLvNL3g+8B7hkWvvbq+ovuhuSHAOcATwT+Gngn5P8x2b3e4FfpVOZvCHJtqq6bRFjlyRJkrT8jAAfSQKd9yN/X1UfS3IDcHmSs4G7gNOb/lcDpwI7gIeAV/Z+yJLma7/Fhqr6TJK1czzeBuCyqvo+8JUkO+hMiQLYUVV3AiS5rOlrsUGSJElaQZr3BM+eof2bwIkztBdwTg+GJqlFi1k549VJXgF8DthcVQ/QWRX2uq4+UyvFwiNXkH3eTAft9QqysPxX+ew2CLGspFVk56KfsfT7Z0GSJEnSyrTQYsMFwJvorAL7JuB84LfZ90qxM60NMRAryMLyX+Wz2yDEspJWkZ2LfsYyl1VuJUmai7Ut/P/ets3rJ1v5u0OS1L4FvQOqqvumHif5a+CjzeZsK8W6gqwkSZIkSSvAgm59OXVLmsav0Vk9FjorxZ6R5DFJjgbWAf8K3ACsS3J0kgPpLCK5beHDliRJkiRJg2q/MxuSfAAYAw5Lsgs4FxhL8hw6l0LsBF4FUFW3JrmczsKPk8A5VfWj5jivBj4OHABcVFW3th6NJEmSJEnqu7ncjeJlMzRfOEv/twBvmaH9ajq3rZEkSZIkSUNsQZdRSJIkSZIk7YvFBkmSJEmS1CqLDZIkSZIkqVUWGyRJkiRJUqssNkiSJEmSpFZZbJAkSZIkSa2y2CBJkiRJklplsUFSq5L8QZJbk9yS5ANJHpvk6CTXJ7kjyQeTHNj0fUyzvaPZv7a/o5e0FMwLkiStPBYbJLUmyRrg94HRqnoWcABwBvBW4O1VtQ54ADi7ecrZwANV9TTg7U0/SUPEvCBJ0spksUFS21YBByVZBTwO2A28ALii2X8xcFrzeEOzTbP/xCTp4Vgl9YZ5QZKkFWZVvwcgaXhU1T1J/gK4C/gu8AngRuDBqppsuu0C1jSP1wB3N8+dTLIXeDLwje7jJtkEbAIYGRlhfHx8iSOBiYmJnpynF0YOgs3rJ/ffccANSxzQ31h6/XNtXhhMC4llEH//lktemMu/9TD9fEkSWGyQ1KIkh9D5VPJo4EHgH4BTZuhaU0+ZZd+PG6q2AlsBRkdHa2xsrI3hzmp8fJxenKcX3n3plZy/ffmn+83rJ4ciDuhvLDvPHOvp+cwLg2khsZy15aqlGcwiLJe8MJffu2H6+ZIk8DIKSe36FeArVfX1qvoh8GHgF4HVzfRpgCOBe5vHu4CjAJr9TwLu7+2QJS0x84IkSSuQxQZJbboLOD7J45prrE8EbgM+Bby06bMRuLJ5vK3Zptn/yap6xCeYkpY184IkSSuQxQZJramq6+ks6PZ5YDudHLMVeD3wuiQ76Fx7fWHzlAuBJzftrwO29HzQkpaUeUGSpJVp8C9yk7SsVNW5wLnTmu8Ejpuh7/eA03sxLkn9Y16QNJMkBwCfA+6pqhcnORq4DDiUToHy5VX1gySPAS4BfgH4JvAbVbWzT8OWNEfObJAkSZLUD68Bbu/afivw9qpaBzwAnN20nw08UFVPA97e9JM04Cw2SJIkSeqpJEcCLwL+ptkO8AI6l10BXAyc1jze0GzT7D+x6S9pgHkZhSRJkqReewfwR8ATmu0nAw9W1WSzvQtY0zxeA9wNUFWTSfY2/b8x/aBJNgGbAEZGRhgfH1+q8QMwMTGx5OfolUGIZfP6yf132o+Rg9o5zlKby7/1ILwmi2GxQZIkSVLPJHkxsKeqbkwyNtU8Q9eaw76fbKzaSmcRWkZHR2tsbGymbq0ZHx9nqc/RK4MQy1lbrlr0MTavn+T87YP/NnfnmWP77TMIr8liDP6rIEmSJGmYnAC8JMmpwGOBJ9KZ6bA6yapmdsORwL1N/13AUcCuJKuAJwH3937YkubDNRskSZIk9UxVvaGqjqyqtcAZwCer6kzgU8BLm24bgSubx9uabZr9n6yqGWc2SBocFhskSZIkDYLXA69LsoPOmgwXNu0XAk9u2l8HbOnT+CTNg5dRSJIkSeqLqhoHxpvHdwLHzdDne8DpPR2YpEVzZoMkSZIkSWqVxQZJkiRJktQqiw2SJEmSJKlVFhskSZIkSVKrLDZIkiRJkqRWWWyQJEmSJEmtstggSZIkSZJaZbFBkiRJkiS1ymKDJEmSJElqlcUGSZIkSZLUKosNkiRJkiSpVRYbJEmSJElSqyw2SJIkSZKkVllskCRJkiRJrbLYIEmSJEmSWrXfYkOSi5LsSXJLV9uhSa5Jckfz/ZCmPUnelWRHkpuTHNv1nI1N/zuSbFyacCT1W5LVSa5I8qUktyd5/kJyhqThYV6QJGnlmcvMhvcDJ09r2wJcW1XrgGubbYBTgHXN1ybgAugUJ4BzgecBxwHnTv1RIWnovBP4WFX9HPBs4HbmmTMkDR3zgiRJK8yq/XWoqs8kWTuteQMw1jy+GBgHXt+0X1JVBVzXfJJxRNP3mqq6HyDJNXQKGB9YdASSBkaSJwK/BJwFUFU/AH6QZF45o6p293jokpaIeUGSpEdau+Wq/fbZvH6Ss+bQD2DneS9a7JBat99iwz6MTP2nX1W7kxzetK8B7u7qt6tp21f7IyTZROeTDEZGRhgfH1/gEOduYmKiJ+fphUGIZfP6yUUfY+Sgdo4zCPoZSx9+Fn4G+Drwt0meDdwIvIb554yfeFNhXlicYfl9GpY4wLyAeaHvFhLLIP7+LZe8MJd/62H6+ZIkWHixYV8yQ1vN0v7IxqqtwFaA0dHRGhsba21w+zI+Pk4vztMLgxDLXKtvs9m8fpLzt7f949kf/Yxl55ljvT7lKuBY4Peq6vok7+THU6NnMqfcYF5YnHdfeuVQ/D6ZF9phXli4YcoLC4mljcsWnr8AACAASURBVP/f27Zc8sJcfu+G6edLkmDhd6O4r7k8gub7nqZ9F3BUV78jgXtnaZc0XHYBu6rq+mb7CjpvMuabMyQND/OCJEkr0EKLDduAqTtKbASu7Gp/RbOS9PHA3maK5MeBk5Ic0iwMeVLTJmmIVNXXgLuTPL1pOhG4jfnnDElDwrwgabokj03yr0m+mOTWJP+jaT86yfXNXWo+mOTApv0xzfaOZv/afo5f0tzsd95Zkg/QWcDpsCS76NxV4jzg8iRnA3cBpzfdrwZOBXYADwGvBKiq+5O8Cbih6fenU4tFSho6vwdc2vyBcCedPPAo5pEzJA0d84Kkbt8HXlBVE0keDXw2yT8BrwPeXlWXJXkfcDadO9KcDTxQVU9LcgbwVuA3+jV4SXMzl7tRvGwfu06coW8B5+zjOBcBF81rdJKWnaq6CRidYde8coak4WFekNSt+T2faDYf3XwV8ALgN5v2i4E30ik2bGgeQ+dSrPckSXMcSQNq8FfUkSRJkjRUkhxA5+40TwPeC/wf4MGqmrq9SPfd6x6+S01VTSbZCzwZ+MYMx+3pnWqG6S4igxCLd7X7SfOJpd+v3UwsNkiSJEnqqar6EfCcJKuBjwDPmKlb831g72w3THcRGYRYvKvdT5pPLH2429R+DcerIEmSJGnZqaoHk4wDxwOrk6xqZjd034lm6i41u5KsAp4EuP7bAFg7gLfE1eBY6N0oJEmSJGnekvxUM6OBJAcBvwLcDnwKeGnTbfpdaqbuXvNS4JOu1yANPmc2SJIkSeqlI4CLm3UbHgVcXlUfTXIbcFmSNwNfAC5s+l8I/F2SHXRmNJzRj0FLmh+LDZIkSZJ6pqpuBp47Q/udwHEztH+PH98eV9Iy4WUUkiRJkiSpVRYbJEmSJElSqyw2SJIkSZKkVllskCRJkiRJrbLYIEmSJEmSWmWxQZIkSZIktcpigyRJkiRJapXFBkmSJEmS1CqLDZIkSZIkqVUWGyRJkiRJUqssNkiSJEmSpFZZbJAkSZIkSa2y2CBJkiRJklplsUGSJEmSJLXKYoMkSZIkSWqVxQZJkiRJktQqiw2SJEmSJKlVFhsktS7JAUm+kOSjzfbRSa5PckeSDyY5sGl/TLO9o9m/tp/jlrR0zAuSJK0sFhskLYXXALd3bb8VeHtVrQMeAM5u2s8GHqiqpwFvb/pJGk7mBUmSVhCLDZJaleRI4EXA3zTbAV4AXNF0uRg4rXm8odmm2X9i01/SEDEvSJK08qzq9wAkDZ13AH8EPKHZfjLwYFVNNtu7gDXN4zXA3QBVNZlkb9P/G90HTLIJ2AQwMjLC+Pj4Uo4fgImJiZ6cpxdGDoLN6yf333HADUsc0N9Y+vRzbV4YMAuJZRB//5ZLXpjLv/Uw/XxJElhskNSiJC8G9lTVjUnGpppn6Fpz2PfjhqqtwFaA0dHRGhsbm96ldePj4/TiPL3w7kuv5Pztyz/db14/ORRxQH9j2XnmWE/PZ14YTAuJ5awtVy3NYBZhueSFufzeDdPP1/4kOQq4BHgK8O/A1qp6Z5JDgQ8Ca4GdwH+tqgea2U3vBE4FHgLOqqrP92PskubOyygktekE4CVJdgKX0Zkm/Q5gdZKpvwaPBO5tHu8CjgJo9j8JuL+XA5a05MwLkqabBDZX1TOA44FzkhwDbAGubdZyubbZBjgFWNd8bQIu6P2QJc2XxQZJramqN1TVkVW1FjgD+GRVnQl8Cnhp020jcGXzeFuzTbP/k1X1iE8wJS1f5gVJ01XV7qmZCVX1bTqLx67hJ9dsmb6WyyXVcR2dYuURPR62pHka/HlnkobB64HLkrwZ+AJwYdN+IfB3SXbQ+eTyjD6NT1LvmRck0dze9rnA9cBIVe2GTkEiyeFNt4fXcmlMrfOye4bj9XQ9l2Faa8O1XAbPfGIZxJ9Diw2SlkRVjQPjzeM7geNm6PM94PSeDkxS35gXtFKtncN6F5vXT/ZtXYyd572oL+dNcjDwIeC1VfWtWW48M6e1XKD367kM01obruUyeOYTS6/XZJoLL6OQJEmS1FNJHk2n0HBpVX24ab5v6vKI5vuepv3htVwa3eu8SBpQFhskSZIk9Uxzd4kLgdur6m1du7rXbJm+lssr0nE8sHfqcgtJg2s45pdIkiRJWi5OAF4ObE9yU9P2x8B5wOVJzgbu4seXVF1N57aXO+jc+vKVvR2upIWw2CBJkiSpZ6rqs8y8DgPAiTP0L+CcJR2UpNZ5GYUkSZIkSWrVUMxsmMsKv7Pp5+q/bRumWCRJkiRJy5MzGyRJkiRJUqsWVWxIsjPJ9iQ3Jflc03ZokmuS3NF8P6RpT5J3JdmR5OYkx7YRgCRJkiRJGixtzGz45ap6TlWNNttbgGurah1wbbMNcAqwrvnaBFzQwrklSZIkSdKAWYrLKDYAFzePLwZO62q/pDquA1YnOWIJzi9JkiRJkvposQtEFvCJJAX8VVVtBUaqajdAVe1OcnjTdw1wd9dzdzVtu7sPmGQTnZkPjIyMMD4+vt9BbF4/uaggRg5a/DEGxbDEMixxQH9jmcvvjyRJkiS1bbHFhhOq6t6moHBNki/N0neme+nWIxo6BYutAKOjozU2NrbfQSz27gub109y/vahuDHH0MQyLHFAf2PZeeZYX84rSZIkaWVb1GUUVXVv830P8BHgOOC+qcsjmu97mu67gKO6nn4kcO9izi9JkiRJkgbPgosNSR6f5AlTj4GTgFuAbcDGpttG4Mrm8TbgFc1dKY4H9k5dbiFJkiRJkobHYuZ2jwAfSTJ1nL+vqo8luQG4PMnZwF3A6U3/q4FTgR3AQ8ArF3FuSZIkSZI0oBZcbKiqO4Fnz9D+TeDEGdoLOGeh55MkSZIkScvDUtz6UpIkSZIkrWAWGyRJkiRJUquG496CkiRJkqRZrd1y1T73bV4/yVmz7Jfmy5kNkiRJkiSpVRYbJEmSJElSqyw2SJIkSZKkVllskCRJkiRJrbLYIKk1SY5K8qkktye5NclrmvZDk1yT5I7m+yFNe5K8K8mOJDcnOba/EUhqm3lBkqSVyWKDpDZNApur6hnA8cA5SY4BtgDXVtU64NpmG+AUYF3ztQm4oPdDlrTEzAuSJK1A3vpSUmuqajewu3n87SS3A2uADcBY0+1iYBx4fdN+SVUVcF2S1UmOaI4jaQiYF+ZutlvStc1b3KnfklwEvBjYU1XPatoOBT4IrAV2Av+1qh5IEuCdwKnAQ8BZVfX5foxb0txZbJC0JJKsBZ4LXA+MTL1RqKrdSQ5vuq0B7u562q6m7SfeVCTZROcTTkZGRhgfH1/KoQMwMTHRk/P0wshBnTcWy92wxAH9jaWfP9fmhdn18mdiWH6fhiUOWJF54f3Ae4BLutqmZjydl2RLs/16fnLG0/PozHh6Xk9HK2neLDZIal2Sg4EPAa+tqm91PpCYuesMbfWIhqqtwFaA0dHRGhsba2mk+zY+Pk4vztML7770Ss7fvvzT/eb1k0MRB/Q3lp1njvXlvOaF/evlTINh+X0aljhg5eWFqvpMU4Ds5ownaYgMR3aWNDCSPJrOG4pLq+rDTfN9U38UJDkC2NO07wKO6nr6kcC9vRutpF4wL0iao0XNeILez3pabjMhZ5s9MywzhYYlDphfLIP4c2ixQVJrmmsqLwRur6q3de3aBmwEzmu+X9nV/uokl9GZDrnXTymk4WJekNSCOc14gt7PelpuMyFnm0E1LDOFhiUOmF8s/Zq5OJvheBUkDYoTgJcD25Pc1LT9MZ03E5cnORu4Czi92Xc1ncWedtBZ8OmVvR2upB4wL0iaK2c8SUPEYoOk1lTVZ5n50weAE2foX8A5SzooSX1lXpA0D854koaIxQZJkiRJPZXkA3QWgzwsyS7gXJzxJA0Viw2SJEmSeqqqXraPXc54kobEo/o9AEmSJEmSNFyc2SBpKK1d5P3qN6+f7Ok975fS5vX9HoEkSVqIxf49I/WTMxskSZIkSVKrLDZIkiRJkqRWWWyQJEmSJEmtstggSZIkSZJaZbFBkiRJkiS1ymKDJEmSJElqlcUGSZIkSZLUKosNkiRJkiSpVav6PQBJkiRJkrRwa7dc1erxdp73okUfw5kNkiRJkiSpVRYbJEmSJElSq7yMQpIkSZJa0PZUdmk5c2aDJEmSJElqlcUGSZIkSZLUKosNkiRJkiSpVa7ZIEmSVoTFXku9ef0kZ3k9tiRJc+LMBkmSJEmS1CqLDZIkSZIkqVUWGyRJkiRJUqt6XmxIcnKSLyfZkWRLr88vafCYFyRNZ16QNJ15QVpeerpAZJIDgPcCvwrsAm5Isq2qbuvlOCQNDvOCpOnMC5KmW6q84MKx0tLp9cyG44AdVXVnVf0AuAzY0OMxSBos5gVJ05kXJE1nXpCWmVRV706WvBQ4uap+p9l+OfC8qnp1V59NwKZm8+nAl3swtMOAb/TgPL0wLLEMSxywPGJ5alX9VD9ObF7oiWGJZVjigOURi3nhkZbD6zZXwxLLsMQByyOWgc4LTXuvc8NyeN3malhiGZY4YHnEss+80NPLKIDM0PYT1Y6q2gps7c1wOpJ8rqpGe3nOpTIssQxLHDBcsSwR88ISG5ZYhiUOGK5Yloh5YYkNSyzDEgcMVyxLZL95AXqfG4bpdRuWWIYlDlj+sfT6MopdwFFd20cC9/Z4DJIGi3lB0nTmBUnTmRekZabXxYYbgHVJjk5yIHAGsK3HY5A0WMwLkqYzL0iazrwgLTM9vYyiqiaTvBr4OHAAcFFV3drLMexDT6dhLrFhiWVY4oDhiqV15oWeGJZYhiUOGK5YWmde6IlhiWVY4oDhiqV15oWeGJZYhiUOWOax9HSBSEmSJEmSNPx6fRmFJEmSJEkachYbJEmSJElSq1ZssSHJUUk+leT2JLcmeU2/x7RYSQ5I8oUkH+33WBYjyeokVyT5UvP6PL/fY1qoJH/Q/HzdkuQDSR7b7zFp38wLg8u8oH4xLwwu84L6xbwwuMwLg2XFFhuASWBzVT0DOB44J8kxfR7TYr0GuL3fg2jBO4GPVdXPAc9mmcaUZA3w+8BoVT2LzmJGZ/R3VNoP88LgMi+oX8wLg8u8oH4xLwwu88IAWbHFhqraXVWfbx5/m84P4pr+jmrhkhwJvAj4m36PZTGSPBH4JeBCgKr6QVU92N9RLcoq4KAkq4DH4f2gB5p5YTCZF9RP5oXBZF5QP5kXBpN5YfCs2GJDtyRrgecC1/d3JIvyDuCPgH/v90AW6WeArwN/20zl+pskj+/3oBaiqu4B/gK4C9gN7K2qT/R3VJor88JAMS9oIJgXBop5QQPBvDBQzAsDZsUXG5IcDHwIeG1Vfavf41mIJC8G9lTVjf0eSwtWAccCF1TVc4HvAFv6O6SFSXIIsAE4Gvhp4PFJfqu/o9JcmBcGjnlBfWdeGDjmBfWdeWHgmBcGzIouNiR5NJ0EcWlVfbjf41mEE4CXJNkJXAa8IMn/6u+QFmwXsKuqpqrDV9BJGsvRrwBfqaqvV9UPgQ8Dv9jnMWk/zAsDybygvjIvDCTzgvrKvDCQzAsDZsUWG5KEzvU8t1fV2/o9nsWoqjdU1ZFVtZbOwiGfrKplV/kCqKqvAXcneXrTdCJwWx+HtBh3AccneVzz83Yiy3SRmpXCvDCYzAvqJ/PCYDIvqJ/MC4PJvDB4VvV7AH10AvByYHuSm5q2P66qq/s4JnX8HnBpkgOBO4FX9nk8C1JV1ye5Avg8nVWLvwBs7e+otB/mhcFlXlC/mBcGl3lB/WJeGFzmhQGSqur3GCRJkiRJ0hBZsZdRSJIkSZKkpWGxQZIkSZIktcpigyRJkiRJapXFBkmSJEmS1CqLDZIkSZIkqVUWG/QISX6U5KYktyT530lW76f/6iT/rWv7p5tbtUgaEuYFSdOZFyRNZ15QN299qUdIMlFVBzePLwb+rareMkv/tcBHq+pZvRmhpF4zL0iazrwgaTrzgro5s0H78y/AGoAkBye5Nsnnk2xPsqHpcx7ws00V88+TrE1yS/Ocs5J8OMnHktyR5H9OHTjJ2Un+Lcl4kr9O8p6eRydpIcwLkqYzL0iazrywwq3q9wA0uJIcAJwIXNg0fQ/4tar6VpLDgOuSbAO2AM+qquc0z1s77VDPAZ4LfB/4cpJ3Az8C/gQ4Fvg28Engi0sakKRFMy9Ims68IGk684LAYoNmdlCSm4C1wI3ANU17gD9L8kvAv9OpVI7M4XjXVtVegCS3AU8FDgM+XVX3N+3/APzHNoOQ1CrzgqTpzAuSpjMv6GFeRqGZfLepLj4VOBA4p2k/E/gp4Bea/fcBj53D8b7f9fhHdIpcaW+4knrAvCBpOvOCpOnMC3qYxQbtU1NF/H3gD5M8GngSsKeqfpjkl+kkEehMX3rCPA//r8B/TnJIklXAr7c1bklLx7wgaTrzgqTpzAsCiw3aj6r6Ap1roM4ALgVGk3yOTnXyS02fbwL/bzq3uPnzOR73HuDPgOuBfwZuA/a2H4GktpkXJE1nXpA0nXlB3vpSfZPk4KqaaCqSHwEuqqqP9HtckvrHvCBpOvOCpOnMC8uDMxvUT29sFpC5BfgK8I99Ho+k/jMvSJrOvCBpOvPCMuDMBkmSJEmS1CpnNkiSJEmSpFZZbJAkSZIkSa2y2KCHJXlfkj/p9zgkDQ7zgqTpzAuSwFyg/bPYsMIk2Znku0kmkjyQ5KokRwFU1e9W1Zt6NI5jknyuGcMDSf45yTFd+5PkrUm+2Xz9zyTpxdiklWZQ8sK0MZ2bpJL8SlfbY5JclORbSb6W5HW9Hpe0UgxSXkjyuCR/meQbSfYm+UzXPv9ekJbQoOSCJAcmuaIZTyUZm7Z/1lyQ5DlJbkzyUPP9Ob0Y90pnsWFl+i9VdTBwBHAf8O4+jOFe4KXAocBhwDbgsq79m4DTgGcDPw+8GHhVj8corSSDkBcASPKzdPLD7mm73gisA54K/DLwR0lO7u3opBVlUPLCVjp/Lzyj+f4HXfv8e0FaeoOSCz4L/BbwtRn27TMXJDkQuBL4X8AhwMXAlU27lpDFhhWsqr4HXAEcA5Dk/Une3DweS7IryeYke5LsTvLKqecmOTXJbUm+neSeJH84z3M/WFU7q3M7lAA/Ap7W1WUjcH5V7aqqe4DzgbMWE6+k/etnXujyHuD1wA+mtb8CeFNVPVBVtwN/jXlBWnL9zAtJng68BNhUVV+vqh9V1Y1dXfx7QeqRPr93+EFVvaOqPkvnfcN0s+WCMWAV8I6q+n5VvYvO+48XzGcMmj+LDStYkscBvwFct48uTwGeBKwBzgbem+SQZt+FwKuq6gnAs4BPNsf8D0kenOXrN6eN4UHge3QqpH/WteuZwBe7tr/YtElaQv3OC0lOB35QVVdPG9chwE9jXpB6rs954XnAV4H/kc5lFNuT/HrXuf17QeqRfv+NsB+z5YJnAjc3H3JOuRlzxZJb1e8BqC/+MckkcDCwB3jhPvr9EPjTqpoErk4yATydToL5IXBMki9W1QPAAwBVdReweq4DqarVSR5Ppxr51a5dBwN7u7b3AgcnybREIakdfc8LSQ6mU3Q8aYbdBzffp+eFJ+zvuJIWrO95ATiSzhuTD9EpOD4fuCrJbc0MJ/9ekJbeIOSC/dlnLphh39R+/4ZYYs5sWJlOq6rVwGOAVwOfTvKUGfp9s0kWUx7ix3/w/zpwKvDVJJ9O8vyFDqaqvgO8D7gkyeFN8wTwxK5uTwQm/MNBWjKDkBf+B/B3VfWVGfZNNN+n54Vvz/MckuZuEPLCd+m8SXlzM43608Cn+HFR0r8XpKU3CLlgf2bLBdP3Te33b4glZrFhBWuue/wwneue/tM8n3tDVW0ADgf+EbgcHp4KNTHL15n7OOSj4P9v7/6jLCvLA99/H2mNKEZg0Jq2YVJ4B02UjmhqGWZY16lIMoPiTeuMcuFygVYmnawLUTM1a2y9uVdvjLPaRHSMZpi0wgD3EoGgBsZ2GQnxXMe7BAUkNtgaEXuwoUMbRbA0gxY+94+zDx5On6o6VWefvffZ9f2s1avOec/+8bx1Tr193me/+315Gt1hVwB3053gpedFRZmkCaq5XTgdeGN0V5r4W+AE4LqIeEtxFeQgtgtS5WpuF768yin8viBVpGF9h0ErtQV3A79YjHLo+UVsKybOZMMGFl3b6M7Kum8N+z0lIs6NiGdm5o+BRygmasnM+zLzqBX+XV0c49ci4sURcURE/CzwXrrDqXpxXAX8m4jYEhHPARaAK8qqu6Th6mwX6CYbTgZOKf49QHcm6T8uXr8K+N2IOCYifh74DWwXpImruV34LHAf8NaI2BQRp9Gd7O0vitf9viBVpOa2oLcE9lOLp0+JiKf2JRBWags6xfneWBzj4qL8r9b1i9DInLNhY/ovEfEYkHTnSbggM++OtS1LfR7wwYg4Avga3WVo1uJoupNCHk93iOQXgTOKWW4B/gR4LrC3eP7hokzSZNTeLmTmd/qfF/E8lJm9WyjeDlxaxPf3wLsz81NrOYekNWlCu/DjonPzYWBnEcf5mfnVYhO/L0iTV3tbUPga3eWv4acJxxOB/azQFmTmjyLi1UXZLrqJkldn5uCqVypZeEubJEmSJEkqk7dRSJIkSZKkUplskCRJkiRJpTLZIEmSJEmSSmWyQZIkSZIklarRq1Ecd9xxOTs7O/Hz/OAHP+DpT3/6xM9ThbbUpS31gOmoy+233/53mfmsuuMYhe3C2rWlLm2pB0xHXWwXDjcN79uo2lKXttQDpqMu09QuQDVtwzS8b6NqS13aUg+Yjrqs1C40OtkwOzvLbbfdNvHzdDod5ufnJ36eKrSlLm2pB0xHXSLiv9Udw6hsF9auLXVpSz1gOupiu3C4aXjfRtWWurSlHjAddZmmdgGqaRum4X0bVVvq0pZ6wHTUZaV2wdsoJEmSJElSqUw2SJIkSZKkUplskCRJkiRJpTLZIEmSJEmSSmWyQZIkSZIklcpkgyRJkiRJKpXJBkmSJEmSVCqTDZIkSZIkqVQmGyRJkiRJUqk21R2ANAmzO/cMLd+/68yKI5HUJMPaBtsFaePqbxNsCyTBT9sF24TxObJBkiRJkiSVymSDJEmSJEkqlckGSZIkSZJUKpMNkiRJkiSpVCYbJEmSJElSqUw2SJIkSZKkUplskCRJkiRJpVp3siEinhoRX4iIv46IuyPi/yrKT4yIWyPi6xFxbUQ8pSj/meL5PcXrs+VUQZIkSZIkNck4IxseBV6emS8CTgHOiIhTgXcD78vMk4CHgAuL7S8EHsrMfwy8r9hOkiRJkqRGm925h9mde+oOY6qsO9mQXYvF0ycX/xJ4OXB9UX4l8Ori8bbiOcXrp0dErPf8kiSp+SLihIj4TETsK0ZCvqkoPzYibipGQt4UEccU5RERf1SMhPxyRLyk3hpIkqT12DTOzhFxBHA78I+BPwa+AXwvM5eKTQ4AW4rHW4BvAWTmUkQ8DPwD4O8GjrkD2AEwMzNDp9MZJ8SRLC4uVnKeKrSlLuPWY2Hr0tDyOn43bXlPJGmdloCFzLwjIp4B3B4RNwHbgZszc1dE7AR2Am8BXgGcVPz7ZeDS4qckSZoiYyUbMvMx4JSIOBr4OPALwzYrfg4bxZCHFWTuBnYDzM3N5fz8/DghjqTT6VDFearQlrqMW4/tywxx2n/u+o+5Xm15T0YREScAVwH/EPgJsDsz3x8RxwLXArPAfuCszHyoGN30fuCVwA+B7Zl5Rx2xS5qMzDwIHCwefz8i9tG9ALENmC82uxLo0E02bAOuyswEbomIoyNic3EcSZI0JcZKNvRk5vciogOcChwdEZuK0Q3HAw8Umx0ATgAORMQm4JnAd8s4v6TG8AqmpGUVk0O/GLgVmOklEDLzYEQ8u9js8ZGQhd4oySckGxwJOZ621KXMkZB1/z7a8p5IUs+6kw0R8Szgx0Wi4UjgV+lO+vgZ4LXANcAFwA3FLjcWzz9fvP5XxVULSS3hFUxJy4mIo4CPAm/OzEdWmLbJkZAVaEtdyhwJWcfox35teU8kqWeckQ2bgSuLeRueBFyXmZ+IiK8A10TE7wNfAi4rtr8M+L8j4h66IxrOHuPckhrOK5jN0Za6lFGPYfO5OJfL5EXEk+kmGq7OzI8VxQ/2kosRsRk4VJT3RkL29I+SlCSpUq5AsX7rTjZk5pfpdiQGy+8FXjqk/L8Dr1vv+SRND69gNktb6lJGPYbN5+JcLpNVzM1yGbAvM9/b91JvxOMuDh8JeXFEXEP3tqqHHe0kSdL0KWXOBknq8QqmpAGnAecBeyPizqLsbXSTDNdFxIXAffz0gsQn6U4aew/diWNfX224kiSpDCYbJJXGK5iSBmXm5xg+igng9CHbJ3DRRIOSJEkTZ7JBG8pK91zt33VmhZG0llcwJUnSqiLicuBVwKHMPLkoc6lsqUVMNkgqjVcwJUnSiK4APghc1Ve2E5fKVk2cCLJ8T6o7AEmSJEkbS2Z+lu4Kdf220V0im+Lnq/vKr8quW4CjizmgJDWYIxvUaN72IEmSRtH/ncHvCFNrrKWyofrlstu0lHFb6tJfj733PwzA1i3PPGy7wdcGl8fuHWO58uWOU6Zpf09MNkiSpt6wxKSdDUlqjZGWyobql8tu01LGbalLfz16S14PW+Z68LXB5bFXK1/uOGWa9vfEZIMkaap4T6UktZZLZUst4pwNkiRJkpqgt1Q2HL5U9vnRdSoulS1NBUc2SJIkSapURHwEmAeOi4gDwNtxqWypVUw2SJI2NOd7kKTqZeY5y7zkUtlSS3gbhSRJkiRJKpXJBkmSJEmSVCpvo5AktdI4q1Z4a4UkSdJ4HNkgSZIkSZJK5cgGSZIkaQX9o50c5SRJo3FkgyRJkiRp6s3u3MPe+x+uOwwVTDZIkiRJkqRSmWyQJEmSJEmlMtkgSZIkSZJKZbJBkiRJktRqszv3jLUsttbOZIMkSZqYiLg8BaLSBAAAIABJREFUIg5FxF19ZddGxJ3Fv/0RcWdRPhsRf9/32n+qL3JJkjQOl76UVJqIuBx4FXAoM08uyq4Fnl9scjTwvcw8JSJmgX3A14rXbsnM36o2YkkVuAL4IHBVryAz/+fe44i4BOifOvwbmXlKZdFJklrPEQ31MNkgqUxXYKdCUp/M/GyRXDxMRARwFvDyKmOSJEmTZ7JBUmnsVEhao/8ReDAzv95XdmJEfAl4BPjdzPyvw3aMiB3ADoCZmRk6nc6kY2VxcbGS81ShLXXpr8fC1qXHy0et26j7rOfYa9WW90SSekw2SKqKnYqatKUuvXr0f+mvUpm/w7a8JyU4B/hI3/ODwD/KzO9ExC8Bfx4RL8zMRwZ3zMzdwG6Aubm5nJ+fn3iwnU6HKs5ThbbUpb8e2/uGSe8/d36k/UfdZz3HXqu2vCeS1GOyQVJV7FTUpC116dVje033XZbZwWjLezKOiNgE/Evgl3plmfko8Gjx+PaI+AbwPOC2WoKUJEnr5moUkiaur1Nxba8sMx/NzO8Uj28Hep0KSRvDrwJfzcwDvYKIeFZEHFE8fi5wEnBvTfFJkqQxrDvZEBEnRMRnImJfRNwdEW8qyt8REff3LVv1yr593hoR90TE1yLiX5RRAUlTwU6F1q23Lvbe+x92NukpFBEfAT4PPD8iDkTEhcVLZ/PE0U4ALwO+HBF/DVwP/FZmfre6aCVJUlnGuY1iCVjIzDsi4hnA7RFxU/Ha+zLzPf0bR8QL6H6xeCHwHOAvI+J5mfnYGDFIapCiUzEPHBcRB4C3Z+ZlLN+p+L2IWAIew06F1EqZec4y5duHlH0U+OikY5IkSZO37mRDZh6ke881mfn9iNgHbFlhl23ANcX9mN+MiHuAl9K92iGpBexUSJIkSYKSJogslrp7MXArcBpwcUScT3dCp4XMfIhuIuKWvt0OMCQ54azz42lLXUaZdX7UJapG5VJWkiRJklSOsZMNEXEU3auTb87MRyLiUuCdQBY/LwHeAMSQ3fOwAmedH0tb6jLKrPOjLlE1KpeykiRJkqRyjLUaRUQ8mW6i4erM/BhAZj6YmY9l5k+AD9G9VQK6IxlO6Nv9eOCBcc4vSZIkSZKaZ5zVKAK4DNiXme/tK9/ct9lrgLuKxzcCZ0fEz0TEiXRnnv/Ces8vSZIkSZKaaZzbKE4DzgP2RsSdRdnbgHMi4hS6t0jsB34TIDPvjojrgK/QXcniIleikCRJkiRNu97y3Pt3nVlzJM0xzmoUn2P4PAyfXGGfdwHvWu85JUmSJElS85WyGoUkSZIkSdNmdh0Ty2s0JhskSRrBsC8jDpWUJEkabqzVKCRJkiRJUtfszj2OliiYbJAkSZIkSaUy2SBJkiRJ0ggcuTA6kw2SJEmSJKlUThCpyqyUAXSSNUmSJElqD5MNkiRJaqz+ixVenJCk6WGyQZLUGN4DKUmKiN8B/jWQwF7g9cBm4BrgWOAO4LzM/FFtQUpalXM2SJIkSWqEiNgCvBGYy8yTgSOAs4F3A+/LzJOAh4AL64tS0ihMNkiSJElqkk3AkRGxCXgacBB4OXB98fqVwKtrik3SiLyNQpIkSVIjZOb9EfEe4D7g74FPA7cD38vMpWKzA8CWYftHxA5gB8DMzAydTmei8S4uLk78HFWZxrrsvf9hALZueSYAC1uXmDmSx+uxsHXpsH1Wem0t2632+geuvuEJsa3HNL4n/Uw2SJKkiYqIy4FXAYeKYdFExDuA3wC+XWz2tsz8ZPHaW+kOkX4MeGNm/kXlQUuqRUQcA2wDTgS+B/wZ8Iohm+aw/TNzN7AbYG5uLufn5ycTaKHT6TDpc1RlGuuyvZjraf+5848/X9i6xFnz8094vV//titZbbu1Hmc9pvE96WeyQRrBcpPWOSv24exUSBriCuCDwFUD5e/LzPf0F0TEC+jen/1C4DnAX0bE8zLzsSoClVS7XwW+mZnfBoiIjwH/FDg6IjYVoxuOBx6oMUZJI3DOBklluwI4Y0j5+zLzlOJfL9HQ36k4A/iPEXFEZZFKqkRmfhb47oibbwOuycxHM/ObwD3ASycWnKSmuQ84NSKeFhEBnA58BfgM8NpimwuAG2qKT9KIHNkgqVSZ+dmImB1x88c7FcA3I6LXqfj8hMKT1CwXR8T5wG3AQmY+RPc+7Fv6thl6b3bV92XD9N8722+a6tJ/P/RgzP31WGm79Rx7PduNY5rek0nKzFsj4nq6y1suAV+ie1vEHuCaiPj9ouyy+qJU1XqjjJcbVezS2c1kskFSVexU1GSa6rLSZE0zR64+mVPV1vt7nab3ZIIuBd5J977rdwKXAG8AYsi2h92bXfV92TD99872m6a69N8PPXjvc389VtpuPcdez3b9HZ613mo5Te/JpGXm24G3DxTfi6OcpKliskFSFexU1Gia6rLSJEsLW5e4ZG+z/tta76RP0/SeTEpmPth7HBEfAj5RPD0AnNC3qfdmS5KewJEM08E5GyRNXGY+mJmPZeZPgA/x0ysTdiqkDSoiNvc9fQ1wV/H4RuDsiPiZiDgROAn4QtXxSZKk8TTrEpGkVoqIzZl5sHg62Kn404h4L91Z5+1USC0UER8B5oHjIuIA3eHR8xFxCt3RTPuB3wTIzLsj4jq6E8ItARe5EoUkqS1Wm3+iTUw2SCqVnQpJgzLznCHFy07ulpnvAt41uYgkSdKkmWyQVCo7FZIkSZJMNkiStE7DJqjaCMMiJUmSVuMEkZIkSZIkqVSObJAk1cJlqyRJktrLkQ2SJEmSJKlUJhskSZIkSVKpTDZIkiRJkqRSmWyQJEmSJEmlWneyISJOiIjPRMS+iLg7It5UlB8bETdFxNeLn8cU5RERfxQR90TElyPiJWVVQpIkSZIkNcc4IxuWgIXM/AXgVOCiiHgBsBO4OTNPAm4ungO8Ajip+LcDuHSMc0uSJEmSpIZad7IhMw9m5h3F4+8D+4AtwDbgymKzK4FXF4+3AVdl1y3A0RGxed2RS5IkSZKkRtpUxkEiYhZ4MXArMJOZB6GbkIiIZxebbQG+1bfbgaLs4MCxdtAd+cDMzAydTqeMEFe0uLhYyXmq0OS6LGxdWva1wZh79VjLPqOeq8zjjfK7bvJ7IkmSJEmTMHayISKOAj4KvDkzH4mIZTcdUpaHFWTuBnYDzM3N5fz8/LghrqrT6VDFearQ5Lps37ln2df2nzv/hOe9eqxln1HPVebxVtqnp8nviSRJkiRNwljJhoh4Mt1Ew9WZ+bGi+MGI2FyMatgMHCrKDwAn9O1+PPDAOOeXJEmSJKnpZtdxMXTajbMaRQCXAfsy8719L90IXFA8vgC4oa/8/GJVilOBh3u3W0iSJEmSpPYYZ2TDacB5wN6IuLMoexuwC7guIi4E7gNeV7z2SeCVwD3AD4HXj3FuSZIkSZLUUOtONmTm5xg+DwPA6UO2T+Ci9Z5PkiRJkiRNh3XfRiFJkiRJksY3u3NP6+Z1KGXpS6lf2/5IJEnrFxGXA68CDmXmyUXZHwL/E/Aj4BvA6zPze8VS2vuArxW735KZv1V50JIkaWyObJAkSZN0BXDGQNlNwMmZ+YvA3wBv7XvtG5l5SvHPRIMkSVPKkQ2SSuMVTEmDMvOzxd97f9mn+57eAry2ypjUDP0jIffvOrPGSCQ1Ra9dsE1oB5MNksp0BfBB4Kq+spuAt2bmUkS8m+4VzLcUr30jM0+pNkRJDfMG4Nq+5ydGxJeAR4Dfzcz/OmyniNgB7ACYmZmh0+lMOk4WFxcrOU8VmlCXha1Ljz9eKZaVtuuvx6jHKzuG9Ww3TBPeE0kqk8kGTS3nhmger2BqOf69apiI+N+BJeDqougg8I8y8zsR8UvAn0fECzPzkcF9M3M3sBtgbm4u5+fnJx5vp9OhivNUoQl12d4/suHc+XVt11+PUY9Xdgzr2W6YJrwnUtP4/WG6mWyQVCWvYNagCXXpv9q3XjNHlnOcSRvld92E96RuEXEB3duuTi+WxyYzHwUeLR7fHhHfAJ4H3FZboJIkaV1MNkiqhFcw69OEumwv4crEwtYlLtnb/P+2Rrma2YT3pE4RcQbd26n+WWb+sK/8WcB3M/OxiHgucBJwb01hSpKkMbgahaSJ67uCeW7/FczM/E7x+Ha6k0c+r74oJU1CRHwE+Dzw/Ig4EBEX0p3b5RnATRFxZ0T8p2LzlwFfjoi/Bq4Hfiszv1tL4JIkaSzNv0Qkaap5BVPa2DLznCHFly2z7UeBj042IkmSVAWTDZJKU1zBnAeOi4gDwNvprj7xM3SvYMJPl7h8GfB7EbEEPIZXMCVJkqTWMNkgqTRewZQkSZIEztkgSZIkqUEi4uiIuD4ivhoR+yLin0TEsRFxU0R8vfh5TN1xSlqZyQZJkiRJTfJ+4FOZ+fPAi4B9wE7g5sw8Cbi5eC6pwbyNQo0wO7As3sLWpVKWypMkSdL0iIifpTuv03aAzPwR8KOI2EZ3XiiAK4EO3QmoJTWUyQZJkiRJTfFc4NvAf46IFwG3A28CZjLzIEBmHoyIZw/bOSJ2ADsAZmZm6HQ6Ew12cXFx4ueoShPqsrB1CYAPXH1D8fyJr/fi6203zMyRK283yjFG2W7c4wz+rnuv95c34T0Zh8kGqTA4ukKSJEmV2wS8BPjtzLw1It7PGm6ZyMzdwG6Aubm5nJ+fn0iQPZ1Oh0mfoypNqMtqI5v3nzu/6nYLW5c4a3757UY5xijbjXucXnlP7/X+8ia8J+NwzgZJkiRJTXEAOJCZtxbPr6ebfHgwIjYDFD8P1RSfpBGZbJAkSZLUCJn5t8C3IuL5RdHpwFeAG4ELirILgBtqCE/SGngbhSRJJRp2S9b+XWfWEIkkTa3fBq6OiKcA9wKvp3uR9LqIuBC4D3hdjfFJGoHJBkmSJEmNkZl3AnNDXjq96lgkrZ+3UUiSJEmSpFKZbJAkSZIkSaUy2SBJkiRJkkplskGSJEmSJJXKZIMkSZIkSSqVq1FIkiRJfYYtYStJWhtHNkiSJEmSpFKNlWyIiMsj4lBE3NVX9o6IuD8i7iz+vbLvtbdGxD0R8bWI+BfjnFuSJEmSJDXTuLdRXAF8ELhqoPx9mfme/oKIeAFwNvBC4DnAX0bE8zLzsTFjkCRJDRYRlwOvAg5l5slF2bHAtcAssB84KzMfiogA3g+8EvghsD0z76gjbm0s3johSeUaa2RDZn4W+O6Im28DrsnMRzPzm8A9wEvHOb+k5llmxNOxEXFTRHy9+HlMUR4R8UfFiKcvR8RL6otc0gRdAZwxULYTuDkzTwJuLp4DvAI4qfi3A7i0ohglSVKJJjVB5MURcT5wG7CQmQ8BW4Bb+rY5UJQ9QUTsoPvlgpmZGTqdzoRC/KnFxcVKzlOFJtRlYevS2MeYObKc40zaKL/rJrwnFbuCw0c89ToVuyJiZ/H8LTyxU/HLdDsVv1xptJImLjM/GxGzA8XbgPni8ZVAh267sA24KjMTuCUijo6IzZl5sJpopWr1RlQsbF16/A9CktpgEsmGS4F3Aln8vAR4AxBDts3DCjJ3A7sB5ubmcn5+fgIhPlGn06GK81ShCXXZXsIwxIWtS1yyt/mLpew/d37VbZrwnlTJToV0uMHh2XYqAJjp/a1n5sGIeHZRvgX4Vt92vYsTT2gXvDgxnibUpf+iwkqxrLRdfz2W227v/Q8//njrlmcue+xRrTfW1faZOXL0fSRpGpTem8vMB3uPI+JDwCeKpweAE/o2PR54oOzzS2okOxU1akJdNtKIp1HYqViRFycq0IS69F+cWCl5v9J2/fVYbruV9l/PBZL1xrraPgtblzirJZ8vSYIJJBsGrkq+Bujdt30j8KcR8V66E0SeBHyh7PNLmip2KirQhLpspBFPo7BTAcCDve8MEbEZOFSUe3FCkqQWGHfpy48AnweeHxEHIuJC4A8iYm9EfBn4FeB3ADLzbuA64CvAp4CLXIlC2jAeLDoT2KmQVLgRuKB4fAFwQ1/5+cUEsqcCD3trlSRpo5nduecJt4FNo7EuEWXmOUOKL1th+3cB7xrnnJKmUq9TsYvDOxUXR8Q1dCeGtFMhtVBxcWIeOC4iDgBvp9seXFdcqLgPeF2x+SfpLnt5D92lL19fecCSJGls7RiPKqkx7FRIGrTMxQmA04dsm8BFk41IkqRmGpxUepqZbJBUKjsVkqQqzO7cw8LWpVLmhJEklW+sORskSZIkSZIGObJBkiRJrdKmYciSNK0c2SBJkiRJkkplskGSJEmSJJXKZIMkSZIkSSqVyQZJkiRJklQqkw2SJEmSJFVoduee1k9m62oU0oT0Go/BNcD37zqzrpAkSZIkqRKObJAkSZIkSaVyZIMkSZI0ollHK0rL6v199P42Bp9rYzHZIEmSpA2h7fdHS1KTmGzQslb6D9nspCQY3k7YPkgby2A7sJHaAJMX0vps5HZjIzHZIEkaiV+qJUmSNConiJQkSZIkSaUy2SBJkiRJkkplskGSJEmSJJXKORskSYdxfgZJUl0i4gjgNuD+zHxVRJwIXAMcC9wBnJeZP6ozRkmrc2SDJEmSpCZ5E7Cv7/m7gfdl5knAQ8CFtUSlsc3u3OMFjQ3EkQ2SJKkWEfF84Nq+oucC/ydwNPAbwLeL8rdl5icrDk81WakjYiel/SLieOBM4F3Av4mIAF4O/C/FJlcC7wAurSVASSMz2SCpEnYqJA3KzK8Bp8Djw6bvBz4OvJ7uVcz31BiepHr8B+DfAc8onv8D4HuZuVQ8PwBsWW7niNgB7ACYmZmh0+lMLlJgcXFx4ueoShl1WdjafZt6x1nu+aDVXl/LdjNHrrxdWeeq4jj9dZlGJhukMXiFZXR2KiSt4nTgG5n537oXMqXp1v8dYf+uM2uMZHpExKuAQ5l5e0TM94qHbJrLHSMzdwO7Aebm5nJ+fn65TUvR6XSY9DmqUkZdthef+/3nzq/4fNBqr69lu4WtS5w1v/x2ZZ2riuP012UamWyQVAc7FZIGnQ18pO/5xRFxPt1J4hYy86H+jau+eglewVzO4NW4UY/bv1//PqtdJew3c+Tatq/LSr+TXvzTfgWzJKcBvx4RrwSeCvws3ZEOR0fEpmJ0w/HAAzXGqBF4QU5gskFSPexUVGg9dRnny/uwc5XRGZiWTsUo7FQ8UUQ8Bfh14K1F0aXAO+levXwncAnwhv59qr56CV7BXM7g1bjeVbq17Ne/z2pXCfstbF3ikr3N/zq70u+kV99pv4JZhsx8K0U7UIxs+LeZeW5E/BnwWrorUlwA3FBbkJJG1vzWWVKr2Kmo3nrqspYv+4OGfake53g909KpGIWdisO8ArgjMx8E6P0EiIgPAZ+oKzBJjfAW4JqI+H3gS8BlNccjaQTt+NYmaZrYqZA06Bz6RjtFxObMPFg8fQ1wVy1RSapNZnaATvH4XuCldcYjae1MNkiqmp0KSY+LiKcBvwb8Zl/xH0TEKXRHPO0feE2SJE0Bkw2SKmOnQtKgzPwh3aXt+svOqykcSZJUkrGSDRFxOdBboubkouxY4Fpglm7H4azMfCi6U86/H3gl8ENge2beMc75JU0XOxWSJEnSxvCkMfe/AjhjoGwncHNmngTcXDyH7n3aJxX/dtCdFE6SJEmSJLXMWMmGzPws8N2B4m3AlcXjK4FX95VflV230F0vd/M455ckSZIkSc0ziTkbZnqTvWXmwYh4dlG+BfhW33YHirKD/TtHxA66Ix+YmZmpZB3y9axB31Rl1mWl9exXOsdK+41q5shyjtMEg3Vpy2dNkiStz2wJywFLTeJnWsNUOUFkDCnLwwoydwO7Aebm5rKKde7XswZ9U5VZl+0rNBr7z13+HCvtN6qFrUtcsrcd85cO1mWl350kSZIktcEkenMP9payK26TOFSUHwBO6NvueOCBCZxfkiRJU8SropI0ml57uX/XmTVHsrpxJ4gc5kbgguLxBcANfeXnR9epwMO92y0kSZIkSVJ7jLv05UeAeeC4iDgAvB3YBVwXERcC9wGvKzb/JN1lL++hu/Tl68c5tyRJ02zYldxpuEohSZI0irGSDZl5zjIvnT5k2wQuGud8kiRJkiSp+SZxG4UkSZIkSdrATDZIkiRJkqRSmWyQJEmSJEmlmsTSl9oAXKJKkiRJkrQcRzZIkiRJkqRSmWyQJEmSJKmBZnfumdpR5SYbJEmSJElSqUw2SJIkSZKkUplskCRJkiRJpXI1Ck3tPUCSJEmSpGYy2SBVbKXkzv5dZ1YYiSTVLyL2A98HHgOWMnMuIo4FrgVmgf3AWZn5UF0xSpKktfM2CkmViYj9EbE3Iu6MiNuKsmMj4qaI+Hrx85i645RUuV/JzFMyc654vhO4OTNPAm4unkuSpCliskFS1exUSFrNNuDK4vGVwKtrjEWSJK2Dt1FIqts2YL54fCXQAd5SVzCSKpfApyMigT/JzN3ATGYeBMjMgxHx7MGdImIHsANgZmaGTqcz8UAXFxcrOU8VyqzLwtalJzwf9biD+63HzJHlHGfSBn8nw2KeOXL0350kTQOTDZKqZKeiBuupyzhf3oedayN1KkaxXF3a8plbo9My84Hib/+miPjqKDsV7cdugLm5uZyfn59giF2dTocqzlOFMuuyfWAuov3njnbcwf3WY2HrEpfsbf7X2cHfybC6L2xd4qyWfL4kCUw2SKqWnYoarKcu43QChnU0NlKnYhTL1WXUTlqbZOYDxc9DEfFx4KXAgxGxuUhAbgYO1RqkJElas3Z8a9OqXN5STWCnQlK/iHg68KTM/H7x+J8DvwfcCFwA7Cp+3lBflJIkaT1MNkiqhJ0KSUPMAB+PCOh+J/nTzPxURHwRuC4iLgTuA15XY4wbWv/FCpdnXj8v+mja9T7DvXZg8Lnq0+T3wmSDpKrYqWgovwSrLpl5L/CiIeXfAU6vPiJJklQWkw2SKmGnQlrdsMRPE69USCYpq+coE0nTxmSDJKlUdkIk9dgeSNLG9aS6A5AkSZIkSe3iyAZJkiRJ0qocraS1MNkgSZKk0tgZ0Tgi4gTgKuAfAj8Bdmfm+yPiWOBaYBbYD5yVmQ/VFaek1ZlskCRJktQUS8BCZt4REc8Abo+Im4DtwM2ZuSsidgI7gbfUGKdUq2lI7DpngyRJkqRGyMyDmXlH8fj7wD5gC7ANuLLY7Erg1fVEKGlUjmyQJEmS1DgRMQu8GLgVmMnMg9BNSETEs5fZZwewA2BmZoZOpzPRGBcXFyd+jqosLi7ygatvAGDrlmc+4bWFrUtD9+nVfbnXR92urOMAzBy58nZNi3ml12eO/Gn5qMdpEpMNkiRJkholIo4CPgq8OTMfiYiR9svM3cBugLm5uZyfn59YjNDt4E36HFXpdDpc8rkfALD/3PknvLZ9mSH7ve2We33U7co6DnQ742fNL79d02Je6fWFrUtcsnfTmo7TJBO7jSIi9kfE3oi4MyJuK8qOjYibIuLrxc9jJnV+SZIkSdMnIp5MN9FwdWZ+rCh+MCI2F69vBg7VFV8Tze7cMxX38GtjmfScDb+Smadk5lzxfCfdiV1OAm4unkuSJEkS0R3CcBmwLzPf2/fSjcAFxeMLgBuqjk3S2lR9G8U2YL54fCXQwVlkJUmSGs+rpqrIacB5wN6IuLMoexuwC7guIi4E7gNeV1N8kkY0yWRDAp+OiAT+pLh/atWJXaqe1AXaN7HLsLqsNnFJ0/RPhjLt1lKXtnwOJUnSeDZqciczPwcsN0HD6VXGImk8k0w2nJaZDxQJhZsi4quj7FT1pC7QvoldhtVltYlLmqZ/MpRpt5a6NHFiF0mSJElaq4n15jLzgeLnoYj4OPBSioldilENTuwiSRXbqFfKJEmSVK2JTBAZEU+PiGf0HgP/HLgLJ3aRJEmq3d77H3b2eknSRE1qZMMM8PFiPdxNwJ9m5qci4os4sYskjWxYR2D/rjPXtO/C1qWpu5VKkjYikz+S2mQiyYbMvBd40ZDy7+DELpIkSZIktdpEbqOQJEmSJEkbl8kGSRMXESdExGciYl9E3B0RbyrK3xER90fEncW/V9Ydq6Rq2C5IktRu7VhbUFLTLQELmXlHMXns7RFxU/Ha+zLzPTXGJqketguSVLPePCGjzgclrYXJhpbZe//DTgSnxsnMg8DB4vH3I2IfsKXeqCTVyXZBkqR2M9kgqVIRMQu8GLgVOA24OCLOB26je5XzoSH77AB2AMzMzNDpdCYe5+LiYiXnWc3C1qXDykaNq7fvzJHDjzNt2lIPWFtdmvA5nDTbher1fwZXqlPT/+ZsF7TRuYKJBjVptIrJBkmViYijgI8Cb87MRyLiUuCdQBY/LwHeMLhfZu4GdgPMzc3l/Pz8xGPtdDpUcZ7VDBuptP/c+cPKhn/Z6DbxC1uXuGTv9Df3bakHrK0uw97vNrFdqMcHrr7h8c9g/2fs8Lak2X9ztguS1FxOECmpEhHxZLodiqsz82MAmflgZj6WmT8BPgS8tM4YJVXLdkGSyjW7c4+jHdQYJhskTVxEBHAZsC8z39tXvrlvs9cAd1Udm6R62C5IktRu7Rh3NsWWyzw24R4bqUSnAecBeyPizqLsbcA5EXEK3eHS+4HfrCc8STWwXZCkiqx2H//szj3FnCF2D1UeP00NtdLwJxMRmjaZ+Tkghrz0yapjkabNsP8P2vD/gO2CJEntZrJBkhrCeywlSdIkNWmlArWfyQZJkqQp4uhHSdI0MNkgSVPGERCSJElqOpMNkiRNmbbO4yBpfP3tg+2CpDpvnTHZMIVWuqq5sLXCQCRJkiRJGsJkgzQlXCZVkiRJVXAiyek32Heo4z012SA1iPfiS5ImYfD/F0dCSpImzWSDJElSw5mMVj/nZZh+415lHrVNsO1QnZ5UdwCSJEmSJKldTDZIkiRJUoPM7tzjqARNVBWfMW+jkKQSuSShpDo5vF6S1BQmG0pi5lHSckxASFqrMr5X+N1Eqt5qczH4d6nHbxnDAAAH7klEQVSNxGTDECs1AnYQpI3JLweSBg22C35HkCTpp0w2rJEdDkmStF5NTFD43Wa6+f4106h/66ttN+6qFVKdTDZIUg38cqiyebtOc/n3LknaiEw2SJIk1cQJHTVJfr7awxEOmkYmGyRJkkrmaAZJ0kZnskGSBszu3MPC1iW221mQtAbjJhhMUEiS2sRkg6QNw3vatdH4mZe0HG+xWNmoS1j2Lk74O1RblHnLTuXJhog4A3g/cATw4czcVXUMPYONhDSN2rBUa5PaBUnNYLsgaZDtgjRdKk02RMQRwB8DvwYcAL4YETdm5lfGOa7DDqXpZbsgaVBV7UJ/Qnalq7xenJDq5/cFaTIm+TdQ9ciGlwL3ZOa9ABFxDbANGKuRkDTVbBckDaqkXbCToY2kBZ93vy9IUyYys7qTRbwWOCMz/3Xx/DzglzPz4r5tdgA7iqfPB75WQWjHAX9XwXmq0Ja6tKUeMB11+bnMfFYdJ7ZdqERb6tKWesB01MV24XDT8L6Nqi11aUs9YDrq0uh2oSivum2YhvdtVG2pS1vqAdNRl2XbhapHNsSQsidkOzJzN7C7mnC6IuK2zJyr8pyT0pa6tKUe0K66TIjtwoS1pS5tqQe0qy4TYrswYW2pS1vqAe2qy4Ss2i5A9W1Dm963ttSlLfWA6a/Lkyo+3wHghL7nxwMPVByDpGaxXZA0yHZB0iDbBWnKVJ1s+CJwUkScGBFPAc4Gbqw4BknNYrsgaZDtgqRBtgvSlKn0NorMXIqIi4G/oLtkzeWZeXeVMSyj0mGYE9aWurSlHtCuupTOdqESbalLW+oB7apL6WwXKtGWurSlHtCuupTOdqESbalLW+oBU16XSieIlCRJkiRJ7Vf1bRSSJEmSJKnlTDZIkiRJkqRSbdhkQ0ScEBGfiYh9EXF3RLyp7pjGFRFHRMSXIuITdccyjog4OiKuj4ivFu/PP6k7pvWKiN8pPl93RcRHIuKpdcek5dkuNJftgupiu9Bctguqi+1Cc9kuNMuGTTYAS8BCZv4CcCpwUUS8oOaYxvUmYF/dQZTg/cCnMvPngRcxpXWKiC3AG4G5zDyZ7mRGZ9cblVZhu9Bctguqi+1Cc9kuqC62C81lu9AgGzbZkJkHM/OO4vH36X4Qt9Qb1fpFxPHAmcCH645lHBHxs8DLgMsAMvNHmfm9eqMayybgyIjYBDwN14NuNNuFZrJdUJ1sF5rJdkF1sl1oJtuF5tmwyYZ+ETELvBi4td5IxvIfgH8H/KTuQMb0XODbwH8uhnJ9OCKeXndQ65GZ9wPvAe4DDgIPZ+an641Ko7JdaBTbBTWC7UKj2C6oEWwXGsV2oWE2fLIhIo4CPgq8OTMfqTue9YiIVwGHMvP2umMpwSbgJcClmfli4AfAznpDWp+IOAbYBpwIPAd4ekT8r/VGpVHYLjSO7YJqZ7vQOLYLqp3tQuPYLjTMhk42RMST6TYQV2fmx+qOZwynAb8eEfuBa4CXR8T/U29I63YAOJCZvezw9XQbjWn0q8A3M/Pbmflj4GPAP605Jq3CdqGRbBdUK9uFRrJdUK1sFxrJdqFhNmyyISKC7v08+zLzvXXHM47MfGtmHp+Zs3QnDvmrzJy6zBdAZv4t8K2IeH5RdDrwlRpDGsd9wKkR8bTi83Y6UzpJzUZhu9BMtguqk+1CM9kuqE62C81ku9A8m+oOoEanAecBeyPizqLsbZn5yRpjUtdvA1dHxFOAe4HX1xzPumTmrRFxPXAH3VmLvwTsrjcqrcJ2oblsF1QX24Xmsl1QXWwXmst2oUEiM+uOQZIkSZIktciGvY1CkiRJkiRNhskGSZIkSZJUKpMNkiRJkiSpVCYbJEmSJElSqUw2SJIkSZKkUpls0GEi4rGIuDMi7oqI/xIRR6+y/dER8b/1PX9OsVSLpJawXZA0yHZB0iDbBfVz6UsdJiIWM/Oo4vGVwN9k5rtW2H4W+ERmnlxNhJKqZrsgaZDtgqRBtgvq58gGrebzwBaAiDgqIm6OiDsiYm9EbCu22QX8D0UW8w8jYjYi7ir22R4RH4uIT0XE1yPiD3oHjogLI+JvIqITER+KiA9WXjtJ62G7IGmQ7YKkQbYLG9ymugNQc0XEEcDpwGVF0X8HXpOZj0TEccAtEXEjsBM4OTNPKfabHTjUKcCLgUeBr0XEB4DHgP8DeAnwfeCvgL+eaIUkjc12QdIg2wVJg2wXBCYbNNyREXEnMAvcDtxUlAfw7yPiZcBP6GYqZ0Y43s2Z+TBARHwF+DngOOD/zczvFuV/BjyvzEpIKpXtgqRBtguSBtku6HHeRqFh/r7ILv4c8BTgoqL8XOBZwC8Vrz8IPHWE4z3a9/gxukmuKC9cSRWwXZA0yHZB0iDbBT3OZIOWVWQR3wj824h4MvBM4FBm/jgifoVuIwLd4UvPWOPhvwD8s4g4JiI2Af+qrLglTY7tgqRBtguSBtkuCEw2aBWZ+SW690CdDVwNzEXEbXSzk18ttvkO8P9Fd4mbPxzxuPcD/x64FfhL4CvAw+XXQFLZbBckDbJdkDTIdkEufanaRMRRmblYZCQ/DlyemR+vOy5J9bFdkDTIdkHSINuF6eDIBtXpHcUEMncB3wT+vOZ4JNXPdkHSINsFSYNsF6aAIxskSZIkSVKpHNkgSZIkSZJKZbJBkiRJkiSVymSDJEmSJEkqlckGSZIkSZJUKpMNkiRJkiSpVP8/IU4DNRcExWUAAAAASUVORK5CYII=\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAABBsAAAJcCAYAAAC4z6wqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nOzdf5RlZX3n+/dHWhRFbZBQkoaxSewxoh2V1EUMszIVSRDQscmKTDBEG0NWmzWYaOys2GZWLk7ULJwEfxtMJxAhQ0SCGnqEqAQtvd4bCKJI80NDD7bQ0NIq0FrirzLf+8fZhceiurp+7Drn1Kn3a61adfazn7P38+1T9e063/PsZ6eqkCRJkiRJasuj+j0ASZIkSZI0XCw2SJIkSZKkVllskCRJkiRJrbLYIEmSJEmSWmWxQZIkSZIktcpigyRJkiRJapXFBu1Tkvcl+ZN+j0PS4DAvSJrOvCDJPKCZpKr6PQb1UZKdwAjwI+CHwP8H/G5V3d3jcRwPvAn4hWYs48DvV9XuXo5D0kDlhWOAS4CfbZpupJMXbuvlOCQNVF5YC3wF+E5X81ur6k29HIe0Eg1QHjgQ+HtgFHgq8MtVNd61P8B5wO80TRcCry/f+PacMxsE8F+q6mDgCOA+4N19GMMhwFZgLZ2k8W3gb/swDkkdg5AX7gVeChwKHAZsAy7rwzgkdQxCXpiyuqoObr4sNEi9Myh54LPAbwFfm2HfJuA04NnAzwMvBl7Vu6FpisUGPayqvgdcARwDkOT9Sd7cPB5LsivJ5iR7kuxO8sqp5yY5NcltSb6d5J4kfzjPc/9TVf1DVX2rqh4C3gOc0F50khaiz3nhwara2XwSETqfpDytteAkLUg/84KkwdDnvw9+UFXvqKrP0vnbYLqNwPlVtauq7gHOB85aWKRaDIsNeliSxwG/AVy3jy5PAZ4ErAHOBt6b5JBm34XAq6rqCcCzgE82x/wPSR6c5es393GuXwJubSk0SQs0CHkhyYPA9+h8evJnbccoaX4GIS8AX23ezPxtksPajlHS7AYkD+zLM4Evdm1/sWlTj63q9wA0EP4xySRwMLAHeOE++v0Q+NOqmgSuTjIBPJ1OkvkhcEySL1bVA8ADAFV1F7B6PoNJ8vPA/w1sWEgwkloxMHmhqlYneTydTyq+utCAJC3aIOSFbwD/F3AT8GTgvcCls4xFUrsGIQ/sz8HA3q7tvcDBSeK6Db3lzAYBnFZVq4HHAK8GPp3kKTP0+2aTMKY8ROeXGeDXgVPpfNLw6STPX8hAkjwN+CfgNVX1/yzkGJJaMTB5AaCqvgO8D7gkyeELPY6kRel7Xqiqiar6XFVNVtV9zThOSvLEeUcjaSH6ngfmYALozglPBCYsNPSexQY9rKp+VFUfpnPt03+a53NvqKoNwOHAPwKXw8PToSZm+Tpz6hhJngr8M/Cmqvq71gKTtGD9zgvTPAp4HJ0pmZL6ZMDywtSbhywwHEkLMGB5YLpb6SwOOeXZeHl2X3gZhR6WJMBL6NwZ4nY6K7fO5XkHAqcDH62qvUm+RbNYSzMd6uDZnt8cYw2d67XeW1XvW1gEktrW57zwq3SmTN8MPB54M52plrfPPxJJbelzXnge8CBwR3P+dwHjVbV31idKalU/80BznMfw4yLjgUkeC3y/mb1wCfC6JFfTKUhupr93z1mxLDYI4H8n+RGdX8avAhur6tZODpmzlwPvSXIA8GU6t6KZj98BfgY4N8m5U43NrXUk9d4g5IXVdP44OBL4LnADcHKzArak3huEvPAzdBaKPRz4FnAN8LJ5HkPSwg1CHqB53lObxx9vvh8N7AT+ik6u2N60/03Tph6Ll65IkiRJkqQ2uWaDJEmSJElqlcUGSZIkSZLUKosNkiRJkiSpVRYbJEmSJElSqwb6bhSHHXZYrV27dsnP853vfIfHP/7xS36eXhiWWIYlDlgesdx4443fqKqf6vc45sK8MH/DEsuwxAHLIxbzwiMth9dtroYllmGJA5ZHLMspL0BvcsNyeN3malhiGZY4YHnEMlteGOhiw9q1a/nc5z635OcZHx9nbGxsyc/TC8MSy7DEAcsjliRf7fcY5sq8MH/DEsuwxAHLIxbzwiMth9dtroYllmGJA5ZHLMspL0BvcsNyeN3malhiGZY4YHnEMlte8DIKSZIkSZLUqv0WG5IcleRTSW5PcmuS1zTtb0xyT5Kbmq9Tu57zhiQ7knw5yQu72k9u2nYk2bI0IUmSJEmSpH6ay8yGSWBzVT0DOB44J8kxzb63V9Vzmq+rAZp9ZwDPBE4G/jLJAUkOAN4LnAIcA7ys6ziSJEmSVogkf9B8kHlLkg8keWySo5Ncn+SOJB9McmDT9zHN9o5m/9r+jl7SXOy32FBVu6vq883jbwO3A2tmecoG4LKq+n5VfQXYARzXfO2oqjur6gfAZU1fSZIkSStEkjXA7wOjVfUs4AA6H1a+lc6HmeuAB4Czm6ecDTxQVU8D3t70kzTg5rVAZFNFfC5wPXAC8OokrwA+R2f2wwN0ChHXdT1tFz8uTtw9rf15M5xjE7AJYGRkhPHx8fkMcUEmJiZ6cp5eGJZYhiUOGK5YJEmSWrIKOCjJD4HHAbuBFwC/2ey/GHgjcAGdDyjf2LRfAbwnSaqqejlgSfMz52JDkoOBDwGvrapvJbkAeBNQzffzgd8GMsPTi5lnUTwiQVTVVmArwOjoaPVi9c3lsMrnXA1LLMMSBwxXLJIkSYtVVfck+QvgLuC7wCeAG4EHq2qy6db9geUamg8tq2oyyV7gycA3ph+71x9cDtOHSsMSy7DEAcs/ljkVG5I8mk6h4dKq+jBAVd3Xtf+vgY82m7uAo7qefiRwb/N4X+2SJEmSVoAkh9CZrXA08CDwD3TWdZtu6oPJfX2Y+cjGHn9wOUwfKg1LLMMSByz/WOZyN4oAFwK3V9XbutqP6Or2a8AtzeNtwBnNQi5HA+uAfwVuANY1C78cSOe6rG3thCFJkiRpmfgV4CtV9fWq+iHwYeAXgdVJpj4M7f5g8uEPM5v9TwLu7+2QJc3XXGY2nAC8HNie5Kam7Y/p3E3iOXSqijuBVwFU1a1JLgduo3Mni3Oq6kcASV4NfJzOIjAXVdWtLcYiSZIkafDdBRyf5HF0LqM4kc4acJ8CXkpnIfmNwJVN/23N9r80+z/peg3S4NtvsaGqPsvMU5eunuU5bwHeMkP71bM9T5IkSdJwq6rrk1wBfJ7Oh5NfoHPpw1XAZUne3LRd2DzlQuDvkuygM6PhjN6PWtJ8zetuFNJcrN1y1aKPsXn9JGe1cJxB0M9Ydp73or6cV4Nl+z17h+L3abG/S/4+SMOtjb8/lor555Gq6lzg3GnNdwLHzdD3e8DpvRiXhkubecHf4/nb75oNkiRJkiRJ82GxQZIkSZIktcpigyRJkiRJapXFBkmSJEmS1CqLDZIkSZIkqVUWGyRJkiRJUqssNkiSJEmSpFZZbJA0b0kuSrInyS0z7PvDJJXksGY7Sd6VZEeSm5Mc29V3Y5I7mq+NvYxBUrvMC5IkqZvFBkkL8X7g5OmNSY4CfhW4q6v5FGBd87UJuKDpeyhwLvA84Djg3CSHLOmoJS2l92NekCRJDYsNkuatqj4D3D/DrrcDfwRUV9sG4JLquA5YneQI4IXANVV1f1U9AFzDDG9UJC0P5gVJktRtVb8HIGk4JHkJcE9VfTFJ9641wN1d27uatn21z3TsTXQ+/WRkZITx8fH2Br4PExMTPTlPL4wcBJvXT/Z7GIu22DgG6fUcpp+v2ZgXBtewxNIdxyDnubn8Ww/LayJJUyw2SFq0JI8D/jtw0ky7Z2irWdof2Vi1FdgKMDo6WmNjYwsb6DyMj4/Ti/P0wrsvvZLzty//dL95/eSi4th55lh7g1mkYfr52hfzwmAblli64zhry1X9Hcws5pJ/huU1kaQpXkYhqQ0/CxwNfDHJTuBI4PNJnkLnk8mjuvoeCdw7S7uk4WBekCRpBbPYIGnRqmp7VR1eVWurai2dNwzHVtXXgG3AK5rV548H9lbVbuDjwElJDmkWgDupaZM0BMwLkiStbBYbJM1bkg8A/wI8PcmuJGfP0v1q4E5gB/DXwH8DqKr7gTcBNzRff9q0SVqGzAuSJKnb8r+IV1LPVdXL9rN/bdfjAs7ZR7+LgItaHZy0D2sH6Hruzesn+3Z9+c7zXrQkxzUvSJKkbs5skCRJkiRJrbLYIEmSJEmSWmWxQZIkSZIktcpigyRJkiRJapXFBkmSJEmS1CqLDZIkSZJ6JsnTk9zU9fWtJK9NcmiSa5Lc0Xw/pOmfJO9KsiPJzUmO7XcMkvbPYoMkSZKknqmqL1fVc6rqOcAvAA8BHwG2ANdW1Trg2mYb4BRgXfO1Cbig96OWNF8WGyRJkiT1y4nA/6mqrwIbgIub9ouB05rHG4BLquM6YHWSI3o/VEnzsarfA5AkSZK0Yp0BfKB5PFJVuwGqaneSw5v2NcDdXc/Z1bTtnn6wJJvozH5gZGSE8fHxJRp2x8TExJKfo1eGJZbuODavn2ztuP34t1nur4nFBkmSJEk9l+RA4CXAG/bXdYa2mqljVW0FtgKMjo7W2NjYYoa4X+Pj4yz1OXplWGLpjuOsLVe1dtydZ461dqy5Wu6viZdRSJIkSeqHU4DPV9V9zfZ9U5dHNN/3NO27gKO6nnckcG/PRilpQSw2SJIkSeqHl/HjSygAtgEbm8cbgSu72l/R3JXieGDv1OUWkgaXl1FIkiRJ6qkkjwN+FXhVV/N5wOVJzgbuAk5v2q8GTgV20LlzxSt7OFRJC2SxQZIkSVJPVdVDwJOntX2Tzt0ppvct4JweDU2a0doW138A2Hnei1o93iDyMgpJkiRJktQqiw2SJEmSJKlVFhskSZIkSVKrLDZIkiRJkqRWWWyQJEmSJEmtstggSZIkSZJaZbFBkiRJkiS1ymKDJEmSJElq1X6LDUmOSvKpJLcnuTXJa5r2Q5Nck+SO5vshTXuSvCvJjiQ3Jzm261gbm/53JNm4dGFJkiRJkqR+mcvMhklgc1U9AzgeOCfJMcAW4NqqWgdc22wDnAKsa742ARdApzgBnAs8DzgOOHeqQCFpeUlyUZI9SW7pavvzJF9qiowfSbK6a98bmgLkl5O8sKv95KZtR5It088jafkwL0iSpG77LTZU1e6q+nzz+NvA7cAaYANwcdPtYuC05vEG4JLquA5YneQI4IXANVV1f1U9AFwDnNxqNJJ65f088vf3GuBZVfXzwL8BbwBoipNnAM9snvOXSQ5IcgDwXjoFymOAlzV9JS1P78e8IEmSGqvm0znJWuC5wPXASFXthk5BIsnhTbc1wN1dT9vVtO2rffo5NtGZEcHIyAjj4+PzGeKCTExM9OQ8vTAIsWxeP7noY4wc1M5xBkE/Y1mqn4Wq+kyTD7rbPtG1eR3w0ubxBuCyqvo+8JUkO+jMbgLYUVV3AiS5rOl725IMWtKSMi9IkqRucy42JDkY+BDw2qr6VpJ9dp2hrWZp/8mGqq3AVoDR0dEaGxub6xAXbHx8nF6cpxcGIZaztly16GNsXj/J+dvnVQsbWP2MZeeZY305L/DbwAebx2vovMmY0l1onF6AfN5MB7MIuTjDUrwbljhgOIuQc2BeGCDDEkt3HIOcH+bybz0sr4kkTZnTO6Akj6ZTaLi0qj7cNN+X5IhmVsMRwJ6mfRdwVNfTjwTubdrHprWPL3zokgZRkv9OZ62XS6eaZuhWzHwZ1yMKkGARcrHefemVQ1G8swjZjn4UIc0Lg2dYYumOo40PO5bKXH7vhuU1kaQpc7kbRYALgdur6m1du7YBU3eU2Ahc2dX+iuauFMcDe5vLLT4OnJTkkGZhyJOaNklDornLzIuBM6tq6g3CbAXImdolDRHzgiRJK9NcPlY5AXg5sD3JTU3bHwPnAZcnORu4Czi92Xc1cCqwA3gIeCVAVd2f5E3ADU2/P62q+1uJQlLfJTkZeD3wn6vqoa5d24C/T/I24Kfp3KnmX+l8srkuydHAPXQWi/vN3o5a0lIyL0iStHLtt9hQVZ9l5umOACfO0L+Ac/ZxrIuAi+YzQEmDJ8kH6FwWdViSXXRua/sG4DHANc2aLtdV1e9W1a1JLqezwNskcE5V/ag5zqvpzHA6ALioqm7teTCSWmFekCRJ3Ybj4ldJPVVVL5uh+cJZ+r8FeMsM7VfTmQ0laZkzL0iSpG77XbNBkiRJkiRpPiw2SJIkSZKkVllskCRJkiRJrbLYIEmSJKmnkqxOckWSLyW5Pcnzkxya5JokdzTfD2n6Jsm7kuxIcnOSY/s9fkn7Z7FBkiRJUq+9E/hYVf0c8GzgdmALcG1VrQOubbYBTqFzi9x1wCbggt4PV9J8WWyQJEmS1DNJngj8Es0da6rqB1X1ILABuLjpdjFwWvN4A3BJdVwHrE5yRI+HLWmevPWlJEmSpF76GeDrwN8meTZwI/AaYKSqdgNU1e4khzf91wB3dz1/V9O2e/qBk2yiM/uBkZERxsfHlyoGACYmJpb8HL0yCLFsv2fvoo8xchC8+9IrAdi8ftGHWzJz+bcehNdkMSw2SJIkSeqlVcCxwO9V1fVJ3smPL5mYSWZoq5k6VtVWYCvA6OhojY2NLXKosxsfH2epz9ErgxDLWVuuWvQxNq+f5Pztg/82d+eZY/vtMwivyWJ4GYUkSZKkXtoF7Kqq65vtK+gUH+6bujyi+b6nq/9RXc8/Eri3R2OVtEAWGyRJkiT1TFV9Dbg7ydObphOB24BtwMambSNwZfN4G/CK5q4UxwN7py63kDS4Bn9+iSRJkqRh83vApUkOBO4EXknng9DLk5wN3AWc3vS9GjgV2AE81PSVNOAsNkiSJEnqqaq6CRidYdeJM/Qt4JwlH5SkVnkZhSRJkiRJapXFBkmSJEmS1CqLDZIkSZIkqVUWGyRJkiRJUqssNkiSJEmSpFZZbJAkSZIkSa2y2CBJkiRJklplsUGSJEmSJLXKYoMkSZIkSWqVxQZJkiRJktQqiw2SJEmSJKlVFhskzVuSi5LsSXJLV9uhSa5Jckfz/ZCmPUnelWRHkpuTHNv1nI1N/zuSbOxHLJLaYV6QJEndLDZIWoj3AydPa9sCXFtV64Brm22AU4B1zdcm4ALovAkBzgWeBxwHnDv1RkTSsvR+zAuSJKlhsUHSvFXVZ4D7pzVvAC5uHl8MnNbVfkl1XAesTnIE8ELgmqq6v6oeAK7hkW9UJC0T5gVJktRtVb8HIGlojFTVboCq2p3k8KZ9DXB3V79dTdu+2h8hySY6n34yMjLC+Ph4uyOfwcTERE/O0wsjB8Hm9ZP9HsaiDUsc0N9YevxzbV4YUMMSS3ccg5wf5vJvPSyviSRNsdggaallhraapf2RjVVbga0Ao6OjNTY21trg9mV8fJxenKcX3n3plZy/ffmn+83rJ4ciDuhvLDvPHOvLeacxL/TZsMTSHcdZW67q72BmMZffu2F5TSRpipdRSGrLfc00aJrve5r2XcBRXf2OBO6dpV3S8DAvSJK0QllskNSWbcDUyvEbgSu72l/RrD5/PLC3mVb9ceCkJIc0C8Cd1LRJGh7mBUmSVqjhmI8qqaeSfAAYAw5LsovO6vHnAZcnORu4Czi96X41cCqwA3gIeCVAVd2f5E3ADU2/P62q6YvLSVomzAuSJKmbxQZJ81ZVL9vHrhNn6FvAOfs4zkXARS0OTVKfmBckSVI3L6OQJEmSJEmtstggSZIkqaeS7EyyPclNST7XtB2a5JokdzTfD2nak+RdSXYkuTnJsf0dvaS5sNggSZIkqR9+uaqeU1WjzfYW4NqqWgdc22wDnAKsa742ARf0fKSS5s1igyRJkqRBsAG4uHl8MXBaV/sl1XEdsHrqtrqSBpcLREqSJEnqtQI+kaSAv6qqrcBIcxtcqmp3ksObvmuAu7ueu6tp2z39oEk20Zn9wMjICOPj40sXATAxMbHk5+iVQYhl8/rJRR9j5KB2jrPU5vJvPQivyWJYbJAkSZLUaydU1b1NQeGaJF+apW9maKuZOjZFi60Ao6OjNTY2tuiBzmZ8fJylPkevDEIsZ225atHH2Lx+kvO3D/7b3J1nju23zyC8JovhZRSSJEmSeqqq7m2+7wE+AhwH3Dd1eUTzfU/TfRdwVNfTjwTu7d1oJS3EfosNSS5KsifJLV1tb0xyT7N67E1JTu3a94ZmpdgvJ3lhV/vJTduOJFumn0eSJEnS8Evy+CRPmHoMnATcAmwDNjbdNgJXNo+3Aa9o7kpxPLB36nILSYNrLvNL3g+8B7hkWvvbq+ovuhuSHAOcATwT+Gngn5P8x2b3e4FfpVOZvCHJtqq6bRFjlyRJkrT8jAAfSQKd9yN/X1UfS3IDcHmSs4G7gNOb/lcDpwI7gIeAV/Z+yJLma7/Fhqr6TJK1czzeBuCyqvo+8JUkO+hMiQLYUVV3AiS5rOlrsUGSJElaQZr3BM+eof2bwIkztBdwTg+GJqlFi1k549VJXgF8DthcVQ/QWRX2uq4+UyvFwiNXkH3eTAft9QqysPxX+ew2CLGspFVk56KfsfT7Z0GSJEnSyrTQYsMFwJvorAL7JuB84LfZ90qxM60NMRAryMLyX+Wz2yDEspJWkZ2LfsYyl1VuJUmai7Ut/P/ets3rJ1v5u0OS1L4FvQOqqvumHif5a+CjzeZsK8W6gqwkSZIkSSvAgm59OXVLmsav0Vk9FjorxZ6R5DFJjgbWAf8K3ACsS3J0kgPpLCK5beHDliRJkiRJg2q/MxuSfAAYAw5Lsgs4FxhL8hw6l0LsBF4FUFW3JrmczsKPk8A5VfWj5jivBj4OHABcVFW3th6NJEmSJEnqu7ncjeJlMzRfOEv/twBvmaH9ajq3rZEkSZIkSUNsQZdRSJIkSZIk7YvFBkmSJEmS1CqLDZIkSZIkqVUWGyRJkiRJUqssNkiSJEmSpFZZbJAkSZIkSa2y2CBJkiRJklplsUFSq5L8QZJbk9yS5ANJHpvk6CTXJ7kjyQeTHNj0fUyzvaPZv7a/o5e0FMwLkiStPBYbJLUmyRrg94HRqnoWcABwBvBW4O1VtQ54ADi7ecrZwANV9TTg7U0/SUPEvCBJ0spksUFS21YBByVZBTwO2A28ALii2X8xcFrzeEOzTbP/xCTp4Vgl9YZ5QZKkFWZVvwcgaXhU1T1J/gK4C/gu8AngRuDBqppsuu0C1jSP1wB3N8+dTLIXeDLwje7jJtkEbAIYGRlhfHx8iSOBiYmJnpynF0YOgs3rJ/ffccANSxzQ31h6/XNtXhhMC4llEH//lktemMu/9TD9fEkSWGyQ1KIkh9D5VPJo4EHgH4BTZuhaU0+ZZd+PG6q2AlsBRkdHa2xsrI3hzmp8fJxenKcX3n3plZy/ffmn+83rJ4ciDuhvLDvPHOvp+cwLg2khsZy15aqlGcwiLJe8MJffu2H6+ZIk8DIKSe36FeArVfX1qvoh8GHgF4HVzfRpgCOBe5vHu4CjAJr9TwLu7+2QJS0x84IkSSuQxQZJbboLOD7J45prrE8EbgM+Bby06bMRuLJ5vK3Zptn/yap6xCeYkpY184IkSSuQxQZJramq6+ks6PZ5YDudHLMVeD3wuiQ76Fx7fWHzlAuBJzftrwO29HzQkpaUeUGSpJVp8C9yk7SsVNW5wLnTmu8Ejpuh7/eA03sxLkn9Y16QNJMkBwCfA+6pqhcnORq4DDiUToHy5VX1gySPAS4BfgH4JvAbVbWzT8OWNEfObJAkSZLUD68Bbu/afivw9qpaBzwAnN20nw08UFVPA97e9JM04Cw2SJIkSeqpJEcCLwL+ptkO8AI6l10BXAyc1jze0GzT7D+x6S9pgHkZhSRJkqReewfwR8ATmu0nAw9W1WSzvQtY0zxeA9wNUFWTSfY2/b8x/aBJNgGbAEZGRhgfH1+q8QMwMTGx5OfolUGIZfP6yf132o+Rg9o5zlKby7/1ILwmi2GxQZIkSVLPJHkxsKeqbkwyNtU8Q9eaw76fbKzaSmcRWkZHR2tsbGymbq0ZHx9nqc/RK4MQy1lbrlr0MTavn+T87YP/NnfnmWP77TMIr8liDP6rIEmSJGmYnAC8JMmpwGOBJ9KZ6bA6yapmdsORwL1N/13AUcCuJKuAJwH3937YkubDNRskSZIk9UxVvaGqjqyqtcAZwCer6kzgU8BLm24bgSubx9uabZr9n6yqGWc2SBocFhskSZIkDYLXA69LsoPOmgwXNu0XAk9u2l8HbOnT+CTNg5dRSJIkSeqLqhoHxpvHdwLHzdDne8DpPR2YpEVzZoMkSZIkSWqVxQZJkiRJktQqiw2SJEmSJKlVFhskSZIkSVKrLDZIkiRJkqRWWWyQJEmSJEmtstggSZIkSZJaZbFBkiRJkiS1ymKDJEmSJElqlcUGSZIkSZLUKosNkiRJkiSpVRYbJEmSJElSqyw2SJIkSZKkVllskCRJkiRJrbLYIEmSJEmSWrXfYkOSi5LsSXJLV9uhSa5Jckfz/ZCmPUnelWRHkpuTHNv1nI1N/zuSbFyacCT1W5LVSa5I8qUktyd5/kJyhqThYV6QJGnlmcvMhvcDJ09r2wJcW1XrgGubbYBTgHXN1ybgAugUJ4BzgecBxwHnTv1RIWnovBP4WFX9HPBs4HbmmTMkDR3zgiRJK8yq/XWoqs8kWTuteQMw1jy+GBgHXt+0X1JVBVzXfJJxRNP3mqq6HyDJNXQKGB9YdASSBkaSJwK/BJwFUFU/AH6QZF45o6p293jokpaIeUGSpEdau+Wq/fbZvH6Ss+bQD2DneS9a7JBat99iwz6MTP2nX1W7kxzetK8B7u7qt6tp21f7IyTZROeTDEZGRhgfH1/gEOduYmKiJ+fphUGIZfP6yUUfY+Sgdo4zCPoZSx9+Fn4G+Drwt0meDdwIvIb554yfeFNhXlicYfl9GpY4wLyAeaHvFhLLIP7+LZe8MJd/62H6+ZIkWHixYV8yQ1vN0v7IxqqtwFaA0dHRGhsba21w+zI+Pk4vztMLgxDLXKtvs9m8fpLzt7f949kf/Yxl55ljvT7lKuBY4Peq6vok7+THU6NnMqfcYF5YnHdfeuVQ/D6ZF9phXli4YcoLC4mljcsWnr8AACAASURBVP/f27Zc8sJcfu+G6edLkmDhd6O4r7k8gub7nqZ9F3BUV78jgXtnaZc0XHYBu6rq+mb7CjpvMuabMyQND/OCJEkr0EKLDduAqTtKbASu7Gp/RbOS9PHA3maK5MeBk5Ic0iwMeVLTJmmIVNXXgLuTPL1pOhG4jfnnDElDwrwgabokj03yr0m+mOTWJP+jaT86yfXNXWo+mOTApv0xzfaOZv/afo5f0tzsd95Zkg/QWcDpsCS76NxV4jzg8iRnA3cBpzfdrwZOBXYADwGvBKiq+5O8Cbih6fenU4tFSho6vwdc2vyBcCedPPAo5pEzJA0d84Kkbt8HXlBVE0keDXw2yT8BrwPeXlWXJXkfcDadO9KcDTxQVU9LcgbwVuA3+jV4SXMzl7tRvGwfu06coW8B5+zjOBcBF81rdJKWnaq6CRidYde8coak4WFekNSt+T2faDYf3XwV8ALgN5v2i4E30ik2bGgeQ+dSrPckSXMcSQNq8FfUkSRJkjRUkhxA5+40TwPeC/wf4MGqmrq9SPfd6x6+S01VTSbZCzwZ+MYMx+3pnWqG6S4igxCLd7X7SfOJpd+v3UwsNkiSJEnqqar6EfCcJKuBjwDPmKlb831g72w3THcRGYRYvKvdT5pPLH2429R+DcerIEmSJGnZqaoHk4wDxwOrk6xqZjd034lm6i41u5KsAp4EuP7bAFg7gLfE1eBY6N0oJEmSJGnekvxUM6OBJAcBvwLcDnwKeGnTbfpdaqbuXvNS4JOu1yANPmc2SJIkSeqlI4CLm3UbHgVcXlUfTXIbcFmSNwNfAC5s+l8I/F2SHXRmNJzRj0FLmh+LDZIkSZJ6pqpuBp47Q/udwHEztH+PH98eV9Iy4WUUkiRJkiSpVRYbJEmSJElSqyw2SJIkSZKkVllskCRJkiRJrbLYIEmSJEmSWmWxQZIkSZIktcpigyRJkiRJapXFBkmSJEmS1CqLDZIkSZIkqVUWGyRJkiRJUqssNkiSJEmSpFZZbJAkSZIkSa2y2CBJkiRJklplsUGSJEmSJLXKYoMkSZIkSWqVxQZJkiRJktQqiw2SJEmSJKlVFhsktS7JAUm+kOSjzfbRSa5PckeSDyY5sGl/TLO9o9m/tp/jlrR0zAuSJK0sFhskLYXXALd3bb8VeHtVrQMeAM5u2s8GHqiqpwFvb/pJGk7mBUmSVhCLDZJaleRI4EXA3zTbAV4AXNF0uRg4rXm8odmm2X9i01/SEDEvSJK08qzq9wAkDZ13AH8EPKHZfjLwYFVNNtu7gDXN4zXA3QBVNZlkb9P/G90HTLIJ2AQwMjLC+Pj4Uo4fgImJiZ6cpxdGDoLN6yf333HADUsc0N9Y+vRzbV4YMAuJZRB//5ZLXpjLv/Uw/XxJElhskNSiJC8G9lTVjUnGpppn6Fpz2PfjhqqtwFaA0dHRGhsbm96ldePj4/TiPL3w7kuv5Pztyz/db14/ORRxQH9j2XnmWE/PZ14YTAuJ5awtVy3NYBZhueSFufzeDdPP1/4kOQq4BHgK8O/A1qp6Z5JDgQ8Ca4GdwH+tqgea2U3vBE4FHgLOqqrP92PskubOyygktekE4CVJdgKX0Zkm/Q5gdZKpvwaPBO5tHu8CjgJo9j8JuL+XA5a05MwLkqabBDZX1TOA44FzkhwDbAGubdZyubbZBjgFWNd8bQIu6P2QJc2XxQZJramqN1TVkVW1FjgD+GRVnQl8Cnhp020jcGXzeFuzTbP/k1X1iE8wJS1f5gVJ01XV7qmZCVX1bTqLx67hJ9dsmb6WyyXVcR2dYuURPR62pHka/HlnkobB64HLkrwZ+AJwYdN+IfB3SXbQ+eTyjD6NT1LvmRck0dze9rnA9cBIVe2GTkEiyeFNt4fXcmlMrfOye4bj9XQ9l2Faa8O1XAbPfGIZxJ9Diw2SlkRVjQPjzeM7geNm6PM94PSeDkxS35gXtFKtncN6F5vXT/ZtXYyd572oL+dNcjDwIeC1VfWtWW48M6e1XKD367kM01obruUyeOYTS6/XZJoLL6OQJEmS1FNJHk2n0HBpVX24ab5v6vKI5vuepv3htVwa3eu8SBpQFhskSZIk9Uxzd4kLgdur6m1du7rXbJm+lssr0nE8sHfqcgtJg2s45pdIkiRJWi5OAF4ObE9yU9P2x8B5wOVJzgbu4seXVF1N57aXO+jc+vKVvR2upIWw2CBJkiSpZ6rqs8y8DgPAiTP0L+CcJR2UpNZ5GYUkSZIkSWrVUMxsmMsKv7Pp5+q/bRumWCRJkiRJy5MzGyRJkiRJUqsWVWxIsjPJ9iQ3Jflc03ZokmuS3NF8P6RpT5J3JdmR5OYkx7YRgCRJkiRJGixtzGz45ap6TlWNNttbgGurah1wbbMNcAqwrvnaBFzQwrklSZIkSdKAWYrLKDYAFzePLwZO62q/pDquA1YnOWIJzi9JkiRJkvposQtEFvCJJAX8VVVtBUaqajdAVe1OcnjTdw1wd9dzdzVtu7sPmGQTnZkPjIyMMD4+vt9BbF4/uaggRg5a/DEGxbDEMixxQH9jmcvvjyRJkiS1bbHFhhOq6t6moHBNki/N0neme+nWIxo6BYutAKOjozU2NrbfQSz27gub109y/vahuDHH0MQyLHFAf2PZeeZYX84rSZIkaWVb1GUUVXVv830P8BHgOOC+qcsjmu97mu67gKO6nn4kcO9izi9JkiRJkgbPgosNSR6f5AlTj4GTgFuAbcDGpttG4Mrm8TbgFc1dKY4H9k5dbiFJkiRJkobHYuZ2jwAfSTJ1nL+vqo8luQG4PMnZwF3A6U3/q4FTgR3AQ8ArF3FuSZIkSZI0oBZcbKiqO4Fnz9D+TeDEGdoLOGeh55MkSZIkScvDUtz6UpIkSZIkrWAWGyRJkiRJUquG496CkiRJkqRZrd1y1T73bV4/yVmz7Jfmy5kNkiRJkiSpVRYbJEmSJElSqyw2SJIkSZKkVllskCRJkiRJrbLYIKk1SY5K8qkktye5NclrmvZDk1yT5I7m+yFNe5K8K8mOJDcnOba/EUhqm3lBkqSVyWKDpDZNApur6hnA8cA5SY4BtgDXVtU64NpmG+AUYF3ztQm4oPdDlrTEzAuSJK1A3vpSUmuqajewu3n87SS3A2uADcBY0+1iYBx4fdN+SVUVcF2S1UmOaI4jaQiYF+ZutlvStc1b3KnfklwEvBjYU1XPatoOBT4IrAV2Av+1qh5IEuCdwKnAQ8BZVfX5foxb0txZbJC0JJKsBZ4LXA+MTL1RqKrdSQ5vuq0B7u562q6m7SfeVCTZROcTTkZGRhgfH1/KoQMwMTHRk/P0wshBnTcWy92wxAH9jaWfP9fmhdn18mdiWH6fhiUOWJF54f3Ae4BLutqmZjydl2RLs/16fnLG0/PozHh6Xk9HK2neLDZIal2Sg4EPAa+tqm91PpCYuesMbfWIhqqtwFaA0dHRGhsba2mk+zY+Pk4vztML7770Ss7fvvzT/eb1k0MRB/Q3lp1njvXlvOaF/evlTINh+X0aljhg5eWFqvpMU4Ds5ownaYgMR3aWNDCSPJrOG4pLq+rDTfN9U38UJDkC2NO07wKO6nr6kcC9vRutpF4wL0iao0XNeILez3pabjMhZ5s9MywzhYYlDphfLIP4c2ixQVJrmmsqLwRur6q3de3aBmwEzmu+X9nV/uokl9GZDrnXTymk4WJekNSCOc14gt7PelpuMyFnm0E1LDOFhiUOmF8s/Zq5OJvheBUkDYoTgJcD25Pc1LT9MZ03E5cnORu4Czi92Xc1ncWedtBZ8OmVvR2upB4wL0iaK2c8SUPEYoOk1lTVZ5n50weAE2foX8A5SzooSX1lXpA0D854koaIxQZJkiRJPZXkA3QWgzwsyS7gXJzxJA0Viw2SJEmSeqqqXraPXc54kobEo/o9AEmSJEmSNFyc2SBpKK1d5P3qN6+f7Ok975fS5vX9HoEkSVqIxf49I/WTMxskSZIkSVKrLDZIkiRJkqRWWWyQJEmSJEmtstggSZIkSZJaZbFBkiRJkiS1ymKDJEmSJElqlcUGSZIkSZLUKosNkiRJkiSpVav6PQBJkiRJkrRwa7dc1erxdp73okUfw5kNkiRJkiSpVRYbJEmSJElSq7yMQpIkSZJa0PZUdmk5c2aDJEmSJElqlcUGSZIkSZLUKosNkiRJkiSpVa7ZIEmSVoTFXku9ef0kZ3k9tiRJc+LMBkmSJEmS1CqLDZIkSZIkqVUWGyRJkiRJUqt6XmxIcnKSLyfZkWRLr88vafCYFyRNZ16QNJ15QVpeerpAZJIDgPcCvwrsAm5Isq2qbuvlOCQNDvOCpOnMC5KmW6q84MKx0tLp9cyG44AdVXVnVf0AuAzY0OMxSBos5gVJ05kXJE1nXpCWmVRV706WvBQ4uap+p9l+OfC8qnp1V59NwKZm8+nAl3swtMOAb/TgPL0wLLEMSxywPGJ5alX9VD9ObF7oiWGJZVjigOURi3nhkZbD6zZXwxLLsMQByyOWgc4LTXuvc8NyeN3malhiGZY4YHnEss+80NPLKIDM0PYT1Y6q2gps7c1wOpJ8rqpGe3nOpTIssQxLHDBcsSwR88ISG5ZYhiUOGK5Yloh5YYkNSyzDEgcMVyxLZL95AXqfG4bpdRuWWIYlDlj+sfT6MopdwFFd20cC9/Z4DJIGi3lB0nTmBUnTmRekZabXxYYbgHVJjk5yIHAGsK3HY5A0WMwLkqYzL0iazrwgLTM9vYyiqiaTvBr4OHAAcFFV3drLMexDT6dhLrFhiWVY4oDhiqV15oWeGJZYhiUOGK5YWmde6IlhiWVY4oDhiqV15oWeGJZYhiUOWOax9HSBSEmSJEmSNPx6fRmFJEmSJEkachYbJEmSJElSq1ZssSHJUUk+leT2JLcmeU2/x7RYSQ5I8oUkH+33WBYjyeokVyT5UvP6PL/fY1qoJH/Q/HzdkuQDSR7b7zFp38wLg8u8oH4xLwwu84L6xbwwuMwLg2XFFhuASWBzVT0DOB44J8kxfR7TYr0GuL3fg2jBO4GPVdXPAc9mmcaUZA3w+8BoVT2LzmJGZ/R3VNoP88LgMi+oX8wLg8u8oH4xLwwu88IAWbHFhqraXVWfbx5/m84P4pr+jmrhkhwJvAj4m36PZTGSPBH4JeBCgKr6QVU92N9RLcoq4KAkq4DH4f2gB5p5YTCZF9RP5oXBZF5QP5kXBpN5YfCs2GJDtyRrgecC1/d3JIvyDuCPgH/v90AW6WeArwN/20zl+pskj+/3oBaiqu4B/gK4C9gN7K2qT/R3VJor88JAMS9oIJgXBop5QQPBvDBQzAsDZsUXG5IcDHwIeG1Vfavf41mIJC8G9lTVjf0eSwtWAccCF1TVc4HvAFv6O6SFSXIIsAE4Gvhp4PFJfqu/o9JcmBcGjnlBfWdeGDjmBfWdeWHgmBcGzIouNiR5NJ0EcWlVfbjf41mEE4CXJNkJXAa8IMn/6u+QFmwXsKuqpqrDV9BJGsvRrwBfqaqvV9UPgQ8Dv9jnMWk/zAsDybygvjIvDCTzgvrKvDCQzAsDZsUWG5KEzvU8t1fV2/o9nsWoqjdU1ZFVtZbOwiGfrKplV/kCqKqvAXcneXrTdCJwWx+HtBh3AccneVzz83Yiy3SRmpXCvDCYzAvqJ/PCYDIvqJ/MC4PJvDB4VvV7AH10AvByYHuSm5q2P66qq/s4JnX8HnBpkgOBO4FX9nk8C1JV1ye5Avg8nVWLvwBs7e+otB/mhcFlXlC/mBcGl3lB/WJeGFzmhQGSqur3GCRJkiRJ0hBZsZdRSJIkSZKkpWGxQZIkSZIktcpigyRJkiRJapXFBkmSJEmS1CqLDZIkSZIkqVUWG/QISX6U5KYktyT530lW76f/6iT/rWv7p5tbtUgaEuYFSdOZFyRNZ15QN299qUdIMlFVBzePLwb+rareMkv/tcBHq+pZvRmhpF4zL0iazrwgaTrzgro5s0H78y/AGoAkBye5Nsnnk2xPsqHpcx7ws00V88+TrE1yS/Ocs5J8OMnHktyR5H9OHTjJ2Un+Lcl4kr9O8p6eRydpIcwLkqYzL0iazrywwq3q9wA0uJIcAJwIXNg0fQ/4tar6VpLDgOuSbAO2AM+qquc0z1s77VDPAZ4LfB/4cpJ3Az8C/gQ4Fvg28Engi0sakKRFMy9Ims68IGk684LAYoNmdlCSm4C1wI3ANU17gD9L8kvAv9OpVI7M4XjXVtVegCS3AU8FDgM+XVX3N+3/APzHNoOQ1CrzgqTpzAuSpjMv6GFeRqGZfLepLj4VOBA4p2k/E/gp4Bea/fcBj53D8b7f9fhHdIpcaW+4knrAvCBpOvOCpOnMC3qYxQbtU1NF/H3gD5M8GngSsKeqfpjkl+kkEehMX3rCPA//r8B/TnJIklXAr7c1bklLx7wgaTrzgqTpzAsCiw3aj6r6Ap1roM4ALgVGk3yOTnXyS02fbwL/bzq3uPnzOR73HuDPgOuBfwZuA/a2H4GktpkXJE1nXpA0nXlB3vpSfZPk4KqaaCqSHwEuqqqP9HtckvrHvCBpOvOCpOnMC8uDMxvUT29sFpC5BfgK8I99Ho+k/jMvSJrOvCBpOvPCMuDMBkmSJEmS1CpnNkiSJEmSpFZZbJAkSZIkSa2y2KCHJXlfkj/p9zgkDQ7zgqTpzAuSwFyg/bPYsMIk2Znku0kmkjyQ5KokRwFU1e9W1Zt6NI5jknyuGcMDSf45yTFd+5PkrUm+2Xz9zyTpxdiklWZQ8sK0MZ2bpJL8SlfbY5JclORbSb6W5HW9Hpe0UgxSXkjyuCR/meQbSfYm+UzXPv9ekJbQoOSCJAcmuaIZTyUZm7Z/1lyQ5DlJbkzyUPP9Ob0Y90pnsWFl+i9VdTBwBHAf8O4+jOFe4KXAocBhwDbgsq79m4DTgGcDPw+8GHhVj8corSSDkBcASPKzdPLD7mm73gisA54K/DLwR0lO7u3opBVlUPLCVjp/Lzyj+f4HXfv8e0FaeoOSCz4L/BbwtRn27TMXJDkQuBL4X8AhwMXAlU27lpDFhhWsqr4HXAEcA5Dk/Une3DweS7IryeYke5LsTvLKqecmOTXJbUm+neSeJH84z3M/WFU7q3M7lAA/Ap7W1WUjcH5V7aqqe4DzgbMWE6+k/etnXujyHuD1wA+mtb8CeFNVPVBVtwN/jXlBWnL9zAtJng68BNhUVV+vqh9V1Y1dXfx7QeqRPr93+EFVvaOqPkvnfcN0s+WCMWAV8I6q+n5VvYvO+48XzGcMmj+LDStYkscBvwFct48uTwGeBKwBzgbem+SQZt+FwKuq6gnAs4BPNsf8D0kenOXrN6eN4UHge3QqpH/WteuZwBe7tr/YtElaQv3OC0lOB35QVVdPG9chwE9jXpB6rs954XnAV4H/kc5lFNuT/HrXuf17QeqRfv+NsB+z5YJnAjc3H3JOuRlzxZJb1e8BqC/+MckkcDCwB3jhPvr9EPjTqpoErk4yATydToL5IXBMki9W1QPAAwBVdReweq4DqarVSR5Ppxr51a5dBwN7u7b3AgcnybREIakdfc8LSQ6mU3Q8aYbdBzffp+eFJ+zvuJIWrO95ATiSzhuTD9EpOD4fuCrJbc0MJ/9ekJbeIOSC/dlnLphh39R+/4ZYYs5sWJlOq6rVwGOAVwOfTvKUGfp9s0kWUx7ix3/w/zpwKvDVJJ9O8vyFDqaqvgO8D7gkyeFN8wTwxK5uTwQm/MNBWjKDkBf+B/B3VfWVGfZNNN+n54Vvz/MckuZuEPLCd+m8SXlzM43608Cn+HFR0r8XpKU3CLlgf2bLBdP3Te33b4glZrFhBWuue/wwneue/tM8n3tDVW0ADgf+EbgcHp4KNTHL15n7OOSj4P9v7/6jLCvLA99/H2mNKEZg0Jq2YVJ4B02UjmhqGWZY16lIMoPiTeuMcuFygVYmnawLUTM1a2y9uVdvjLPaRHSMZpi0wgD3EoGgBsZ2GQnxXMe7BAUkNtgaEXuwoUMbRbA0gxY+94+zDx5On6o6VWefvffZ9f2s1avOec/+8bx1Tr193me/+315Gt1hVwB3053gpedFRZmkCaq5XTgdeGN0V5r4W+AE4LqIeEtxFeQgtgtS5WpuF768yin8viBVpGF9h0ErtQV3A79YjHLo+UVsKybOZMMGFl3b6M7Kum8N+z0lIs6NiGdm5o+BRygmasnM+zLzqBX+XV0c49ci4sURcURE/CzwXrrDqXpxXAX8m4jYEhHPARaAK8qqu6Th6mwX6CYbTgZOKf49QHcm6T8uXr8K+N2IOCYifh74DWwXpImruV34LHAf8NaI2BQRp9Gd7O0vitf9viBVpOa2oLcE9lOLp0+JiKf2JRBWags6xfneWBzj4qL8r9b1i9DInLNhY/ovEfEYkHTnSbggM++OtS1LfR7wwYg4Avga3WVo1uJoupNCHk93iOQXgTOKWW4B/gR4LrC3eP7hokzSZNTeLmTmd/qfF/E8lJm9WyjeDlxaxPf3wLsz81NrOYekNWlCu/DjonPzYWBnEcf5mfnVYhO/L0iTV3tbUPga3eWv4acJxxOB/azQFmTmjyLi1UXZLrqJkldn5uCqVypZeEubJEmSJEkqk7dRSJIkSZKkUplskCRJkiRJpTLZIEmSJEmSSmWyQZIkSZIklarRq1Ecd9xxOTs7O/Hz/OAHP+DpT3/6xM9ThbbUpS31gOmoy+233/53mfmsuuMYhe3C2rWlLm2pB0xHXWwXDjcN79uo2lKXttQDpqMu09QuQDVtwzS8b6NqS13aUg+Yjrqs1C40OtkwOzvLbbfdNvHzdDod5ufnJ36eKrSlLm2pB0xHXSLiv9Udw6hsF9auLXVpSz1gOupiu3C4aXjfRtWWurSlHjAddZmmdgGqaRum4X0bVVvq0pZ6wHTUZaV2wdsoJEmSJElSqUw2SJIkSZKkUplskCRJkiRJpTLZIEmSJEmSSmWyQZIkSZIklcpkgyRJkiRJKpXJBkmSJEmSVCqTDZIkSZIkqVQmGyRJkiRJUqk21R2ANAmzO/cMLd+/68yKI5HUJMPaBtsFaePqbxNsCyTBT9sF24TxObJBkiRJkiSVymSDJEmSJEkqlckGSZIkSZJUKpMNkiRJkiSpVCYbJEmSJElSqUw2SJIkSZKkUplskCRJkiRJpVp3siEinhoRX4iIv46IuyPi/yrKT4yIWyPi6xFxbUQ8pSj/meL5PcXrs+VUQZIkSZIkNck4IxseBV6emS8CTgHOiIhTgXcD78vMk4CHgAuL7S8EHsrMfwy8r9hOkiRJkqRGm925h9mde+oOY6qsO9mQXYvF0ycX/xJ4OXB9UX4l8Ori8bbiOcXrp0dErPf8kiSp+SLihIj4TETsK0ZCvqkoPzYibipGQt4UEccU5RERf1SMhPxyRLyk3hpIkqT12DTOzhFxBHA78I+BPwa+AXwvM5eKTQ4AW4rHW4BvAWTmUkQ8DPwD4O8GjrkD2AEwMzNDp9MZJ8SRLC4uVnKeKrSlLuPWY2Hr0tDyOn43bXlPJGmdloCFzLwjIp4B3B4RNwHbgZszc1dE7AR2Am8BXgGcVPz7ZeDS4qckSZoiYyUbMvMx4JSIOBr4OPALwzYrfg4bxZCHFWTuBnYDzM3N5fz8/DghjqTT6VDFearQlrqMW4/tywxx2n/u+o+5Xm15T0YREScAVwH/EPgJsDsz3x8RxwLXArPAfuCszHyoGN30fuCVwA+B7Zl5Rx2xS5qMzDwIHCwefz8i9tG9ALENmC82uxLo0E02bAOuyswEbomIoyNic3EcSZI0JcZKNvRk5vciogOcChwdEZuK0Q3HAw8Umx0ATgAORMQm4JnAd8s4v6TG8AqmpGUVk0O/GLgVmOklEDLzYEQ8u9js8ZGQhd4oySckGxwJOZ621KXMkZB1/z7a8p5IUs+6kw0R8Szgx0Wi4UjgV+lO+vgZ4LXANcAFwA3FLjcWzz9fvP5XxVULSS3hFUxJy4mIo4CPAm/OzEdWmLbJkZAVaEtdyhwJWcfox35teU8kqWeckQ2bgSuLeRueBFyXmZ+IiK8A10TE7wNfAi4rtr8M+L8j4h66IxrOHuPckhrOK5jN0Za6lFGPYfO5OJfL5EXEk+kmGq7OzI8VxQ/2kosRsRk4VJT3RkL29I+SlCSpUq5AsX7rTjZk5pfpdiQGy+8FXjqk/L8Dr1vv+SRND69gNktb6lJGPYbN5+JcLpNVzM1yGbAvM9/b91JvxOMuDh8JeXFEXEP3tqqHHe0kSdL0KWXOBknq8QqmpAGnAecBeyPizqLsbXSTDNdFxIXAffz0gsQn6U4aew/diWNfX224kiSpDCYbJJXGK5iSBmXm5xg+igng9CHbJ3DRRIOSJEkTZ7JBG8pK91zt33VmhZG0llcwJUnSqiLicuBVwKHMPLkoc6lsqUVMNkgqjVcwJUnSiK4APghc1Ve2E5fKVk2cCLJ8T6o7AEmSJEkbS2Z+lu4Kdf220V0im+Lnq/vKr8quW4CjizmgJDWYIxvUaN72IEmSRtH/ncHvCFNrrKWyofrlstu0lHFb6tJfj733PwzA1i3PPGy7wdcGl8fuHWO58uWOU6Zpf09MNkiSpt6wxKSdDUlqjZGWyobql8tu01LGbalLfz16S14PW+Z68LXB5bFXK1/uOGWa9vfEZIMkaap4T6UktZZLZUst4pwNkiRJkpqgt1Q2HL5U9vnRdSoulS1NBUc2SJIkSapURHwEmAeOi4gDwNtxqWypVUw2SJI2NOd7kKTqZeY5y7zkUtlSS3gbhSRJkiRJKpXJBkmSJEmSVCpvo5AktdI4q1Z4a4UkSdJ4HNkgSZIkSZJK5cgGSZIkaQX9o50c5SRJo3FkgyRJkiRp6s3u3MPe+x+uOwwVTDZIkiRJkqRSmWyQJEmSJEmlMtkgSZIkSZJKZbJBkiRJktRqszv3jLUsttbOZIMkSZqYiLg8BaLSBAAAIABJREFUIg5FxF19ZddGxJ3Fv/0RcWdRPhsRf9/32n+qL3JJkjQOl76UVJqIuBx4FXAoM08uyq4Fnl9scjTwvcw8JSJmgX3A14rXbsnM36o2YkkVuAL4IHBVryAz/+fe44i4BOifOvwbmXlKZdFJklrPEQ31MNkgqUxXYKdCUp/M/GyRXDxMRARwFvDyKmOSJEmTZ7JBUmnsVEhao/8ReDAzv95XdmJEfAl4BPjdzPyvw3aMiB3ADoCZmRk6nc6kY2VxcbGS81ShLXXpr8fC1qXHy0et26j7rOfYa9WW90SSekw2SKqKnYqatKUuvXr0f+mvUpm/w7a8JyU4B/hI3/ODwD/KzO9ExC8Bfx4RL8zMRwZ3zMzdwG6Aubm5nJ+fn3iwnU6HKs5ThbbUpb8e2/uGSe8/d36k/UfdZz3HXqu2vCeS1GOyQVJV7FTUpC116dVje033XZbZwWjLezKOiNgE/Evgl3plmfko8Gjx+PaI+AbwPOC2WoKUJEnr5moUkiaur1Nxba8sMx/NzO8Uj28Hep0KSRvDrwJfzcwDvYKIeFZEHFE8fi5wEnBvTfFJkqQxrDvZEBEnRMRnImJfRNwdEW8qyt8REff3LVv1yr593hoR90TE1yLiX5RRAUlTwU6F1q23Lvbe+x92NukpFBEfAT4PPD8iDkTEhcVLZ/PE0U4ALwO+HBF/DVwP/FZmfre6aCVJUlnGuY1iCVjIzDsi4hnA7RFxU/Ha+zLzPf0bR8QL6H6xeCHwHOAvI+J5mfnYGDFIapCiUzEPHBcRB4C3Z+ZlLN+p+L2IWAIew06F1EqZec4y5duHlH0U+OikY5IkSZO37mRDZh6ke881mfn9iNgHbFlhl23ANcX9mN+MiHuAl9K92iGpBexUSJIkSYKSJogslrp7MXArcBpwcUScT3dCp4XMfIhuIuKWvt0OMCQ54azz42lLXUaZdX7UJapG5VJWkiRJklSOsZMNEXEU3auTb87MRyLiUuCdQBY/LwHeAMSQ3fOwAmedH0tb6jLKrPOjLlE1KpeykiRJkqRyjLUaRUQ8mW6i4erM/BhAZj6YmY9l5k+AD9G9VQK6IxlO6Nv9eOCBcc4vSZIkSZKaZ5zVKAK4DNiXme/tK9/ct9lrgLuKxzcCZ0fEz0TEiXRnnv/Ces8vSZIkSZKaaZzbKE4DzgP2RsSdRdnbgHMi4hS6t0jsB34TIDPvjojrgK/QXcniIleikCRJkiRNu97y3Pt3nVlzJM0xzmoUn2P4PAyfXGGfdwHvWu85JUmSJElS85WyGoUkSZIkSdNmdh0Ty2s0JhskSRrBsC8jDpWUJEkabqzVKCRJkiRJUtfszj2OliiYbJAkSZIkSaUy2SBJkiRJ0ggcuTA6kw2SJEmSJKlUThCpyqyUAXSSNUmSJElqD5MNkiRJaqz+ixVenJCk6WGyQZLUGN4DKUmKiN8B/jWQwF7g9cBm4BrgWOAO4LzM/FFtQUpalXM2SJIkSWqEiNgCvBGYy8yTgSOAs4F3A+/LzJOAh4AL64tS0ihMNkiSJElqkk3AkRGxCXgacBB4OXB98fqVwKtrik3SiLyNQpIkSVIjZOb9EfEe4D7g74FPA7cD38vMpWKzA8CWYftHxA5gB8DMzAydTmei8S4uLk78HFWZxrrsvf9hALZueSYAC1uXmDmSx+uxsHXpsH1Wem0t2632+geuvuEJsa3HNL4n/Uw2SJKkiYqIy4FXAYeKYdFExDuA3wC+XWz2tsz8ZPHaW+kOkX4MeGNm/kXlQUuqRUQcA2wDTgS+B/wZ8Iohm+aw/TNzN7AbYG5uLufn5ycTaKHT6TDpc1RlGuuyvZjraf+5848/X9i6xFnz8094vV//titZbbu1Hmc9pvE96WeyQRrBcpPWOSv24exUSBriCuCDwFUD5e/LzPf0F0TEC+jen/1C4DnAX0bE8zLzsSoClVS7XwW+mZnfBoiIjwH/FDg6IjYVoxuOBx6oMUZJI3DOBklluwI4Y0j5+zLzlOJfL9HQ36k4A/iPEXFEZZFKqkRmfhb47oibbwOuycxHM/ObwD3ASycWnKSmuQ84NSKeFhEBnA58BfgM8NpimwuAG2qKT9KIHNkgqVSZ+dmImB1x88c7FcA3I6LXqfj8hMKT1CwXR8T5wG3AQmY+RPc+7Fv6thl6b3bV92XD9N8722+a6tJ/P/RgzP31WGm79Rx7PduNY5rek0nKzFsj4nq6y1suAV+ie1vEHuCaiPj9ouyy+qJU1XqjjJcbVezS2c1kskFSVexU1GSa6rLSZE0zR64+mVPV1vt7nab3ZIIuBd5J977rdwKXAG8AYsi2h92bXfV92TD99872m6a69N8PPXjvc389VtpuPcdez3b9HZ613mo5Te/JpGXm24G3DxTfi6OcpKliskFSFexU1Gia6rLSJEsLW5e4ZG+z/tta76RP0/SeTEpmPth7HBEfAj5RPD0AnNC3qfdmS5KewJEM08E5GyRNXGY+mJmPZeZPgA/x0ysTdiqkDSoiNvc9fQ1wV/H4RuDsiPiZiDgROAn4QtXxSZKk8TTrEpGkVoqIzZl5sHg62Kn404h4L91Z5+1USC0UER8B5oHjIuIA3eHR8xFxCt3RTPuB3wTIzLsj4jq6E8ItARe5EoUkqS1Wm3+iTUw2SCqVnQpJgzLznCHFy07ulpnvAt41uYgkSdKkmWyQVCo7FZIkSZJMNkiStE7DJqjaCMMiJUmSVuMEkZIkSZIkqVSObJAk1cJlqyRJktrLkQ2SJEmSJKlUJhskSZIkSVKpTDZIkiRJkqRSmWyQJEmSJEmlWneyISJOiIjPRMS+iLg7It5UlB8bETdFxNeLn8cU5RERfxQR90TElyPiJWVVQpIkSZIkNcc4IxuWgIXM/AXgVOCiiHgBsBO4OTNPAm4ungO8Ajip+LcDuHSMc0uSJEmSpIZad7IhMw9m5h3F4+8D+4AtwDbgymKzK4FXF4+3AVdl1y3A0RGxed2RS5IkSZKkRtpUxkEiYhZ4MXArMJOZB6GbkIiIZxebbQG+1bfbgaLs4MCxdtAd+cDMzAydTqeMEFe0uLhYyXmq0OS6LGxdWva1wZh79VjLPqOeq8zjjfK7bvJ7IkmSJEmTMHayISKOAj4KvDkzH4mIZTcdUpaHFWTuBnYDzM3N5fz8/LghrqrT6VDFearQ5Lps37ln2df2nzv/hOe9eqxln1HPVebxVtqnp8nviSRJkiRNwljJhoh4Mt1Ew9WZ+bGi+MGI2FyMatgMHCrKDwAn9O1+PPDAOOeXJEmSJKnpZtdxMXTajbMaRQCXAfsy8719L90IXFA8vgC4oa/8/GJVilOBh3u3W0iSJEmSpPYYZ2TDacB5wN6IuLMoexuwC7guIi4E7gNeV7z2SeCVwD3AD4HXj3FuSZIkSZLUUOtONmTm5xg+DwPA6UO2T+Ci9Z5PkiRJkiRNh3XfRiFJkiRJksY3u3NP6+Z1KGXpS6lf2/5IJEnrFxGXA68CDmXmyUXZHwL/E/Aj4BvA6zPze8VS2vuArxW735KZv1V50JIkaWyObJAkSZN0BXDGQNlNwMmZ+YvA3wBv7XvtG5l5SvHPRIMkSVPKkQ2SSuMVTEmDMvOzxd97f9mn+57eAry2ypjUDP0jIffvOrPGSCQ1Ra9dsE1oB5MNksp0BfBB4Kq+spuAt2bmUkS8m+4VzLcUr30jM0+pNkRJDfMG4Nq+5ydGxJeAR4Dfzcz/OmyniNgB7ACYmZmh0+lMOk4WFxcrOU8VmlCXha1Ljz9eKZaVtuuvx6jHKzuG9Ww3TBPeE0kqk8kGTS3nhmger2BqOf69apiI+N+BJeDqougg8I8y8zsR8UvAn0fECzPzkcF9M3M3sBtgbm4u5+fnJx5vp9OhivNUoQl12d4/suHc+XVt11+PUY9Xdgzr2W6YJrwnUtP4/WG6mWyQVCWvYNagCXXpv9q3XjNHlnOcSRvld92E96RuEXEB3duuTi+WxyYzHwUeLR7fHhHfAJ4H3FZboJIkaV1MNkiqhFcw69OEumwv4crEwtYlLtnb/P+2Rrma2YT3pE4RcQbd26n+WWb+sK/8WcB3M/OxiHgucBJwb01hSpKkMbgahaSJ67uCeW7/FczM/E7x+Ha6k0c+r74oJU1CRHwE+Dzw/Ig4EBEX0p3b5RnATRFxZ0T8p2LzlwFfjoi/Bq4Hfiszv1tL4JIkaSzNv0Qkaap5BVPa2DLznCHFly2z7UeBj042IkmSVAWTDZJKU1zBnAeOi4gDwNvprj7xM3SvYMJPl7h8GfB7EbEEPIZXMCVJkqTWMNkgqTRewZQkSZIEztkgSZIkqUEi4uiIuD4ivhoR+yLin0TEsRFxU0R8vfh5TN1xSlqZyQZJkiRJTfJ+4FOZ+fPAi4B9wE7g5sw8Cbi5eC6pwbyNQo0wO7As3sLWpVKWypMkSdL0iIifpTuv03aAzPwR8KOI2EZ3XiiAK4EO3QmoJTWUyQZJkiRJTfFc4NvAf46IFwG3A28CZjLzIEBmHoyIZw/bOSJ2ADsAZmZm6HQ6Ew12cXFx4ueoShPqsrB1CYAPXH1D8fyJr/fi6203zMyRK283yjFG2W7c4wz+rnuv95c34T0Zh8kGqTA4ukKSJEmV2wS8BPjtzLw1It7PGm6ZyMzdwG6Aubm5nJ+fn0iQPZ1Oh0mfoypNqMtqI5v3nzu/6nYLW5c4a3757UY5xijbjXucXnlP7/X+8ia8J+NwzgZJkiRJTXEAOJCZtxbPr6ebfHgwIjYDFD8P1RSfpBGZbJAkSZLUCJn5t8C3IuL5RdHpwFeAG4ELirILgBtqCE/SGngbhSRJJRp2S9b+XWfWEIkkTa3fBq6OiKcA9wKvp3uR9LqIuBC4D3hdjfFJGoHJBkmSJEmNkZl3AnNDXjq96lgkrZ+3UUiSJEmSpFKZbJAkSZIkSaUy2SBJkiRJkkplskGSJEmSJJXKZIMkSZIkSSqVq1FIkiRJfYYtYStJWhtHNkiSJEmSpFKNlWyIiMsj4lBE3NVX9o6IuD8i7iz+vbLvtbdGxD0R8bWI+BfjnFuSJEmSJDXTuLdRXAF8ELhqoPx9mfme/oKIeAFwNvBC4DnAX0bE8zLzsTFjkCRJDRYRlwOvAg5l5slF2bHAtcAssB84KzMfiogA3g+8EvghsD0z76gjbm0s3johSeUaa2RDZn4W+O6Im28DrsnMRzPzm8A9wEvHOb+k5llmxNOxEXFTRHy9+HlMUR4R8UfFiKcvR8RL6otc0gRdAZwxULYTuDkzTwJuLp4DvAI4qfi3A7i0ohglSVKJJjVB5MURcT5wG7CQmQ8BW4Bb+rY5UJQ9QUTsoPvlgpmZGTqdzoRC/KnFxcVKzlOFJtRlYevS2MeYObKc40zaKL/rJrwnFbuCw0c89ToVuyJiZ/H8LTyxU/HLdDsVv1xptJImLjM/GxGzA8XbgPni8ZVAh267sA24KjMTuCUijo6IzZl5sJpopWr1RlQsbF16/A9CktpgEsmGS4F3Aln8vAR4AxBDts3DCjJ3A7sB5ubmcn5+fgIhPlGn06GK81ShCXXZXsIwxIWtS1yyt/mLpew/d37VbZrwnlTJToV0uMHh2XYqAJjp/a1n5sGIeHZRvgX4Vt92vYsTT2gXvDgxnibUpf+iwkqxrLRdfz2W227v/Q8//njrlmcue+xRrTfW1faZOXL0fSRpGpTem8vMB3uPI+JDwCeKpweAE/o2PR54oOzzS2okOxU1akJdNtKIp1HYqViRFycq0IS69F+cWCl5v9J2/fVYbruV9l/PBZL1xrraPgtblzirJZ8vSYIJJBsGrkq+Bujdt30j8KcR8V66E0SeBHyh7PNLmip2KirQhLpspBFPo7BTAcCDve8MEbEZOFSUe3FCkqQWGHfpy48AnweeHxEHIuJC4A8iYm9EfBn4FeB3ADLzbuA64CvAp4CLXIlC2jAeLDoT2KmQVLgRuKB4fAFwQ1/5+cUEsqcCD3trlSRpo5nduecJt4FNo7EuEWXmOUOKL1th+3cB7xrnnJKmUq9TsYvDOxUXR8Q1dCeGtFMhtVBxcWIeOC4iDgBvp9seXFdcqLgPeF2x+SfpLnt5D92lL19fecCSJGls7RiPKqkx7FRIGrTMxQmA04dsm8BFk41IkqRmGpxUepqZbJBUKjsVkqQqzO7cw8LWpVLmhJEklW+sORskSZIkSZIGObJBkiRJrdKmYciSNK0c2SBJkiRJkkplskGSJEmSJJXKZIMkSZIkSSqVyQZJkiRJklQqkw2SJEmSJFVoduee1k9m62oU0oT0Go/BNcD37zqzrpAkSZIkqRKObJAkSZIkSaVyZIMkSZI0ollHK0rL6v199P42Bp9rYzHZIEmSpA2h7fdHS1KTmGzQslb6D9nspCQY3k7YPkgby2A7sJHaAJMX0vps5HZjIzHZIEkaiV+qJUmSNConiJQkSZIkSaUy2SBJkiRJkkplskGSJEmSJJXKORskSYdxfgZJUl0i4gjgNuD+zHxVRJwIXAMcC9wBnJeZP6ozRkmrc2SDJEmSpCZ5E7Cv7/m7gfdl5knAQ8CFtUSlsc3u3OMFjQ3EkQ2SJKkWEfF84Nq+oucC/ydwNPAbwLeL8rdl5icrDk81WakjYiel/SLieOBM4F3Av4mIAF4O/C/FJlcC7wAurSVASSMz2SCpEnYqJA3KzK8Bp8Djw6bvBz4OvJ7uVcz31BiepHr8B+DfAc8onv8D4HuZuVQ8PwBsWW7niNgB7ACYmZmh0+lMLlJgcXFx4ueoShl1WdjafZt6x1nu+aDVXl/LdjNHrrxdWeeq4jj9dZlGJhukMXiFZXR2KiSt4nTgG5n537oXMqXp1v8dYf+uM2uMZHpExKuAQ5l5e0TM94qHbJrLHSMzdwO7Aebm5nJ+fn65TUvR6XSY9DmqUkZdthef+/3nzq/4fNBqr69lu4WtS5w1v/x2ZZ2riuP012UamWyQVAc7FZIGnQ18pO/5xRFxPt1J4hYy86H+jau+eglewVzO4NW4UY/bv1//PqtdJew3c+Tatq/LSr+TXvzTfgWzJKcBvx4RrwSeCvws3ZEOR0fEpmJ0w/HAAzXGqBF4QU5gskFSPexUVGg9dRnny/uwc5XRGZiWTsUo7FQ8UUQ8Bfh14K1F0aXAO+levXwncAnwhv59qr56CV7BXM7g1bjeVbq17Ne/z2pXCfstbF3ikr3N/zq70u+kV99pv4JZhsx8K0U7UIxs+LeZeW5E/BnwWrorUlwA3FBbkJJG1vzWWVKr2Kmo3nrqspYv+4OGfake53g909KpGIWdisO8ArgjMx8E6P0EiIgPAZ+oKzBJjfAW4JqI+H3gS8BlNccjaQTt+NYmaZrYqZA06Bz6RjtFxObMPFg8fQ1wVy1RSapNZnaATvH4XuCldcYjae1MNkiqmp0KSY+LiKcBvwb8Zl/xH0TEKXRHPO0feE2SJE0Bkw2SKmOnQtKgzPwh3aXt+svOqykcSZJUkrGSDRFxOdBboubkouxY4Fpglm7H4azMfCi6U86/H3gl8ENge2beMc75JU0XOxWSJEnSxvCkMfe/AjhjoGwncHNmngTcXDyH7n3aJxX/dtCdFE6SJEmSJLXMWMmGzPws8N2B4m3AlcXjK4FX95VflV230F0vd/M455ckSZIkSc0ziTkbZnqTvWXmwYh4dlG+BfhW33YHirKD/TtHxA66Ix+YmZmpZB3y9axB31Rl1mWl9exXOsdK+41q5shyjtMEg3Vpy2dNkiStz2wJywFLTeJnWsNUOUFkDCnLwwoydwO7Aebm5rKKde7XswZ9U5VZl+0rNBr7z13+HCvtN6qFrUtcsrcd85cO1mWl350kSZIktcEkenMP9payK26TOFSUHwBO6NvueOCBCZxfkiRJU8SropI0ml57uX/XmTVHsrpxJ4gc5kbgguLxBcANfeXnR9epwMO92y0kSZIkSVJ7jLv05UeAeeC4iDgAvB3YBVwXERcC9wGvKzb/JN1lL++hu/Tl68c5tyRJ02zYldxpuEohSZI0irGSDZl5zjIvnT5k2wQuGud8kiRJkiSp+SZxG4UkSZIkSdrATDZIkiRJkqRSmWyQJEmSJEmlmsTSl9oAXKJKkiRJkrQcRzZIkiRJkqRSmWyQJEmSJKmBZnfumdpR5SYbJEmSJElSqUw2SJIkSZKkUplskCRJkiRJpXI1Ck3tPUCSJEmSpGYy2SBVbKXkzv5dZ1YYiSTVLyL2A98HHgOWMnMuIo4FrgVmgf3AWZn5UF0xSpKktfM2CkmViYj9EbE3Iu6MiNuKsmMj4qaI+Hrx85i645RUuV/JzFMyc654vhO4OTNPAm4unkuSpCliskFS1exUSFrNNuDK4vGVwKtrjEWSJK2Dt1FIqts2YL54fCXQAd5SVzCSKpfApyMigT/JzN3ATGYeBMjMgxHx7MGdImIHsANgZmaGTqcz8UAXFxcrOU8VyqzLwtalJzwf9biD+63HzJHlHGfSBn8nw2KeOXL0350kTQOTDZKqZKeiBuupyzhf3oedayN1KkaxXF3a8plbo9My84Hib/+miPjqKDsV7cdugLm5uZyfn59giF2dTocqzlOFMuuyfWAuov3njnbcwf3WY2HrEpfsbf7X2cHfybC6L2xd4qyWfL4kCUw2SKqWnYoarKcu43QChnU0NlKnYhTL1WXUTlqbZOYDxc9DEfFx4KXAgxGxuUhAbgYO1RqkJElas3Z8a9OqXN5STWCnQlK/iHg68KTM/H7x+J8DvwfcCFwA7Cp+3lBflJIkaT1MNkiqhJ0KSUPMAB+PCOh+J/nTzPxURHwRuC4iLgTuA15XY4wbWv/FCpdnXj8v+mja9T7DvXZg8Lnq0+T3wmSDpKrYqWgovwSrLpl5L/CiIeXfAU6vPiJJklQWkw2SKmGnQlrdsMRPE69USCYpq+coE0nTxmSDJKlUdkIk9dgeSNLG9aS6A5AkSZIkSe3iyAZJkiRJ0qocraS1MNkgSZKk0tgZ0Tgi4gTgKuAfAj8Bdmfm+yPiWOBaYBbYD5yVmQ/VFaek1ZlskCRJktQUS8BCZt4REc8Abo+Im4DtwM2ZuSsidgI7gbfUGKdUq2lI7DpngyRJkqRGyMyDmXlH8fj7wD5gC7ANuLLY7Erg1fVEKGlUjmyQJEmS1DgRMQu8GLgVmMnMg9BNSETEs5fZZwewA2BmZoZOpzPRGBcXFyd+jqosLi7ygatvAGDrlmc+4bWFrUtD9+nVfbnXR92urOMAzBy58nZNi3ml12eO/Gn5qMdpEpMNkiRJkholIo4CPgq8OTMfiYiR9svM3cBugLm5uZyfn59YjNDt4E36HFXpdDpc8rkfALD/3PknvLZ9mSH7ve2We33U7co6DnQ742fNL79d02Je6fWFrUtcsnfTmo7TJBO7jSIi9kfE3oi4MyJuK8qOjYibIuLrxc9jJnV+SZIkSdMnIp5MN9FwdWZ+rCh+MCI2F69vBg7VFV8Tze7cMxX38GtjmfScDb+Smadk5lzxfCfdiV1OAm4unkuSJEkS0R3CcBmwLzPf2/fSjcAFxeMLgBuqjk3S2lR9G8U2YL54fCXQwVlkJUmSGs+rpqrIacB5wN6IuLMoexuwC7guIi4E7gNeV1N8kkY0yWRDAp+OiAT+pLh/atWJXaqe1AXaN7HLsLqsNnFJ0/RPhjLt1lKXtnwOJUnSeDZqciczPwcsN0HD6VXGImk8k0w2nJaZDxQJhZsi4quj7FT1pC7QvoldhtVltYlLmqZ/MpRpt5a6NHFiF0mSJElaq4n15jLzgeLnoYj4OPBSioldilENTuwiSRXbqFfKJEmSVK2JTBAZEU+PiGf0HgP/HLgLJ3aRJEmq3d77H3b2eknSRE1qZMMM8PFiPdxNwJ9m5qci4os4sYskjWxYR2D/rjPXtO/C1qWpu5VKkjYikz+S2mQiyYbMvBd40ZDy7+DELpIkSZIktdpEbqOQJEmSJEkbl8kGSRMXESdExGciYl9E3B0RbyrK3xER90fEncW/V9Ydq6Rq2C5IktRu7VhbUFLTLQELmXlHMXns7RFxU/Ha+zLzPTXGJqketguSVLPePCGjzgclrYXJhpbZe//DTgSnxsnMg8DB4vH3I2IfsKXeqCTVyXZBkqR2M9kgqVIRMQu8GLgVOA24OCLOB26je5XzoSH77AB2AMzMzNDpdCYe5+LiYiXnWc3C1qXDykaNq7fvzJHDjzNt2lIPWFtdmvA5nDTbher1fwZXqlPT/+ZsF7TRuYKJBjVptIrJBkmViYijgI8Cb87MRyLiUuCdQBY/LwHeMLhfZu4GdgPMzc3l/Pz8xGPtdDpUcZ7VDBuptP/c+cPKhn/Z6DbxC1uXuGTv9Df3bakHrK0uw97vNrFdqMcHrr7h8c9g/2fs8Lak2X9ztguS1FxOECmpEhHxZLodiqsz82MAmflgZj6WmT8BPgS8tM4YJVXLdkGSyjW7c4+jHdQYJhskTVxEBHAZsC8z39tXvrlvs9cAd1Udm6R62C5IktRu7Rh3NsWWyzw24R4bqUSnAecBeyPizqLsbcA5EXEK3eHS+4HfrCc8STWwXZCkiqx2H//szj3FnCF2D1UeP00NtdLwJxMRmjaZ+Tkghrz0yapjkabNsP8P2vD/gO2CJEntZrJBkhrCeywlSdIkNWmlArWfyQZJkqQp4uhHSdI0MNkgSVPGERCSJElqOpMNkiRNmbbO4yBpfP3tg+2CpDpvnTHZMIVWuqq5sLXCQCRJkiRJGsJkgzQlXCZVkiRJVXAiyek32Heo4z012SA1iPfiS5ImYfD/F0dCSpImzWSDJElSw5mMVj/nZZh+415lHrVNsO1QnZ5UdwCSJEmSJKldTDZIkiRJUoPM7tzjqARNVBWfMW+jkKQSuSShpDo5vF6S1BQmG0pi5lHSckxASFqrMr5X+N1Eqt5qczH4d6nHbxnDAAAH7klEQVSNxGTDECs1AnYQpI3JLweSBg22C35HkCTpp0w2rJEdDkmStF5NTFD43Wa6+f4106h/66ttN+6qFVKdTDZIUg38cqiyebtOc/n3LknaiEw2SJIk1cQJHTVJfr7awxEOmkYmGyRJkkrmaAZJ0kZnskGSBszu3MPC1iW221mQtAbjJhhMUEiS2sRkg6QNw3vatdH4mZe0HG+xWNmoS1j2Lk74O1RblHnLTuXJhog4A3g/cATw4czcVXUMPYONhDSN2rBUa5PaBUnNYLsgaZDtgjRdKk02RMQRwB8DvwYcAL4YETdm5lfGOa7DDqXpZbsgaVBV7UJ/Qnalq7xenJDq5/cFaTIm+TdQ9ciGlwL3ZOa9ABFxDbANGKuRkDTVbBckDaqkXbCToY2kBZ93vy9IUyYys7qTRbwWOCMz/3Xx/DzglzPz4r5tdgA7iqfPB75WQWjHAX9XwXmq0Ja6tKUeMB11+bnMfFYdJ7ZdqERb6tKWesB01MV24XDT8L6Nqi11aUs9YDrq0uh2oSivum2YhvdtVG2pS1vqAdNRl2XbhapHNsSQsidkOzJzN7C7mnC6IuK2zJyr8pyT0pa6tKUe0K66TIjtwoS1pS5tqQe0qy4TYrswYW2pS1vqAe2qy4Ss2i5A9W1Dm963ttSlLfWA6a/Lkyo+3wHghL7nxwMPVByDpGaxXZA0yHZB0iDbBWnKVJ1s+CJwUkScGBFPAc4Gbqw4BknNYrsgaZDtgqRBtgvSlKn0NorMXIqIi4G/oLtkzeWZeXeVMSyj0mGYE9aWurSlHtCuupTOdqESbalLW+oB7apL6WwXKtGWurSlHtCuupTOdqESbalLW+oBU16XSieIlCRJkiRJ7Vf1bRSSJEmSJKnlTDZIkiRJkqRSbdhkQ0ScEBGfiYh9EXF3RLyp7pjGFRFHRMSXIuITdccyjog4OiKuj4ivFu/PP6k7pvWKiN8pPl93RcRHIuKpdcek5dkuNJftgupiu9Bctguqi+1Cc9kuNMuGTTYAS8BCZv4CcCpwUUS8oOaYxvUmYF/dQZTg/cCnMvPngRcxpXWKiC3AG4G5zDyZ7mRGZ9cblVZhu9Bctguqi+1Cc9kuqC62C81lu9AgGzbZkJkHM/OO4vH36X4Qt9Qb1fpFxPHAmcCH645lHBHxs8DLgMsAMvNHmfm9eqMayybgyIjYBDwN14NuNNuFZrJdUJ1sF5rJdkF1sl1oJtuF5tmwyYZ+ETELvBi4td5IxvIfgH8H/KTuQMb0XODbwH8uhnJ9OCKeXndQ65GZ9wPvAe4DDgIPZ+an641Ko7JdaBTbBTWC7UKj2C6oEWwXGsV2oWE2fLIhIo4CPgq8OTMfqTue9YiIVwGHMvP2umMpwSbgJcClmfli4AfAznpDWp+IOAbYBpwIPAd4ekT8r/VGpVHYLjSO7YJqZ7vQOLYLqp3tQuPYLjTMhk42RMST6TYQV2fmx+qOZwynAb8eEfuBa4CXR8T/U29I63YAOJCZvezw9XQbjWn0q8A3M/Pbmflj4GPAP605Jq3CdqGRbBdUK9uFRrJdUK1sFxrJdqFhNmyyISKC7v08+zLzvXXHM47MfGtmHp+Zs3QnDvmrzJy6zBdAZv4t8K2IeH5RdDrwlRpDGsd9wKkR8bTi83Y6UzpJzUZhu9BMtguqk+1CM9kuqE62C81ku9A8m+oOoEanAecBeyPizqLsbZn5yRpjUtdvA1dHxFOAe4HX1xzPumTmrRFxPXAH3VmLvwTsrjcqrcJ2oblsF1QX24Xmsl1QXWwXmst2oUEiM+uOQZIkSZIktciGvY1CkiRJkiRNhskGSZIkSZJUKpMNkiRJkiSpVCYbJEmSJElSqUw2SJIkSZKkUpls0GEi4rGIuDMi7oqI/xIRR6+y/dER8b/1PX9OsVSLpJawXZA0yHZB0iDbBfVz6UsdJiIWM/Oo4vGVwN9k5rtW2H4W+ERmnlxNhJKqZrsgaZDtgqRBtgvq58gGrebzwBaAiDgqIm6OiDsiYm9EbCu22QX8D0UW8w8jYjYi7ir22R4RH4uIT0XE1yPiD3oHjogLI+JvIqITER+KiA9WXjtJ62G7IGmQ7YKkQbYLG9ymugNQc0XEEcDpwGVF0X8HXpOZj0TEccAtEXEjsBM4OTNPKfabHTjUKcCLgUeBr0XEB4DHgP8DeAnwfeCvgL+eaIUkjc12QdIg2wVJg2wXBCYbNNyREXEnMAvcDtxUlAfw7yPiZcBP6GYqZ0Y43s2Z+TBARHwF+DngOOD/zczvFuV/BjyvzEpIKpXtgqRBtguSBtku6HHeRqFh/r7ILv4c8BTgoqL8XOBZwC8Vrz8IPHWE4z3a9/gxukmuKC9cSRWwXZA0yHZB0iDbBT3OZIOWVWQR3wj824h4MvBM4FBm/jgifoVuIwLd4UvPWOPhvwD8s4g4JiI2Af+qrLglTY7tgqRBtguSBtkuCEw2aBWZ+SW690CdDVwNzEXEbXSzk18ttvkO8P9Fd4mbPxzxuPcD/x64FfhL4CvAw+XXQFLZbBckDbJdkDTIdkEufanaRMRRmblYZCQ/DlyemR+vOy5J9bFdkDTIdkHSINuF6eDIBtXpHcUEMncB3wT+vOZ4JNXPdkHSINsFSYNsF6aAIxskSZIkSVKpHNkgSZIkSZJKZbJBkiRJkiSVymSDJEmSJEkqlckGSZIkSZJUKpMNkiRJkiSpVP8/IU4DNRcExWUAAAAASUVORK5CYII=",
             "text/plain": [
               "<Figure size 1296x720 with 8 Axes>"
             ]
@@ -1317,37 +1311,37 @@
             "needs_background": "light"
           }
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "4MUtaGwi_G_O"
-      },
-      "source": [
-        "Do you see the issues with having too few bins or too many bins? In particular, do you notice weird patterns that emerge from `bins=30`? \n",
-        "\n",
-        "**Q: Can you guess why do you see such patterns? What are the peaks and what are the empty bars? What do they tell you about choosing the binsize in histograms?**"
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "qIj9lKUM_G_P",
-        "outputId": "5dae9680-092d-4992-f116-8d2c33a27b7c"
-      },
+        "id": "NbM-6DjA_G_O",
+        "outputId": "d4276bd5-de15-4431-a2d8-e7336373709e"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Do you see the issues with having too few bins or too many bins? In particular, do you notice weird patterns that emerge from `bins=30`? \n",
+        "\n",
+        "**Q: Can you guess why do you see such patterns? What are the peaks and what are the empty bars? What do they tell you about choosing the binsize in histograms?**"
+      ],
+      "metadata": {
+        "id": "4MUtaGwi_G_O"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "# TODO: Provide your answer and evidence here\n"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD4CAYAAAAXUaZHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAASAElEQVR4nO3dfYxld13H8feHFtAWSQudNmsfnEIqEY1um0lBGxq0gH0gFIhoG8WKxAVTTBETKZiIDyFZlAclaMlCa0sshcLS0EhFmoogiUVmSylbtkhblnbbdXcE5MEScMvXP+YM3i53Onfvw9w7v32/kpt7zu+ce893NzOf+5vf/Z1zUlVIktrymGkXIEkaP8NdkhpkuEtSgwx3SWqQ4S5JDTpy2gUAHHfccTU/Pz/tMiRpQ9mxY8d/VdVcv20zEe7z8/MsLi5OuwxJ2lCSfGW1bQ7LSFKDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSg2biDFVJkzd/+Uf6tu/eesE6V6L1YM9dkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNWjNcE9ycpKPJ9mV5M4kl3XtT0pyc5Ivdc/Hdu1J8vYkdye5I8kZk/5HSJIeaZCe+wHgD6rqp4BnApcmeTpwOXBLVZ0G3NKtA5wHnNY9tgBXjL1qSdKjWjPcq2pvVd3WLX8L2AWcCFwIXNPtdg3wwm75QuA9texW4Jgkm8ZeuSRpVYc05p5kHjgd+DRwQlXtheUPAOD4brcTgft7Xrana5MkrZOBwz3JE4DtwKur6puPtmufturzfluSLCZZXFpaGrQMSdIABgr3JI9lOdivraoPdc37VoZbuuf9Xfse4OSel58EPHjwe1bVtqpaqKqFubm5YeuXJPUxyGyZAFcCu6rqrT2bbgQu6ZYvAT7c0/6b3ayZZwLfWBm+kSStj0GuCnkW8FLg80lu79peD2wFrk/ycuA+4CXdtpuA84G7gYeAl421YknSmtYM96r6FP3H0QHO6bN/AZeOWJckaQSeoSpJDTLcJalB3olJmlH97pzkXZM0KHvuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAZ5EpOkgXhS1cZiz12SGmS4S1KDDHdJapDhLkkNGuQ2e1cl2Z9kZ0/b+5Pc3j12r9yhKcl8ku/0bHvnJIuXJPU3yGyZq4F3AO9ZaaiqX1tZTvIW4Bs9+99TVZvHVaAk6dANcpu9TyaZ77etu3n2rwK/NN6yJEmjGHXM/VnAvqr6Uk/bqUk+m+QTSZ612guTbEmymGRxaWlpxDIkSb1GDfeLget61vcCp1TV6cBrgPcmeWK/F1bVtqpaqKqFubm5EcuQJPUaOtyTHAm8GHj/SltVfbeqvtot7wDuAX5y1CIlSYdmlJ77c4C7qmrPSkOSuSRHdMtPAU4D7h2tREnSoRpkKuR1wL8BT0uyJ8nLu00X8cghGYCzgTuSfA74IPDKqvraOAuWJK1tkNkyF6/S/lt92rYD20cvS5I0Cs9QlaQGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDBrmHqqQhzV/+kR9q2731gilUosONPXdJapDhLkkNGuRmHVcl2Z9kZ0/bnyR5IMnt3eP8nm2vS3J3ki8m+eVJFS5JWt0gPfergXP7tL+tqjZ3j5sAkjyd5Ts0/XT3mr9due2eJGn9rBnuVfVJYNBb5V0IvK+7UfaXgbuBM0eoT5I0hFHG3F+V5I5u2ObYru1E4P6effZ0bZKkdTRsuF8BPBXYDOwF3tK1p8++1e8NkmxJsphkcWlpacgyJEn9DDXPvar2rSwneRfwD93qHuDknl1PAh5c5T22AdsAFhYW+n4ASGqD8/3X31A99ySbelZfBKzMpLkRuCjJ45OcCpwG/PtoJUqSDtWaPfck1wHPBo5Lsgd4A/DsJJtZHnLZDbwCoKruTHI98AXgAHBpVT08mdIlSatZM9yr6uI+zVc+yv5vBN44SlGSpNF4hqokNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUFrhnuSq5LsT7Kzp+0vk9yV5I4kNyQ5pmufT/KdJLd3j3dOsnhJUn+D9NyvBs49qO1m4Geq6meB/wBe17Ptnqra3D1eOZ4yJUmHYpDb7H0yyfxBbR/rWb0V+JXxliXNjvnLP/JDbbu3XjCFSqTBjWPM/beBf+xZPzXJZ5N8IsmzVntRki1JFpMsLi0tjaEMSdKKkcI9yR8BB4Bru6a9wClVdTrwGuC9SZ7Y77VVta2qFqpqYW5ubpQyJEkHGTrck1wCPB/49aoqgKr6blV9tVveAdwD/OQ4CpUkDW6ocE9yLvBa4AVV9VBP+1ySI7rlpwCnAfeOo1BJ0uDW/EI1yXXAs4HjkuwB3sDy7JjHAzcnAbi1mxlzNvBnSQ4ADwOvrKqvTah2SdIqBpktc3Gf5itX2Xc7sH3UoiRJo/EMVUlqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAateVVISYeffveN1cZiz12SGjRQuCe5Ksn+JDt72p6U5OYkX+qej+3ak+TtSe5OckeSMyZVvCSpv0GHZa4G3gG8p6ftcuCWqtqa5PJu/bXAeSzfXu804BnAFd2zpBnkEEybBuq5V9UngYNvl3chcE23fA3wwp7299SyW4FjkmwaR7GSpMGM8oXqCVW1F6Cq9iY5vms/Ebi/Z789XdveEY4lST/Q76+N3VsvmEIls2sSs2XSp61+aKdkC7AF4JRTTplAGdLhwaBTP6PMltm3MtzSPe/v2vcAJ/fsdxLw4MEvrqptVbVQVQtzc3MjlCFJOtgo4X4jcEm3fAnw4Z723+xmzTwT+MbK8I0kaX0MNCyT5Drg2cBxSfYAbwC2AtcneTlwH/CSbvebgPOBu4GHgJeNuWZJ0hoGCvequniVTef02beAS0cpSpI0Gi8/IM0A55pr3Lz8gCQ1yJ67tIHYw9eg7LlLUoMMd0lqkOEuSQ0y3CWpQYa7JDXI2TKShuZFy2aX4S41yCmTMtzVlNVCzd7k+vGDZTY45i5JDTLcJalBhrskNchwl6QGGe6S1KChZ8skeRrw/p6mpwB/DBwD/A6w1LW/vqpuGrpCaYMYdJaIs0m0HoYO96r6IrAZIMkRwAPADSzfVu9tVfXmsVQoSTpk45rnfg5wT1V9JcmY3lJSyzy7dbLGNeZ+EXBdz/qrktyR5Kokx/Z7QZItSRaTLC4tLfXbRZI0pJHDPcnjgBcAH+iargCeyvKQzV7gLf1eV1Xbqmqhqhbm5uZGLUOS1GMcPffzgNuqah9AVe2rqoer6vvAu4Azx3AMSdIhGEe4X0zPkEySTT3bXgTsHMMxJEmHYKQvVJMcBTwXeEVP818k2QwUsPugbZKkdTBSuFfVQ8CTD2p76UgVSZJG5hmqktQgw12SGuTNOiTNNC/XMBx77pLUIHvu0hDsTWrW2XOXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaNPK1ZZLsBr4FPAwcqKqFJE8C3g/Ms3w3pl+tqq+PeixJ0mDG1XP/xaraXFUL3frlwC1VdRpwS7cuSVonkxqWuRC4plu+BnjhhI4jSepjHOFewMeS7EiypWs7oar2AnTPxx/8oiRbkiwmWVxaWhpDGZKkFeO4nvtZVfVgkuOBm5PcNciLqmobsA1gYWGhxlCHJKkzcs+9qh7snvcDNwBnAvuSbALonvePehxJ0uBGCvckRyf5sZVl4HnATuBG4JJut0uAD49yHEnSoRl1WOYE4IYkK+/13qr6aJLPANcneTlwH/CSEY+jw0i/W9jt3nrBFCrRevP2heMzUrhX1b3Az/Vp/ypwzijvLa3FINAwDpfOgzfI1mHLDwe1zMsPSFKDDHdJapDDMjosOASjw409d0lqkOEuSQ0y3CWpQYa7JDXIL1S1IfiFqHRoDHdJzTqcOwUOy0hSgwx3SWqQwzKaiMPl4kzSrDLcJTXhcB5f78dhGUlq0NDhnuTkJB9PsivJnUku69r/JMkDSW7vHuePr1xJ0iBGGZY5APxBVd3W3WpvR5Kbu21vq6o3j16eJGkYQ4d7Ve0F9nbL30qyCzhxXIVJkoY3ljH3JPPA6cCnu6ZXJbkjyVVJjl3lNVuSLCZZXFpaGkcZkqTOyLNlkjwB2A68uqq+meQK4M+B6p7fAvz2wa+rqm3ANoCFhYUatQ5tTM5wkCZjpJ57kseyHOzXVtWHAKpqX1U9XFXfB94FnDl6mZKkQzHKbJkAVwK7quqtPe2benZ7EbBz+PIkScMYZVjmLOClwOeT3N61vR64OMlmlodldgOvGKlCSdIhG2W2zKeA9Nl00/DlSJLGwcsPHIYG/RLTa8FIG5eXH5CkBtlzl6RDsFGueGrPXZIaZLhLUoMcltHIPMtUmj2Ge+MMXmltq/2ezOJY+qAclpGkBtlz16o2yqwAST/McG/Eeg2/OMwjbQyG+wjs2UqaVYb7DGn9w8Jevzaajfwza7hPyUb+oZE0+wz3Gdd6b15qwSz+nhru68BeuqT1ZriP2XoEuR8WktYysXBPci7w18ARwLurauukjiVJG8F6Dt9MJNyTHAH8DfBcYA/wmSQ3VtUXJnG8Qf/DRtlPkjaSSfXczwTurqp7AZK8D7gQmEi492NAS5qmaWfQpML9ROD+nvU9wDN6d0iyBdjSrX47yRcnVMujypvW3OU44L8mX8lQrG041jYcaxvOo9Y2QAY9mp9YbcOkwr3fjbPrEStV24BtEzr+2CRZrKqFadfRj7UNx9qGY23DmVZtk7oq5B7g5J71k4AHJ3QsSdJBJhXunwFOS3JqkscBFwE3TuhYkqSDTGRYpqoOJHkV8E8sT4W8qqrunMSx1sEsDx1Z23CsbTjWNpyp1JaqWnsvSdKG4p2YJKlBhrskNchwX0WSk5N8PMmuJHcmuWzaNa1I8iNJ/j3J57ra/nTaNfVKckSSzyb5h2nXcrAku5N8PsntSRanXU+vJMck+WCSu7qfu5+fdk0ASZ7W/X+tPL6Z5NXTrmtFkt/vfg92JrkuyY9Mu6YVSS7r6rpzvf/PHHNfRZJNwKaqui3JjwE7gBdO6hIKhyJJgKOr6ttJHgt8Crisqm6dcmkAJHkNsAA8saqeP+16eiXZDSxU1cyd8JLkGuBfq+rd3Syzo6rqv6ddV6/u0iIPAM+oqq/MQD0nsvzz//Sq+k6S64Gbqurq6VYGSX4GeB/LZ+x/D/go8LtV9aX1OL4991VU1d6quq1b/hawi+Uzb6euln27W31s95iJT+kkJwEXAO+edi0bSZInAmcDVwJU1fdmLdg75wD3zEKw9zgS+NEkRwJHMTvn1PwUcGtVPVRVB4BPAC9ar4Mb7gNIMg+cDnx6upX8v27o43ZgP3BzVc1KbX8F/CHw/WkXsooCPpZkR3cJjFnxFGAJ+LtuSOvdSY6edlF9XARcN+0iVlTVA8CbgfuAvcA3qupj063qB3YCZyd5cpKjgPN55MmdE2W4ryHJE4DtwKur6pvTrmdFVT1cVZtZPvv3zO5PwKlK8nxgf1XtmHYtj+KsqjoDOA+4NMnZ0y6ocyRwBnBFVZ0O/A9w+XRLeqRuqOgFwAemXcuKJMeyfFHCU4EfB45O8hvTrWpZVe0C3gTczPKQzOeAA+t1fMP9UXTj2duBa6vqQ9Oup5/uT/d/Ac6dcikAZwEv6Ma13wf8UpK/n25Jj1RVD3bP+4EbWB4PnQV7gD09f4F9kOWwnyXnAbdV1b5pF9LjOcCXq2qpqv4X+BDwC1Ou6Qeq6sqqOqOqzga+BqzLeDsY7qvqvrS8EthVVW+ddj29kswlOaZb/lGWf8Dvmm5VUFWvq6qTqmqe5T/f/7mqZqIXBZDk6O7Lcbohj+ex/Kfz1FXVfwL3J3la13QO63iJ7AFdzAwNyXTuA56Z5Kjud/Yclr8fmwlJju+eTwFezDr+/3mbvdWdBbwU+Hw3tg3w+qq6aYo1rdgEXNPNXHgMcH1Vzdy0wxl0AnDDcgZwJPDeqvrodEt6hN8Dru2GP+4FXjblen6gGzN+LvCKadfSq6o+neSDwG0sD3l8ltm6FMH2JE8G/he4tKq+vl4HdiqkJDXIYRlJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhr0f0mp/incm3mJAAAAAElFTkSuQmCC\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD4CAYAAAAXUaZHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAASAElEQVR4nO3dfYxld13H8feHFtAWSQudNmsfnEIqEY1um0lBGxq0gH0gFIhoG8WKxAVTTBETKZiIDyFZlAclaMlCa0sshcLS0EhFmoogiUVmSylbtkhblnbbdXcE5MEScMvXP+YM3i53Onfvw9w7v32/kpt7zu+ce893NzOf+5vf/Z1zUlVIktrymGkXIEkaP8NdkhpkuEtSgwx3SWqQ4S5JDTpy2gUAHHfccTU/Pz/tMiRpQ9mxY8d/VdVcv20zEe7z8/MsLi5OuwxJ2lCSfGW1bQ7LSFKDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSg2biDFVJkzd/+Uf6tu/eesE6V6L1YM9dkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNWjNcE9ycpKPJ9mV5M4kl3XtT0pyc5Ivdc/Hdu1J8vYkdye5I8kZk/5HSJIeaZCe+wHgD6rqp4BnApcmeTpwOXBLVZ0G3NKtA5wHnNY9tgBXjL1qSdKjWjPcq2pvVd3WLX8L2AWcCFwIXNPtdg3wwm75QuA9texW4Jgkm8ZeuSRpVYc05p5kHjgd+DRwQlXtheUPAOD4brcTgft7Xrana5MkrZOBwz3JE4DtwKur6puPtmufturzfluSLCZZXFpaGrQMSdIABgr3JI9lOdivraoPdc37VoZbuuf9Xfse4OSel58EPHjwe1bVtqpaqKqFubm5YeuXJPUxyGyZAFcCu6rqrT2bbgQu6ZYvAT7c0/6b3ayZZwLfWBm+kSStj0GuCnkW8FLg80lu79peD2wFrk/ycuA+4CXdtpuA84G7gYeAl421YknSmtYM96r6FP3H0QHO6bN/AZeOWJckaQSeoSpJDTLcJalB3olJmlH97pzkXZM0KHvuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAZ5EpOkgXhS1cZiz12SGmS4S1KDDHdJapDhLkkNGuQ2e1cl2Z9kZ0/b+5Pc3j12r9yhKcl8ku/0bHvnJIuXJPU3yGyZq4F3AO9ZaaiqX1tZTvIW4Bs9+99TVZvHVaAk6dANcpu9TyaZ77etu3n2rwK/NN6yJEmjGHXM/VnAvqr6Uk/bqUk+m+QTSZ612guTbEmymGRxaWlpxDIkSb1GDfeLget61vcCp1TV6cBrgPcmeWK/F1bVtqpaqKqFubm5EcuQJPUaOtyTHAm8GHj/SltVfbeqvtot7wDuAX5y1CIlSYdmlJ77c4C7qmrPSkOSuSRHdMtPAU4D7h2tREnSoRpkKuR1wL8BT0uyJ8nLu00X8cghGYCzgTuSfA74IPDKqvraOAuWJK1tkNkyF6/S/lt92rYD20cvS5I0Cs9QlaQGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDBrmHqqQhzV/+kR9q2731gilUosONPXdJapDhLkkNGuRmHVcl2Z9kZ0/bnyR5IMnt3eP8nm2vS3J3ki8m+eVJFS5JWt0gPfergXP7tL+tqjZ3j5sAkjyd5Ts0/XT3mr9due2eJGn9rBnuVfVJYNBb5V0IvK+7UfaXgbuBM0eoT5I0hFHG3F+V5I5u2ObYru1E4P6effZ0bZKkdTRsuF8BPBXYDOwF3tK1p8++1e8NkmxJsphkcWlpacgyJEn9DDXPvar2rSwneRfwD93qHuDknl1PAh5c5T22AdsAFhYW+n4ASGqD8/3X31A99ySbelZfBKzMpLkRuCjJ45OcCpwG/PtoJUqSDtWaPfck1wHPBo5Lsgd4A/DsJJtZHnLZDbwCoKruTHI98AXgAHBpVT08mdIlSatZM9yr6uI+zVc+yv5vBN44SlGSpNF4hqokNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUFrhnuSq5LsT7Kzp+0vk9yV5I4kNyQ5pmufT/KdJLd3j3dOsnhJUn+D9NyvBs49qO1m4Geq6meB/wBe17Ptnqra3D1eOZ4yJUmHYpDb7H0yyfxBbR/rWb0V+JXxliXNjvnLP/JDbbu3XjCFSqTBjWPM/beBf+xZPzXJZ5N8IsmzVntRki1JFpMsLi0tjaEMSdKKkcI9yR8BB4Bru6a9wClVdTrwGuC9SZ7Y77VVta2qFqpqYW5ubpQyJEkHGTrck1wCPB/49aoqgKr6blV9tVveAdwD/OQ4CpUkDW6ocE9yLvBa4AVV9VBP+1ySI7rlpwCnAfeOo1BJ0uDW/EI1yXXAs4HjkuwB3sDy7JjHAzcnAbi1mxlzNvBnSQ4ADwOvrKqvTah2SdIqBpktc3Gf5itX2Xc7sH3UoiRJo/EMVUlqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAateVVISYeffveN1cZiz12SGjRQuCe5Ksn+JDt72p6U5OYkX+qej+3ak+TtSe5OckeSMyZVvCSpv0GHZa4G3gG8p6ftcuCWqtqa5PJu/bXAeSzfXu804BnAFd2zpBnkEEybBuq5V9UngYNvl3chcE23fA3wwp7299SyW4FjkmwaR7GSpMGM8oXqCVW1F6Cq9iY5vms/Ebi/Z789XdveEY4lST/Q76+N3VsvmEIls2sSs2XSp61+aKdkC7AF4JRTTplAGdLhwaBTP6PMltm3MtzSPe/v2vcAJ/fsdxLw4MEvrqptVbVQVQtzc3MjlCFJOtgo4X4jcEm3fAnw4Z723+xmzTwT+MbK8I0kaX0MNCyT5Drg2cBxSfYAbwC2AtcneTlwH/CSbvebgPOBu4GHgJeNuWZJ0hoGCvequniVTef02beAS0cpSpI0Gi8/IM0A55pr3Lz8gCQ1yJ67tIHYw9eg7LlLUoMMd0lqkOEuSQ0y3CWpQYa7JDXI2TKShuZFy2aX4S41yCmTMtzVlNVCzd7k+vGDZTY45i5JDTLcJalBhrskNchwl6QGGe6S1KChZ8skeRrw/p6mpwB/DBwD/A6w1LW/vqpuGrpCaYMYdJaIs0m0HoYO96r6IrAZIMkRwAPADSzfVu9tVfXmsVQoSTpk45rnfg5wT1V9JcmY3lJSyzy7dbLGNeZ+EXBdz/qrktyR5Kokx/Z7QZItSRaTLC4tLfXbRZI0pJHDPcnjgBcAH+iargCeyvKQzV7gLf1eV1Xbqmqhqhbm5uZGLUOS1GMcPffzgNuqah9AVe2rqoer6vvAu4Azx3AMSdIhGEe4X0zPkEySTT3bXgTsHMMxJEmHYKQvVJMcBTwXeEVP818k2QwUsPugbZKkdTBSuFfVQ8CTD2p76UgVSZJG5hmqktQgw12SGuTNOiTNNC/XMBx77pLUIHvu0hDsTWrW2XOXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaNPK1ZZLsBr4FPAwcqKqFJE8C3g/Ms3w3pl+tqq+PeixJ0mDG1XP/xaraXFUL3frlwC1VdRpwS7cuSVonkxqWuRC4plu+BnjhhI4jSepjHOFewMeS7EiypWs7oar2AnTPxx/8oiRbkiwmWVxaWhpDGZKkFeO4nvtZVfVgkuOBm5PcNciLqmobsA1gYWGhxlCHJKkzcs+9qh7snvcDNwBnAvuSbALonvePehxJ0uBGCvckRyf5sZVl4HnATuBG4JJut0uAD49yHEnSoRl1WOYE4IYkK+/13qr6aJLPANcneTlwH/CSEY+jw0i/W9jt3nrBFCrRevP2heMzUrhX1b3Az/Vp/ypwzijvLa3FINAwDpfOgzfI1mHLDwe1zMsPSFKDDHdJapDDMjosOASjw409d0lqkOEuSQ0y3CWpQYa7JDXIL1S1IfiFqHRoDHdJzTqcOwUOy0hSgwx3SWqQwzKaiMPl4kzSrDLcJTXhcB5f78dhGUlq0NDhnuTkJB9PsivJnUku69r/JMkDSW7vHuePr1xJ0iBGGZY5APxBVd3W3WpvR5Kbu21vq6o3j16eJGkYQ4d7Ve0F9nbL30qyCzhxXIVJkoY3ljH3JPPA6cCnu6ZXJbkjyVVJjl3lNVuSLCZZXFpaGkcZkqTOyLNlkjwB2A68uqq+meQK4M+B6p7fAvz2wa+rqm3ANoCFhYUatQ5tTM5wkCZjpJ57kseyHOzXVtWHAKpqX1U9XFXfB94FnDl6mZKkQzHKbJkAVwK7quqtPe2benZ7EbBz+PIkScMYZVjmLOClwOeT3N61vR64OMlmlodldgOvGKlCSdIhG2W2zKeA9Nl00/DlSJLGwcsPHIYG/RLTa8FIG5eXH5CkBtlzl6RDsFGueGrPXZIaZLhLUoMcltHIPMtUmj2Ge+MMXmltq/2ezOJY+qAclpGkBtlz16o2yqwAST/McG/Eeg2/OMwjbQyG+wjs2UqaVYb7DGn9w8Jevzaajfwza7hPyUb+oZE0+wz3Gdd6b15qwSz+nhru68BeuqT1ZriP2XoEuR8WktYysXBPci7w18ARwLurauukjiVJG8F6Dt9MJNyTHAH8DfBcYA/wmSQ3VtUXJnG8Qf/DRtlPkjaSSfXczwTurqp7AZK8D7gQmEi492NAS5qmaWfQpML9ROD+nvU9wDN6d0iyBdjSrX47yRcnVMujypvW3OU44L8mX8lQrG041jYcaxvOo9Y2QAY9mp9YbcOkwr3fjbPrEStV24BtEzr+2CRZrKqFadfRj7UNx9qGY23DmVZtk7oq5B7g5J71k4AHJ3QsSdJBJhXunwFOS3JqkscBFwE3TuhYkqSDTGRYpqoOJHkV8E8sT4W8qqrunMSx1sEsDx1Z23CsbTjWNpyp1JaqWnsvSdKG4p2YJKlBhrskNchwX0WSk5N8PMmuJHcmuWzaNa1I8iNJ/j3J57ra/nTaNfVKckSSzyb5h2nXcrAku5N8PsntSRanXU+vJMck+WCSu7qfu5+fdk0ASZ7W/X+tPL6Z5NXTrmtFkt/vfg92JrkuyY9Mu6YVSS7r6rpzvf/PHHNfRZJNwKaqui3JjwE7gBdO6hIKhyJJgKOr6ttJHgt8Crisqm6dcmkAJHkNsAA8saqeP+16eiXZDSxU1cyd8JLkGuBfq+rd3Syzo6rqv6ddV6/u0iIPAM+oqq/MQD0nsvzz//Sq+k6S64Gbqurq6VYGSX4GeB/LZ+x/D/go8LtV9aX1OL4991VU1d6quq1b/hawi+Uzb6euln27W31s95iJT+kkJwEXAO+edi0bSZInAmcDVwJU1fdmLdg75wD3zEKw9zgS+NEkRwJHMTvn1PwUcGtVPVRVB4BPAC9ar4Mb7gNIMg+cDnx6upX8v27o43ZgP3BzVc1KbX8F/CHw/WkXsooCPpZkR3cJjFnxFGAJ+LtuSOvdSY6edlF9XARcN+0iVlTVA8CbgfuAvcA3qupj063qB3YCZyd5cpKjgPN55MmdE2W4ryHJE4DtwKur6pvTrmdFVT1cVZtZPvv3zO5PwKlK8nxgf1XtmHYtj+KsqjoDOA+4NMnZ0y6ocyRwBnBFVZ0O/A9w+XRLeqRuqOgFwAemXcuKJMeyfFHCU4EfB45O8hvTrWpZVe0C3gTczPKQzOeAA+t1fMP9UXTj2duBa6vqQ9Oup5/uT/d/Ac6dcikAZwEv6Ma13wf8UpK/n25Jj1RVD3bP+4EbWB4PnQV7gD09f4F9kOWwnyXnAbdV1b5pF9LjOcCXq2qpqv4X+BDwC1Ou6Qeq6sqqOqOqzga+BqzLeDsY7qvqvrS8EthVVW+ddj29kswlOaZb/lGWf8Dvmm5VUFWvq6qTqmqe5T/f/7mqZqIXBZDk6O7Lcbohj+ex/Kfz1FXVfwL3J3la13QO63iJ7AFdzAwNyXTuA56Z5Kjud/Yclr8fmwlJju+eTwFezDr+/3mbvdWdBbwU+Hw3tg3w+qq6aYo1rdgEXNPNXHgMcH1Vzdy0wxl0AnDDcgZwJPDeqvrodEt6hN8Dru2GP+4FXjblen6gGzN+LvCKadfSq6o+neSDwG0sD3l8ltm6FMH2JE8G/he4tKq+vl4HdiqkJDXIYRlJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhr0f0mp/incm3mJAAAAAElFTkSuQmCC",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
@@ -1357,25 +1351,29 @@
             "needs_background": "light"
           }
         }
-      ]
+      ],
+      "metadata": {
+        "jupyter": {
+          "outputs_hidden": false
+        },
+        "id": "qIj9lKUM_G_P",
+        "outputId": "5dae9680-092d-4992-f116-8d2c33a27b7c"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "f_07JYIS_G_P"
-      },
       "source": [
         "## Formulae for choosing the number of bins. \n",
         "\n",
         "We can manually choose the number of bins based on those formulae. "
-      ]
+      ],
+      "metadata": {
+        "id": "f_07JYIS_G_P"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "id": "EFxa5Cwz_G_Q",
-        "outputId": "99ee4e8d-011f-4ade-9bf3-0afda60017e7"
-      },
+      "execution_count": null,
       "source": [
         "N = len(movies)\n",
         "\n",
@@ -1405,7 +1403,6 @@
         "movies['IMDB_Rating'].hist(bins=nbins)\n",
         "\n"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1422,7 +1419,7 @@
         {
           "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsYAAAEICAYAAABcYjLsAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nO3dfZhkZX3n//cn4gMBFRHpIJCMrsREnRV1omZZs52QKIIJmCjCEgUlP3QXsprM7opuspo17pJs0GiMJKMYICEgKxr4KWskhF4lG1BBIuJIRJzAwMgI8jRg1MHv/nFOS9FT3VPTXc/9fl1XXVV1n/uc+lZ13X2+dZ/73CdVhSRJkrTa/dCoA5AkSZLGgYmxJEmShImxJEmSBJgYS5IkSYCJsSRJkgSYGEuSJEmAibEkqUOS2SSbl1j+J0l+e5gxSatRkk1Jfn6RZS9KcsOwY1oNTIw1EDZoTZok/zrJ/01yT5JvJfm7JD/VLjshyRWjjnExSfZLcnGS25JUkjULlv9+kluS3Jvkn5L8l+W+VlW9oaresdKYpWFo90XfTrKt4/bkRerOJfnnJPe1beXqJKcmefQuvN5fJNnSrv+PSX6tY9matn12xrKsH5lV9Zmqevpy1tXSTIyHaKkdb7v8gCTnJrkzyf1JPpvk8AXbqHbZtiS3JnlXkke0y67vaGwPtg18/vlbe4jvrCTfXdBoH9Gl3tvaOLomvjtjg9a4SfI44OPAHwF7A/sDvwN8p0/b360f21nC94FPAr+yyPIzgZ+oqscB/wr4t0l+ecAxSePiF6tqz47bbUvUPaWqHgvsB6wHjgEuSZIeX+t/AGvatvZLwO8med6COnt1xOKPzDFjYjwkO9vxJtkbuAL4LvBMYB/g3cD5SY5asLlnV9WewL8BXgW8DqCqnjnf2IDP0DTw+cb333sM9fcX/AN5cMH7+BfAK4Atu/gRSOPsxwGq6ryqerCqvl1Vn6qqLyb5SeBPgJ9ufyzeDT/oXersDXpYr3L74/HkJF8FvtqWvTjJDe2P4/cn+T8LtvG6JBuT3JXkr5P8WC/BV9XtVfV+4HOLLL+hqu7vKPo+8LSltpnkrUnuaHvcjusoPyvJ77aPZ5NsTrI+yda2p+y1HXUPT/Lltgfu1iT/sZf3I41aVd1fVXM0ye1PA0f0uN71VTX/g7ra279YQSg/1bahu5L8WZLHwI5Dntp2+h+TfLH9//Lhjrr7JPl4krvbTrnPJDH/W4QfzPAsuuNtl/8GsA04saq+0S4/D3gn8K5uv1ar6kbg74CDh/QeAN4HvJkmgd8ZG7QmxT8CDyY5O8lLkzxhfkFVbQTeAPx9+2Nxr13Y7lHAC4BnJNkH+AjwFuCJwA00vbcAtD+A3wr8MvAkmh+3563sbT0kzSHhbcBmYA/gL5eo/iM0P873B44HNiRZ7CjPjwCPb+ueCPxxx+d3JvD6tgfuWcDfrviNSENUVTcDnwde1Os67Y/eB4Cv0HQiXbKgyj+1Pyj/rP2/sJTjgJfQJNc/DvzWEnWPBg4DngL8S+CEtnw9Tbt/EjBD83+men0/q40JxvAsuuNt/QJwYVV9f0H5BTRf8h16d5L8BE1jvbGPcf77NgG9OsnDDssmeSXw3apa2MgXY4PWRKiqe4F/TfPd+gDwzTRjdmdWuOn/UVXfqqpvA4cD11fVR6tqO/Be4BsddV/f1t/YLv/vwMG99hrvTFWdBjwWeC7w58A9O1nlt6vqO1X1f4BP0LTRbr4H/Leq+l77v2Eb8PSOZc9I8riququqrlnxG5F23V+1nSt3J/mrZax/G82R3p5U1b+naWsvAj7KQ0Oy7gB+Cvgx4HltnXN3srn3VdUtVfUtmo6yY5eo+96quq2t+//zUKfZ92iGhvxY204/U1XuRxdhYjwkPex496H78IT5sid1lF2T5H5gIzAHvL9PYb4XOAjYF/ht4KwkhwAk2ZNmR/2mXdieDVoTo01IT6iqA2h6N58M/OEKN3tLx+Mndz5vv8edsz/8GPCe+R048C0gND2xfVGNLwDfphnKtZi7Fgy9+Kc2/m7ubBP5eQ8Ae7aPf4XmB8E/tcNGfnqZoUsrcVRV7dXejoIfzK7S6zk4+9O0x561R4avAA4A/l1btq2qPl9V26vqduAU4MXtUMvFdP4PWaodwsN/aHe2w/9J04H2qSQ3JTl1V97LamNiPEQ72fHeQZMALjRf9s2OsufSfOFfRXOYdo8+xXdNVd3ZNtpLaH7Jzp+g8zvAn1fV13dhkzZoTaSq+gpwFk07he5HKe4Hfrjj+Y9021TH4y00O0kA2uFRB3Qsv4Vm2MFeHbfdq+r/LuMt7MxuLD3u8QlJOv+v/ChNr9kuqarPVdWRND+2/4rmCJg0cu3sKjs9ByfJgTS9u59Z5kst1dbm/z8sdWLfgR2Pl9sO76uq9VX1VOAXgd9Mcuiubme1MDEekS473r8BfqXL+NmjaXqVvrZg/aqqC4C/B/7roMLkoQZ7KPAfknwjyTdoGusFSd68xPo2aE2EJD/RnkB2QPv8QJojHFe2VW4HDkjyqI7VrgV+OckPJ3kazfjapXwCWJvkqDSzVJzMw5PpPwHekuSZbQyPb4cvzcc4l+TtS7yHxwDz00o9umOc/g8leX2SJ6Tx/Pa1L9tJvL+T5FFJXgS8DPhfO6m/MJ5HJTkuyeOr6nvAvcCDO1tPGgdtu/43wEXAZ2nHCbfnyHQ9aplk3yTHJNkzySOSvITm/8jftstfkOTpbZt8Is1R2rmqWmpY08lpZqzam2Yo4YeX8V5eluRp7Y/x+XZoW1yEifGQ9LDjfTfwOODMJD+S5DFJjqUZ0vC2LmOP550GnJSkW2/Vwhjm51Bcs8jyV7QN+oeSvBj4VeDidvGhNEn8we3tNpoxkX+8xEvaoDUp7qM5+nJVO0zpSuBLNGPcodmxXQ98I8kdbdm7aU5CvR04m52MFayqO4BXAr8P3Ak8g+aknu+0yz8G/B7NTDT3tq//0o5NHEhzsu1ivk0zvheak36+3bHs5TQ/ru8D/oJmdpw/WmJb3wDuomnn5wJvaH/M76pXA5va9/MGmv8p0jh7X5L7aNr1HwIXAod17IMPpOmQ6qZohk1spmk/fwC8qaouapc/lWZaxfto2vd3WHqIITQnyX4KuKm9/e4y3tNBNJ1v29rY39/OuKEu4nDN4UiyP82O9BBgL+Bumunb/lM7/pgkP0qzY3wJTZJcwK9V1dkd2yngoHZGivmy/w18uarWd5TNAX9RVR/sKHsRzUk3B7U9OAtj/AzNiW8Bvk5zItD5i7yfTW1sf7PE8j+l2TE+meZX97+rqgeSzLaxHdBtW22v2NOq6leT/AbwRpox1ncBf1rO+6gp0B4d2gwcV1WX76TuAcD/qirH6EojlOSDNG3xr0cdiwbDxHhMtYPx/w74WFX1ZahEkt8CvllVf9qP7UnaNe2h1atoenP/E82Qhqe2s1ZIkkbMoRRjqu1FPpxmiredDpPocZu/a1IsjdRP0wxpuINmzPxRJsWSND7sMZYkSZKwx1iSJEkCmvn1Rm6fffapNWvWDGTb999/P3vs0ZdpfofKuIdr3OK++uqr76iqJ+285mgMqs2O29+hV8Y9XOMY9zi3WfexOzLu4RnHmJdsr1U18tvznve8GpTLL798YNseJOMernGLG/h8raBN0cx88hGaabs20oxt3Ru4FPhqe/+Etm5o5tO8Efgi8NydbX9QbXbc/g69Mu7hGse4V9pmB3lzH7sj4x6ecYx5qfbqUAppOr0H+GRV/QTwbJrk+FTgsqo6iObiDvNXEXwpzTyXBwEnAWcMP1xJkkbPxFiaMu1Ufz8DnAlQVd+tqruBI2kuREF7f1T7+EjgnPaH9JXAXkm6XZ5ckqSpNhZjjCX11VOBbwJ/luTZwNU0F0mZqaotAFW1Jcm+bf39gVs61t/clm3p3GiSk2h6lJmZmWFubq7vgW/btm0g2x004x6uSY1b0vgzMZamz27Ac4Ffr6qrkryHh4ZNdJMuZTvM41hVG4ANAOvWravZ2dk+hPpwc3NzDGK7g2bcwzWpcUsafw6lkKbPZmBzVV3VPv8ITaJ8+/wQifZ+a0f9AzvWPwC4bUixSpI0NkyMpSlTVd8Abkny9LboUODLwMXA8W3Z8cBF7eOLgdek8ULgnvkhF5IkrSYOpZCm068D5yZ5FHAT8FqaH8IXJDkRuBl4ZVv3EprLj98IPNDWlSRp1TExlqZQVV0LrOuy6NAudQs4eeBBSZI05hxKIUmSJGGPscbEmlM/8YPHm047YoSRSKtbZ1vcFbZbaTi6tVHbX//YYyxJkiRhYixJkiQBJsaSJEkSYGIsSZIkASbGkiRJEuCsFJKkPljObBaeSS9p3Oy0xzjJgUkuT7IxyfVJ3tiW753k0iRfbe+f0JYnyXuT3Jjki0meO+g3IUmSJK1UL0MptgPrq+ongRcCJyd5BnAqcFlVHQRc1j4HeClwUHs7CTij71FLkiRJfbbTxLiqtlTVNe3j+4CNwP7AkcDZbbWzgaPax0cC51TjSmCvJPv1PXJJkiSpj3bp5Lska4DnAFcBM1W1BZrkGdi3rbY/cEvHapvbMkmSJGls9XzyXZI9gQuBN1XVvUkWrdqlrLps7ySaoRbMzMwwNzfXayi7ZNu2bQPb9iCttrjXr93+g8ejeN+T+nlLkqT+6SkxTvJImqT43Kr6aFt8e5L9qmpLO1Ria1u+GTiwY/UDgNsWbrOqNgAbANatW1ezs7PLewc7MTc3x6C2PUirLe4TOs5o33Tcrq+/UpP6eUuSpP7pZVaKAGcCG6vqXR2LLgaObx8fD1zUUf6adnaKFwL3zA+5kCRJksZVLz3GhwCvBq5Lcm1b9lbgNOCCJCcCNwOvbJddAhwO3Ag8ALy2rxFLkiRJA7DTxLiqrqD7uGGAQ7vUL+DkFcYlSZIkDZWXhJYkSZIwMZYkSZIAE2NJkiQJMDGWJEmSABNjSZIkCdiFK99Jo7Cm48IfAJtOO2JEkUiSpGlnj7EkSSOS5MAklyfZmOT6JG9sy9+e5NYk17a3wzvWeUuSG5PckOQlo4temj72GEuSNDrbgfVVdU2SxwJXJ7m0XfbuqvqDzspJngEcAzwTeDLwN0l+vKoeHGrU0pSyx1iSpBGpqi1VdU37+D5gI7D/EqscCZxfVd+pqq/TXGX2+YOPVFod7DHWQHWOEXZ88PAk2QTcBzwIbK+qdUn2Bj4MrAE2AUdX1V1JAryH5lLuDwAnzO+oJQ1PkjXAc4CrgEOAU5K8Bvg8Ta/yXTRJ85Udq22mSyKd5CTgJICZmRnm5uYGEvO2bdsGtu1BmuS416/d8eDAIN7Ldbfes0PZ2v0fv8vbmbTP2sRYml4/W1V3dDw/Fbisqk5Lcmr7/M3AS4GD2tsLgDPae02whSeudrN+7XZO6KGeBi/JnsCFwJuq6t4kZwDvAKq9Px14HZAuq9cOBVUbgA0A69atq9nZ2YHEPTc3x6C2PUiTHPfpV9y/Q/mm42b7/lrd/jcs53Um7bN2KIW0ehwJnN0+Phs4qqP8nGpcCeyVZL9RBCitRkkeSZMUn1tVHwWoqtur6sGq+j7wAR4aLrEZOLBj9QOA24YZrzTNTIyl6VTAp5Jc3R5SBZipqi3QjGsE9m3L9wdu6Vi366FZSf3XDmU6E9hYVe/qKO/8cfpy4Evt44uBY5I8OslTaI70fHZY8UrTzqEU0nQ6pKpuS7IvcGmSryxRt6dDs8MYszhpY9HmjWPc69du32mdmd17qzcoy/3MxvHzXoFDgFcD1yW5ti17K3BskoNp2uIm4PUAVXV9kguAL9PMaHGyM1JI/WNiLE2hqrqtvd+a5GM0h2FvT7JfVW1pe6O2ttV7OjQ7jDGLkzYWbd44xt3L2OH1a7dz+nWj2w0sd1zkOH7ey1VVV9D9x+klS6zzTuCdAwtKWsUcSiFNmSR7tPOhkmQP4MU0h2EvBo5vqx0PXNQ+vhh4TRovBO6ZH3IhSdJqstOugiQfAl4GbK2qZ7VlHwae3lbZC7i7qg5up5rZCNzQLruyqt7Q76AlLWkG+FgzdJHdgL+sqk8m+RxwQZITgZuBV7b1L6GZqu1GmunaXjv8kCVJGr1ejqGdBbwPOGe+oKpeNf84yelA52R3X6uqg/sVoKRdU1U3Ac/uUn4ncGiX8gJOHkJokiSNtZ0mxlX16bYneAft2bRHAz/X37AkSZKk4VrpWRcvAm6vqq92lD0lyReAe4HfqqrPdFvRq/IsbVri7jzjfan3s1i9hWfM+z2RJEmDstLE+FjgvI7nW4Afrao7kzwP+Kskz6yqexeu6FV5ljYtcXeeGb/UGeiL1Vt4Zv0gru4Dk/t5S5Kk/ll2YpxkN+CXgefNl1XVd4DvtI+vTvI14MdprvOuKdV56dmzDttjhJFIkiQt30qma/t54CtVtXm+IMmTkjyiffxUmivy3LSyECVJkqTB22linOQ84O+BpyfZ3E71BHAMDx9GAfAzwBeT/APwEeANVfWtfgYsSZIkDUIvs1Icu0j5CV3KLgQuXHlY0s51DuHYdNoRI4xEkiRNA698J0mSJGFiLEmSJAEmxpIkSRJgYixJkiQBJsaSJEkSYGIsSZIkASbGkiRJEmBiLEmSJAEmxpIkSRJgYixJkiQBJsaSJEkSYGIsSZIkAbDbqAOQJElS/6059RM7lG067YgRRDI57DGWJEmSsMdYPVr4q9NfnJIkTR57kZe20x7jJB9KsjXJlzrK3p7k1iTXtrfDO5a9JcmNSW5I8pJBBS5JkiT1Uy9DKc4CDutS/u6qOri9XQKQ5BnAMcAz23Xen+QR/QpWkiRJGpSdJsZV9WngWz1u70jg/Kr6TlV9HbgReP4K4pMkaWolOTDJ5Uk2Jrk+yRvb8r2TXJrkq+39E9ryJHlve2T2i0meO9p3IE2XlZx8d0rbKD8032CB/YFbOupsbsskSdKOtgPrq+ongRcCJ7dHX08FLquqg4DL2ucALwUOam8nAWcMP2Rpei335LszgHcA1d6fDrwOSJe61W0DSU6iadTMzMwwNze3zFCWtm3btoFte5DGLe71a7c/7HlnbJ3LFsbduWyp97NYvV5fd6Wf1bh93pJWh6raAmxpH9+XZCNNh9KRwGxb7WxgDnhzW35OVRVwZZK9kuzXbkfSCi0rMa6q2+cfJ/kA8PH26WbgwI6qBwC3LbKNDcAGgHXr1tXs7OxyQtmpubk5BrXtQRq3uE9YOCvFcbNdl5112B4Pi7tzWec6S21/sW0vtWypbfdi3D7vlWrH9n8euLWqXpbkKcD5wN7ANcCrq+q7SR4NnAM8D7gTeFVVbRpR2NKqlmQN8BzgKmBmPtmtqi1J9m2rLXZk9mGJsZ1PS5vkuNevfXCH8sXey8LOpcV0W7/busv5zCbts15WYrzg1+nLgfkZKy4G/jLJu4An0xzq+eyKo5S0q94IbAQe1z7/PZoTZs9P8ifAiTRHfk4E7qqqpyU5pq33qlEELK1mSfYELgTeVFX3Jt0OwDZVu5TtcGTWzqelTXLcp19x/w7li3UOLexcWky39butu5xOqEn7rHuZru084O+BpyfZnORE4PeTXJfki8DPAr8BUFXXAxcAXwY+CZxcVTv+tJE0MEkOAI4APtg+D/BzwEfaKmcDR7WPj2yf0y4/NEvskSX1X5JH0iTF51bVR9vi25Ps1y7fD9jalvd8ZFbSrttpj3FVHdul+Mwl6r8TeOdKgpJWqnMC81U4cfkfAv8ZeGz7/InA3VU1f1ys86TYHxyWrartSe5p69+xcKPDODQ7aYfc5o1j3L0cQp3ZvfdDrYOw3M9sHD/v5Wp/iJ4JbKyqd3Usuhg4Hjitvb+oo/yUJOcDLwDucXyx1D9e+U6aIkleBmytqquTzM4Xd6laPSx7eOEQDs1O2iG3eeMYdy+HUNev3c7p141uN7DccwPG8fNegUOAVwPXJbm2LXsrTUJ8QXuU9mbgle2yS4DDaaZDfQB47XDDlaabibE0XQ4Bfqm9GuVjaMYY/yGwV5Ld2l7jzkOv84dlNyfZDXg8vc9bLmmFquoKuv9ABTi0S/0CTh5oUNIqtpJ5jCWNmap6S1UdUFVraK5C+bdVdRxwOfCKttrCw7LHt49f0dbv2mMsSdK0MzGWVoc3A7+Z5EaaMcTz5wmcCTyxLf9NHrqIgCRJq45DKaQpVVVzNBcFoKpuosvl2avqn3lo7KI0VGt6nEpqobMO26PPkUhSwx5jSZIkCRNjSZIkCXAohSRJ0kRb7rAk7cgeY0mSJAl7jCVJklY1e5wfYo+xJEmShImxJEmSBJgYS5IkSYCJsSRJkgSYGEuSJEmAibEkSZIE9DBdW5IPAS8DtlbVs9qy/wn8IvBd4GvAa6vq7iRrgI3ADe3qV1bVGwYQtyRJ0lRbOI3a+rXbcabdweqlx/gs4LAFZZcCz6qqfwn8I/CWjmVfq6qD25tJsSRJkibCTn92VNWn257gzrJPdTy9EnhFf8PSqHT+Ot102hEjjESSpMnX7eIZ7l/HVz/6418HfLjj+VOSfAG4F/itqvpMt5WSnAScBDAzM8Pc3FwfQtnRtm3bBrbtQRpV3M1hmkbn63eWL7VsYdyLba/fr7tw272+7rxJ/Z5IkqT+WVFinOS/ANuBc9uiLcCPVtWdSZ4H/FWSZ1bVvQvXraoNwAaAdevW1ezs7EpCWdTc3ByD2vYgjSruEzp7jI+b7Vq+1LKzDtvjYXEvtr1+v+7Cbff6uvMm9XsiSZL6Z9mzUiQ5nuakvOOqqgCq6jtVdWf7+GqaE/N+vB+BSpIkSYO0rMQ4yWHAm4FfqqoHOsqflOQR7eOnAgcBN/UjUEmSJGmQepmu7TxgFtgnyWbgbTSzUDwauDQJPDQt288A/y3JduBB4A1V9a0BxS5JkiT1TS+zUhzbpfjMRepeCFy40qAkSZKkYfPKd5IkSRImxpIkSRJgYixJkiQBXnBbksZat6tmSZo+tvXxYI+xJEmShImxJEkjk+RDSbYm+VJH2duT3Jrk2vZ2eMeytyS5MckNSV4ymqil6WViLEnS6JwFHNal/N1VdXB7uwQgyTOAY4Bntuu8f/6iWpL6w8RYmjJJHpPks0n+Icn1SX6nLX9KkquSfDXJh5M8qi1/dPv8xnb5mlHGL60mVfVpoNcLYR0JnF9V36mqrwM3As8fWHDSKuTJd9L0+Q7wc1W1LckjgSuS/G/gN2l6oc5P8ifAicAZ7f1dVfW0JMcAvwe8alTBSwLglCSvAT4PrK+qu4D9gSs76mxuy3aQ5CTgJICZmRnm5uYGEuS2bdsGtu1BGmbc69du36Gs22t3q7fQzO691RuU5Xxmk/YdMTGWpkxVFbCtffrI9lbAzwH/ti0/G3g7TWJ8ZPsY4CPA+5Kk3Y6k4TsDeAdNu30HcDrwOiBd6nZtp1W1AdgAsG7dupqdnR1IoHNzcwxq24M0zLhP6DLbxKbjdnztbvUWWr92O6dfN7rUrVvcOzNp3xETY2kKteMOrwaeBvwx8DXg7qqa72ro7GnaH7gFoKq2J7kHeCJwx4JtDrwHatJ6FuYNMu5B9g6NuvdpuSb1e9Krqrp9/nGSDwAfb59uBg7sqHoAcNsQQ5OmnomxNIWq6kHg4CR7AR8DfrJbtfa+p16oYfRATVrPwrxBxt1LL9Jyjbr3abnOOmyPifye9CrJflW1pX36cmB+xoqLgb9M8i7gycBBwGdHEKJWqW5zLW867YgRRDI4k/cfUVLPquruJHPAC4G9kuzW9hp39jTN90JtTrIb8Hh6PxlI0gokOQ+YBfZJshl4GzCb5GCaH6ibgNcDVNX1SS4AvgxsB05ufwRL6hMTY2nKJHkS8L02Kd4d+HmaE+ouB14BnA8cD1zUrnJx+/zv2+V/6/hiaTiq6tguxWcuUf+dwDsHF5GGwavcjS8TY2n67Aec3Y4z/iHggqr6eJIvA+cn+V3gCzy08z0T+PMkN9L0FB8ziqAlSRq1nhLjJB8CXgZsrapntWV7Ax8G1tAc6jm6qu5KEuA9wOHAA8AJVXVN/0OX1E1VfRF4Tpfym+gy52lV/TPwyiGEJknSWOu1x/gs4H3AOR1lpwKXVdVpSU5tn78ZeCnNCQEHAS+gmXbmBf0KWNPPQ0ySJGkUerry3SJX5jmSZi5U2vujOsrPqcaVNCf87NePYCVJkqRBWckY45n56WSqakuSfdvyH8yJ2pqfL3UL0hjp7Jlev3Y7s6MLRZIkjYFBnHzX05yoXq5yaaOKu3Oy/87XX3gRgMWWbf3WPfzRuRd1LHtonc7ytfs/ftHXXcpi2174WS32PharM7P78i51KUmSpsdKEuPb5ychb4dKbG3Le7oyj5erXNqo4u68mEDnpR8XXmRgsWW9XjBg4WUlV3oRg6W2t9glLBfGffQEfk8kSVL/9DTGeBHzc5/CjnOiviaNFwL3dFzBR5IkSRpLvU7X1u3KPKcBFyQ5EbiZh6Z7uoRmqrYbaaZre22fY5YkSZL6rqfEeJEr8wAc2qVuASevJChJkiRp2FYylEKSJEmaGibGkiRJEibGkiRJEmBiLEmSJAEmxpIkSRJgYixJkiQBJsaSJEkSYGIsSZIkAT1e4EOTb82pn/jB402nHTHCSCRJksaTibFGojNRlyRJGgcOpZAkSZKwx1iSJEnL1O0I8CQP2bTHWJIkScLEWJIkSQIcSjFVFh7OGOShjHE7eW7c4pEkSZPHHmNJkiSJFfQYJ3k68OGOoqcC/xXYC/j/gG+25W+tqkuWHaEkSZI0BMvuMa6qG6rq4Ko6GHge8ADwsXbxu+eXmRRLktRdkg8l2ZrkSx1leye5NMlX2/sntOVJ8t4kNyb5YpLnji5yaTr1a4zxocDXquqfkvRpk5KWI8mBwDnAjwDfBzZU1XuS7E1zlGcNsAk4uqruStNo3wMcTvMD94SqumYUsU8zx8FrEWcB76Nps/NOBS6rqtOSnNo+fzPwUuCg9vYC4Iz2XlKf9CsxPgY4r+P5KUleA3weWF9Vdy1cIclJwEkAMzMzzM3N9SmUh9u2bdvAtj1Iy4l7/drtD3veuX7nsqW2u1i9hdtezMzuvdcdlsXeb2ecM7sv/blMmO007UvTPN0AAA2OSURBVO6aJI8Frk5yKXAC7mylsVJVn06yZkHxkcBs+/hsYI6mrR4JnFNVBVyZZK8k+1XVluFEK/WmsyNg/drtnHDqJyZmbuMVJ8ZJHgX8EvCWtugM4B1AtfenA69buF5VbQA2AKxbt65mZ2dXGkpXc3NzDGrbg7ScuE9YOCvFcbNdl3WWL7WNxdZfyvq12zn9uvGa7GSx93vCgoZ79AR+T7ppd5Jb2sf3JdkI7I87W2lSzMy3v6rakmTftnx/4JaOepvbsh3aqp1PSxtm3P3sLBrHzqedmY95Ur4n/chgXgpcU1W3A8zfAyT5APDxPryGpGVoe6KeA1xFH3a2kkaq21jF6lbRzqelDTPuXjuWejGOnU87Mx/zUp1y46Qfn+6xdAyjWNDT9HLgS13XkjRQSfYELgTeVFX3LjH+v6ed7TB6oKa592kce3kmsfcJJvd7sgtun9+XJtkP2NqWbwYO7Kh3AHDb0KOTptiKEuMkPwz8AvD6juLfT3IwzY5104JlkoYgySNpkuJzq+qjbfGKdrbD6IGa5t6nfvYa9csk9j4BnHXYHhP5PdkFFwPHA6e19xd1lJ+S5Hya8wDucciT1F8r+o9YVQ8AT1xQ9uoVRSRpRdpZJs4ENlbVuzoWubOVxkyS82jG/u+TZDPwNpo2ekGSE4GbgVe21S+hmT3mRpoZZF479IClKTd5XQWSduYQ4NXAdUmubcveijtbaexU1bGLLDq0S90CTh5sRNLqZmIsTZmquoLu44bBna0kSYsyMdaq4kUWJEnSYpZ9SWhJkiRpmthjrEXZuypJklYTe4wlSZIk7DGWJE2Y6269Z1nzQm867YgBRCM9xCOti1vssxm3dmliLEmStItMgqeTQykkSZIkTIwlSZIkwKEUkiRJS3LYxOphj7EkSZKEibEkSZIEmBhLkiRJgGOMpa46x5ON2xyLkiRpMOwxliRJkuhDj3GSTcB9wIPA9qpal2Rv4MPAGmATcHRV3bXS15IkSZIGpV9DKX62qu7oeH4qcFlVnZbk1Pb5m/v0WpIkSX3ntGwa1FCKI4Gz28dnA0cN6HUkSZKkvuhHj3EBn0pSwJ9W1QZgpqq2AFTVliT7LlwpyUnASQAzMzPMzc31IZQdbdu2bWDbHqTlxL1+7faHPe9cv3PZUttduI1dNbP7yrfRb4t9Dp1mdl/e5yVJkqZHPxLjQ6rqtjb5vTTJV3pZqU2gNwCsW7euZmdn+xDKjubm5hjUtgdpOXGfsOAQ0KbjZrsu6yzf2TZ21fq12zn9uvGa7GSxz6HT+rXbOXq2e72lPi9JkjQ9VjyUoqpua++3Ah8Dng/cnmQ/gPZ+60pfR5IkSRqkFSXGSfZI8tj5x8CLgS8BFwPHt9WOBy5ayetIkiRJg7bSY94zwMeSzG/rL6vqk0k+B1yQ5ETgZuCVK3wddfDiE7vGs4wlSVIvVpQYV9VNwLO7lN8JHLqSbUuSJEnDNF5nSWko7EGVJEnakZeEliRJkjAxliRJkgCHUkiSNJaSbALuAx4EtlfVuiR7Ax8G1gCbgKOr6q5RxShNG3uMpSmT5ENJtib5UkfZ3kkuTfLV9v4JbXmSvDfJjUm+mOS5o4tcUhc/W1UHV9W69vmpwGVVdRBwWftcUp+YGE+xNad+4gc3rSpnAYctKFtsZ/pS4KD2dhJwxpBilLQ8RwJnt4/PBo4aYSzS1HEohTRlqurTSdYsKD4SmG0fnw3MAW9uy8+pqgKuTLJXkv2qastwopW0hAI+laSAP62qDcDMfPusqi1J9u22YpKTaH7sMjMzw9zc3EAC3LZt28C2PUiLxb1+7fbhB7MLZnYf/xgX2lnM4/b9MTGWVofFdqb7A7d01Nvclu2QGA9jRzttO9lO47gzm8SdLCw/7gn8bh1SVbe17fXSJF/pdcU2id4AsG7dupqdnR1IgHNzcwxq24O0WNwnjPkR1vVrt3P6dZOVuu0s5k3HzQ4vmB5M1qcrqd/Spay6VRzGjnbadrKdxnGHO4k7WVh+3OO2A96Zqrqtvd+a5GPA84Hb54/qJNkP2DrSIKUp4xhjaXW4vd2JsmBnuhk4sKPeAcBtQ45N0gJJ9kjy2PnHwIuBLwEXA8e31Y4HLhpNhNJ0MjGWVofFdqYXA69pZ6d4IXCP44ulsTADXJHkH4DPAp+oqk8CpwG/kOSrwC+0zyX1yeQdQ5sAC2eB2HTaESOKRKtRkvNoTrTbJ8lm4G00O88LkpwI3Ay8sq1+CXA4cCPwAPDaoQcsaQdVdRPw7C7ldwKHDj8iaXUwMR5T1916zw/GJJpYa1dU1bGLLNphZ9rORnHyYCOaPgt//K5fu30sxxBLknaNibHUcr5nSZJWNxNjSZI09rp1XnhEVf227JPvkhyY5PIkG5Ncn+SNbfnbk9ya5Nr2dnj/wpUkSZIGYyU9xtuB9VV1TTulzNVJLm2Xvbuq/mDl4UmSJGlajduRgGUnxu2UTvNX0rovyUaaK2ZJkiRJE6cvY4yTrAGeA1wFHAKckuQ1wOdpepXv6rLO1F7HfeGlSpfz+p2XPF24fuf2O5eNw6Vdp/ESsxN4GVn1yBMuJUmdVpwYJ9kTuBB4U1Xdm+QM4B00l5V9B3A68LqF603zddwXTtu0nMuQ/tG5F/3gkqcL13/Y9q+7v2PJ6M+lnMpLzD7sM/ZkD0mSptWKrnyX5JE0SfG5VfVRgKq6vaoerKrvAx+guba7JEmSNNZWMitFgDOBjVX1ro7y/TqqvZzm2u6SJEnSWFvJMe9DgFcD1yW5ti17K3BskoNphlJsAl6/ogilMdM5LtVhFZI0mTzHQN2sZFaKK4B0WXTJ8sORJEmSRmNFY4wlSZKkaTF50wdMOA/DS5I0XAuHTTTTc5oCaUf2GEuSJEmYGEuSJEmAxxEkSdIUcbYJrYSJ8RjpbMzr144wEC3Lwn/GjiGXpMEyCVa/mRhLklaF5SZR/siVhqtbWx1WOzQxHgJ/0UqSJI0/T76TJEmSsMd4pOxJlvrDtiSNl8XapMNStFzDGl5hYiytgAmZJEnTY9Umxr1egW4crlRn8qXV4rpb7+EEv+/S1BrlSVVSL1ZtYryUXhNRE1ZJklbGZFnjxMR4F5gIS5IkTa9VlRgvltia8EqStDyD2Ie6X9aoTH1i7JhFSZIk9WJgiXGSw4D3AI8APlhVpw3qtaRxNw4ncS7F9ipNDtur1BjE+PSBJMZJHgH8MfALwGbgc0kurqovL3ebC9985xsf96RDGmeDaK+wvEOh69eu5BWl6TdO7RVg/drtrIKDz1pFBvVtfj5wY1XdBJDkfOBIYEUNt5PjjzTuJug7OvD2KqlvbK/SAKWq+r/R5BXAYVX1a+3zVwMvqKpTOuqcBJzUPn06cEPfA2nsA9wxoG0PknEP17jF/WNV9aRhvFAv7bUtH0abHbe/Q6+Me7jGMe6htNkxa68wnn+LXhj38IxjzIu210H1GKdL2cMy8KraAGwY0Os/FEjy+apaN+jX6TfjHq5JjbtPdtpeYThtdlL/DsY9XJMad5+MTXuFyf1bGPfwTFrMPzSg7W4GDux4fgBw24BeS9LK2F6lyWF7lQZoUInx54CDkjwlyaOAY4CLB/RaklbG9ipNDturNEADGUpRVduTnAL8Nc10Mh+qqusH8Vo9GPihpAEx7uGa1LhXzPbaF8Y9XJMa94qNWXuFyf1bGPfwTFTMAzn5TpIkSZo0gxpKIUmSJE0UE2NJkiSJKU6MkxyY5PIkG5Ncn+SNo46pV0kekeQLST4+6lh6lWSvJB9J8pX2M//pUcfUiyS/0X4/vpTkvCSPGXVMq9Ekt1ewzQ6TbXb0bK/DZ3sdnqlNjIHtwPqq+knghcDJSZ4x4ph69UZg46iD2EXvAT5ZVT8BPJsJiD/J/sB/ANZV1bNoTmQ5ZrRRrVqT3F7BNjsUttmxYXsdPtvrkExtYlxVW6rqmvbxfTRfov1HG9XOJTkAOAL44Khj6VWSxwE/A5wJUFXfraq7RxtVz3YDdk+yG/DDOB/oSExqewXb7AjYZkfM9jpcttfhmtrEuFOSNcBzgKtGG0lP/hD4z8D3Rx3ILngq8E3gz9rDUx9Msseog9qZqroV+APgZmALcE9VfWq0UWnC2ivYZofGNjt+bK9DYXsdoqlPjJPsCVwIvKmq7h11PEtJ8jJga1VdPepYdtFuwHOBM6rqOcD9wKmjDWnnkjwBOBJ4CvBkYI8kvzraqFa3SWqvYJsdNtvseLG9Do3tdYimOjFO8kiaRntuVX101PH04BDgl5JsAs4Hfi7JX4w2pJ5sBjZX1XyPwUdoGvG4+3ng61X1zar6HvBR4F+NOKZVawLbK9hmh802OyZsr0Nlex2iqU2Mk4RmPM7GqnrXqOPpRVW9paoOqKo1NAPU/7aqxv7XVVV9A7glydPbokOBL48wpF7dDLwwyQ+335dDmYATGqbRJLZXsM2OgG12DNheh8v2OlwDuST0mDgEeDVwXZJr27K3VtUlI4xpmv06cG6SRwE3Aa8dcTw7VVVXJfkIcA3NWdZfYMIuXTlFbK/DZ5vVctleh8/2OiReElqSJEliiodSSJIkSbvCxFiSJEnCxFiSJEkCTIwlSZIkwMRYkiRJAkyMJUmSJMDEWJIkSQLg/wHxKl2vFOJ4qgAAAABJRU5ErkJggg==\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsYAAAEICAYAAABcYjLsAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nO3dfZhkZX3n//cn4gMBFRHpIJCMrsREnRV1omZZs52QKIIJmCjCEgUlP3QXsprM7opuspo17pJs0GiMJKMYICEgKxr4KWskhF4lG1BBIuJIRJzAwMgI8jRg1MHv/nFOS9FT3VPTXc/9fl1XXVV1n/uc+lZ13X2+dZ/73CdVhSRJkrTa/dCoA5AkSZLGgYmxJEmShImxJEmSBJgYS5IkSYCJsSRJkgSYGEuSJEmAibEkqUOS2SSbl1j+J0l+e5gxSatRkk1Jfn6RZS9KcsOwY1oNTIw1EDZoTZok/zrJ/01yT5JvJfm7JD/VLjshyRWjjnExSfZLcnGS25JUkjULlv9+kluS3Jvkn5L8l+W+VlW9oaresdKYpWFo90XfTrKt4/bkRerOJfnnJPe1beXqJKcmefQuvN5fJNnSrv+PSX6tY9matn12xrKsH5lV9Zmqevpy1tXSTIyHaKkdb7v8gCTnJrkzyf1JPpvk8AXbqHbZtiS3JnlXkke0y67vaGwPtg18/vlbe4jvrCTfXdBoH9Gl3tvaOLomvjtjg9a4SfI44OPAHwF7A/sDvwN8p0/b360f21nC94FPAr+yyPIzgZ+oqscB/wr4t0l+ecAxSePiF6tqz47bbUvUPaWqHgvsB6wHjgEuSZIeX+t/AGvatvZLwO8med6COnt1xOKPzDFjYjwkO9vxJtkbuAL4LvBMYB/g3cD5SY5asLlnV9WewL8BXgW8DqCqnjnf2IDP0DTw+cb333sM9fcX/AN5cMH7+BfAK4Atu/gRSOPsxwGq6ryqerCqvl1Vn6qqLyb5SeBPgJ9ufyzeDT/oXersDXpYr3L74/HkJF8FvtqWvTjJDe2P4/cn+T8LtvG6JBuT3JXkr5P8WC/BV9XtVfV+4HOLLL+hqu7vKPo+8LSltpnkrUnuaHvcjusoPyvJ77aPZ5NsTrI+yda2p+y1HXUPT/Lltgfu1iT/sZf3I41aVd1fVXM0ye1PA0f0uN71VTX/g7ra279YQSg/1bahu5L8WZLHwI5Dntp2+h+TfLH9//Lhjrr7JPl4krvbTrnPJDH/W4QfzPAsuuNtl/8GsA04saq+0S4/D3gn8K5uv1ar6kbg74CDh/QeAN4HvJkmgd8ZG7QmxT8CDyY5O8lLkzxhfkFVbQTeAPx9+2Nxr13Y7lHAC4BnJNkH+AjwFuCJwA00vbcAtD+A3wr8MvAkmh+3563sbT0kzSHhbcBmYA/gL5eo/iM0P873B44HNiRZ7CjPjwCPb+ueCPxxx+d3JvD6tgfuWcDfrviNSENUVTcDnwde1Os67Y/eB4Cv0HQiXbKgyj+1Pyj/rP2/sJTjgJfQJNc/DvzWEnWPBg4DngL8S+CEtnw9Tbt/EjBD83+men0/q40JxvAsuuNt/QJwYVV9f0H5BTRf8h16d5L8BE1jvbGPcf77NgG9OsnDDssmeSXw3apa2MgXY4PWRKiqe4F/TfPd+gDwzTRjdmdWuOn/UVXfqqpvA4cD11fVR6tqO/Be4BsddV/f1t/YLv/vwMG99hrvTFWdBjwWeC7w58A9O1nlt6vqO1X1f4BP0LTRbr4H/Leq+l77v2Eb8PSOZc9I8riququqrlnxG5F23V+1nSt3J/mrZax/G82R3p5U1b+naWsvAj7KQ0Oy7gB+Cvgx4HltnXN3srn3VdUtVfUtmo6yY5eo+96quq2t+//zUKfZ92iGhvxY204/U1XuRxdhYjwkPex496H78IT5sid1lF2T5H5gIzAHvL9PYb4XOAjYF/ht4KwkhwAk2ZNmR/2mXdieDVoTo01IT6iqA2h6N58M/OEKN3tLx+Mndz5vv8edsz/8GPCe+R048C0gND2xfVGNLwDfphnKtZi7Fgy9+Kc2/m7ubBP5eQ8Ae7aPf4XmB8E/tcNGfnqZoUsrcVRV7dXejoIfzK7S6zk4+9O0x561R4avAA4A/l1btq2qPl9V26vqduAU4MXtUMvFdP4PWaodwsN/aHe2w/9J04H2qSQ3JTl1V97LamNiPEQ72fHeQZMALjRf9s2OsufSfOFfRXOYdo8+xXdNVd3ZNtpLaH7Jzp+g8zvAn1fV13dhkzZoTaSq+gpwFk07he5HKe4Hfrjj+Y9021TH4y00O0kA2uFRB3Qsv4Vm2MFeHbfdq+r/LuMt7MxuLD3u8QlJOv+v/ChNr9kuqarPVdWRND+2/4rmCJg0cu3sKjs9ByfJgTS9u59Z5kst1dbm/z8sdWLfgR2Pl9sO76uq9VX1VOAXgd9Mcuiubme1MDEekS473r8BfqXL+NmjaXqVvrZg/aqqC4C/B/7roMLkoQZ7KPAfknwjyTdoGusFSd68xPo2aE2EJD/RnkB2QPv8QJojHFe2VW4HDkjyqI7VrgV+OckPJ3kazfjapXwCWJvkqDSzVJzMw5PpPwHekuSZbQyPb4cvzcc4l+TtS7yHxwDz00o9umOc/g8leX2SJ6Tx/Pa1L9tJvL+T5FFJXgS8DPhfO6m/MJ5HJTkuyeOr6nvAvcCDO1tPGgdtu/43wEXAZ2nHCbfnyHQ9aplk3yTHJNkzySOSvITm/8jftstfkOTpbZt8Is1R2rmqWmpY08lpZqzam2Yo4YeX8V5eluRp7Y/x+XZoW1yEifGQ9LDjfTfwOODMJD+S5DFJjqUZ0vC2LmOP550GnJSkW2/Vwhjm51Bcs8jyV7QN+oeSvBj4VeDidvGhNEn8we3tNpoxkX+8xEvaoDUp7qM5+nJVO0zpSuBLNGPcodmxXQ98I8kdbdm7aU5CvR04m52MFayqO4BXAr8P3Ak8g+aknu+0yz8G/B7NTDT3tq//0o5NHEhzsu1ivk0zvheak36+3bHs5TQ/ru8D/oJmdpw/WmJb3wDuomnn5wJvaH/M76pXA5va9/MGmv8p0jh7X5L7aNr1HwIXAod17IMPpOmQ6qZohk1spmk/fwC8qaouapc/lWZaxfto2vd3WHqIITQnyX4KuKm9/e4y3tNBNJ1v29rY39/OuKEu4nDN4UiyP82O9BBgL+Bumunb/lM7/pgkP0qzY3wJTZJcwK9V1dkd2yngoHZGivmy/w18uarWd5TNAX9RVR/sKHsRzUk3B7U9OAtj/AzNiW8Bvk5zItD5i7yfTW1sf7PE8j+l2TE+meZX97+rqgeSzLaxHdBtW22v2NOq6leT/AbwRpox1ncBf1rO+6gp0B4d2gwcV1WX76TuAcD/qirH6EojlOSDNG3xr0cdiwbDxHhMtYPx/w74WFX1ZahEkt8CvllVf9qP7UnaNe2h1atoenP/E82Qhqe2s1ZIkkbMoRRjqu1FPpxmiredDpPocZu/a1IsjdRP0wxpuINmzPxRJsWSND7sMZYkSZKwx1iSJEkCmvn1Rm6fffapNWvWDGTb999/P3vs0ZdpfofKuIdr3OK++uqr76iqJ+285mgMqs2O29+hV8Y9XOMY9zi3WfexOzLu4RnHmJdsr1U18tvznve8GpTLL798YNseJOMernGLG/h8raBN0cx88hGaabs20oxt3Ru4FPhqe/+Etm5o5tO8Efgi8NydbX9QbXbc/g69Mu7hGse4V9pmB3lzH7sj4x6ecYx5qfbqUAppOr0H+GRV/QTwbJrk+FTgsqo6iObiDvNXEXwpzTyXBwEnAWcMP1xJkkbPxFiaMu1Ufz8DnAlQVd+tqruBI2kuREF7f1T7+EjgnPaH9JXAXkm6XZ5ckqSpNhZjjCX11VOBbwJ/luTZwNU0F0mZqaotAFW1Jcm+bf39gVs61t/clm3p3GiSk2h6lJmZmWFubq7vgW/btm0g2x004x6uSY1b0vgzMZamz27Ac4Ffr6qrkryHh4ZNdJMuZTvM41hVG4ANAOvWravZ2dk+hPpwc3NzDGK7g2bcwzWpcUsafw6lkKbPZmBzVV3VPv8ITaJ8+/wQifZ+a0f9AzvWPwC4bUixSpI0NkyMpSlTVd8Abkny9LboUODLwMXA8W3Z8cBF7eOLgdek8ULgnvkhF5IkrSYOpZCm068D5yZ5FHAT8FqaH8IXJDkRuBl4ZVv3EprLj98IPNDWlSRp1TExlqZQVV0LrOuy6NAudQs4eeBBSZI05hxKIUmSJGGPscbEmlM/8YPHm047YoSRSKtbZ1vcFbZbaTi6tVHbX//YYyxJkiRhYixJkiQBJsaSJEkSYGIsSZIkASbGkiRJEuCsFJKkPljObBaeSS9p3Oy0xzjJgUkuT7IxyfVJ3tiW753k0iRfbe+f0JYnyXuT3Jjki0meO+g3IUmSJK1UL0MptgPrq+ongRcCJyd5BnAqcFlVHQRc1j4HeClwUHs7CTij71FLkiRJfbbTxLiqtlTVNe3j+4CNwP7AkcDZbbWzgaPax0cC51TjSmCvJPv1PXJJkiSpj3bp5Lska4DnAFcBM1W1BZrkGdi3rbY/cEvHapvbMkmSJGls9XzyXZI9gQuBN1XVvUkWrdqlrLps7ySaoRbMzMwwNzfXayi7ZNu2bQPb9iCttrjXr93+g8ejeN+T+nlLkqT+6SkxTvJImqT43Kr6aFt8e5L9qmpLO1Ria1u+GTiwY/UDgNsWbrOqNgAbANatW1ezs7PLewc7MTc3x6C2PUirLe4TOs5o33Tcrq+/UpP6eUuSpP7pZVaKAGcCG6vqXR2LLgaObx8fD1zUUf6adnaKFwL3zA+5kCRJksZVLz3GhwCvBq5Lcm1b9lbgNOCCJCcCNwOvbJddAhwO3Ag8ALy2rxFLkiRJA7DTxLiqrqD7uGGAQ7vUL+DkFcYlSZIkDZWXhJYkSZIwMZYkSZIAE2NJkiQJMDGWJEmSABNjSZIkCdiFK99Jo7Cm48IfAJtOO2JEkUiSpGlnj7EkSSOS5MAklyfZmOT6JG9sy9+e5NYk17a3wzvWeUuSG5PckOQlo4temj72GEuSNDrbgfVVdU2SxwJXJ7m0XfbuqvqDzspJngEcAzwTeDLwN0l+vKoeHGrU0pSyx1iSpBGpqi1VdU37+D5gI7D/EqscCZxfVd+pqq/TXGX2+YOPVFod7DHWQHWOEXZ88PAk2QTcBzwIbK+qdUn2Bj4MrAE2AUdX1V1JAryH5lLuDwAnzO+oJQ1PkjXAc4CrgEOAU5K8Bvg8Ta/yXTRJ85Udq22mSyKd5CTgJICZmRnm5uYGEvO2bdsGtu1BmuS416/d8eDAIN7Ldbfes0PZ2v0fv8vbmbTP2sRYml4/W1V3dDw/Fbisqk5Lcmr7/M3AS4GD2tsLgDPae02whSeudrN+7XZO6KGeBi/JnsCFwJuq6t4kZwDvAKq9Px14HZAuq9cOBVUbgA0A69atq9nZ2YHEPTc3x6C2PUiTHPfpV9y/Q/mm42b7/lrd/jcs53Um7bN2KIW0ehwJnN0+Phs4qqP8nGpcCeyVZL9RBCitRkkeSZMUn1tVHwWoqtur6sGq+j7wAR4aLrEZOLBj9QOA24YZrzTNTIyl6VTAp5Jc3R5SBZipqi3QjGsE9m3L9wdu6Vi366FZSf3XDmU6E9hYVe/qKO/8cfpy4Evt44uBY5I8OslTaI70fHZY8UrTzqEU0nQ6pKpuS7IvcGmSryxRt6dDs8MYszhpY9HmjWPc69du32mdmd17qzcoy/3MxvHzXoFDgFcD1yW5ti17K3BskoNp2uIm4PUAVXV9kguAL9PMaHGyM1JI/WNiLE2hqrqtvd+a5GM0h2FvT7JfVW1pe6O2ttV7OjQ7jDGLkzYWbd44xt3L2OH1a7dz+nWj2w0sd1zkOH7ey1VVV9D9x+klS6zzTuCdAwtKWsUcSiFNmSR7tPOhkmQP4MU0h2EvBo5vqx0PXNQ+vhh4TRovBO6ZH3IhSdJqstOugiQfAl4GbK2qZ7VlHwae3lbZC7i7qg5up5rZCNzQLruyqt7Q76AlLWkG+FgzdJHdgL+sqk8m+RxwQZITgZuBV7b1L6GZqu1GmunaXjv8kCVJGr1ejqGdBbwPOGe+oKpeNf84yelA52R3X6uqg/sVoKRdU1U3Ac/uUn4ncGiX8gJOHkJokiSNtZ0mxlX16bYneAft2bRHAz/X37AkSZKk4VrpWRcvAm6vqq92lD0lyReAe4HfqqrPdFvRq/IsbVri7jzjfan3s1i9hWfM+z2RJEmDstLE+FjgvI7nW4Afrao7kzwP+Kskz6yqexeu6FV5ljYtcXeeGb/UGeiL1Vt4Zv0gru4Dk/t5S5Kk/ll2YpxkN+CXgefNl1XVd4DvtI+vTvI14MdprvOuKdV56dmzDttjhJFIkiQt30qma/t54CtVtXm+IMmTkjyiffxUmivy3LSyECVJkqTB22linOQ84O+BpyfZ3E71BHAMDx9GAfAzwBeT/APwEeANVfWtfgYsSZIkDUIvs1Icu0j5CV3KLgQuXHlY0s51DuHYdNoRI4xEkiRNA698J0mSJGFiLEmSJAEmxpIkSRJgYixJkiQBJsaSJEkSYGIsSZIkASbGkiRJEmBiLEmSJAEmxpIkSRJgYixJkiQBJsaSJEkSYGIsSZIkAbDbqAOQJElS/6059RM7lG067YgRRDI57DGWJEmSsMdYPVr4q9NfnJIkTR57kZe20x7jJB9KsjXJlzrK3p7k1iTXtrfDO5a9JcmNSW5I8pJBBS5JkiT1Uy9DKc4CDutS/u6qOri9XQKQ5BnAMcAz23Xen+QR/QpWkiRJGpSdJsZV9WngWz1u70jg/Kr6TlV9HbgReP4K4pMkaWolOTDJ5Uk2Jrk+yRvb8r2TXJrkq+39E9ryJHlve2T2i0meO9p3IE2XlZx8d0rbKD8032CB/YFbOupsbsskSdKOtgPrq+ongRcCJ7dHX08FLquqg4DL2ucALwUOam8nAWcMP2Rpei335LszgHcA1d6fDrwOSJe61W0DSU6iadTMzMwwNze3zFCWtm3btoFte5DGLe71a7c/7HlnbJ3LFsbduWyp97NYvV5fd6Wf1bh93pJWh6raAmxpH9+XZCNNh9KRwGxb7WxgDnhzW35OVRVwZZK9kuzXbkfSCi0rMa6q2+cfJ/kA8PH26WbgwI6qBwC3LbKNDcAGgHXr1tXs7OxyQtmpubk5BrXtQRq3uE9YOCvFcbNdl5112B4Pi7tzWec6S21/sW0vtWypbfdi3D7vlWrH9n8euLWqXpbkKcD5wN7ANcCrq+q7SR4NnAM8D7gTeFVVbRpR2NKqlmQN8BzgKmBmPtmtqi1J9m2rLXZk9mGJsZ1PS5vkuNevfXCH8sXey8LOpcV0W7/busv5zCbts15WYrzg1+nLgfkZKy4G/jLJu4An0xzq+eyKo5S0q94IbAQe1z7/PZoTZs9P8ifAiTRHfk4E7qqqpyU5pq33qlEELK1mSfYELgTeVFX3Jt0OwDZVu5TtcGTWzqelTXLcp19x/w7li3UOLexcWky39butu5xOqEn7rHuZru084O+BpyfZnORE4PeTXJfki8DPAr8BUFXXAxcAXwY+CZxcVTv+tJE0MEkOAI4APtg+D/BzwEfaKmcDR7WPj2yf0y4/NEvskSX1X5JH0iTF51bVR9vi25Ps1y7fD9jalvd8ZFbSrttpj3FVHdul+Mwl6r8TeOdKgpJWqnMC81U4cfkfAv8ZeGz7/InA3VU1f1ys86TYHxyWrartSe5p69+xcKPDODQ7aYfc5o1j3L0cQp3ZvfdDrYOw3M9sHD/v5Wp/iJ4JbKyqd3Usuhg4Hjitvb+oo/yUJOcDLwDucXyx1D9e+U6aIkleBmytqquTzM4Xd6laPSx7eOEQDs1O2iG3eeMYdy+HUNev3c7p141uN7DccwPG8fNegUOAVwPXJbm2LXsrTUJ8QXuU9mbgle2yS4DDaaZDfQB47XDDlaabibE0XQ4Bfqm9GuVjaMYY/yGwV5Ld2l7jzkOv84dlNyfZDXg8vc9bLmmFquoKuv9ABTi0S/0CTh5oUNIqtpJ5jCWNmap6S1UdUFVraK5C+bdVdRxwOfCKttrCw7LHt49f0dbv2mMsSdK0MzGWVoc3A7+Z5EaaMcTz5wmcCTyxLf9NHrqIgCRJq45DKaQpVVVzNBcFoKpuosvl2avqn3lo7KI0VGt6nEpqobMO26PPkUhSwx5jSZIkCRNjSZIkCXAohSRJ0kRb7rAk7cgeY0mSJAl7jCVJklY1e5wfYo+xJEmShImxJEmSBJgYS5IkSYCJsSRJkgSYGEuSJEmAibEkSZIE9DBdW5IPAS8DtlbVs9qy/wn8IvBd4GvAa6vq7iRrgI3ADe3qV1bVGwYQtyRJ0lRbOI3a+rXbcabdweqlx/gs4LAFZZcCz6qqfwn8I/CWjmVfq6qD25tJsSRJkibCTn92VNWn257gzrJPdTy9EnhFf8PSqHT+Ot102hEjjESSpMnX7eIZ7l/HVz/6418HfLjj+VOSfAG4F/itqvpMt5WSnAScBDAzM8Pc3FwfQtnRtm3bBrbtQRpV3M1hmkbn63eWL7VsYdyLba/fr7tw272+7rxJ/Z5IkqT+WVFinOS/ANuBc9uiLcCPVtWdSZ4H/FWSZ1bVvQvXraoNwAaAdevW1ezs7EpCWdTc3ByD2vYgjSruEzp7jI+b7Vq+1LKzDtvjYXEvtr1+v+7Cbff6uvMm9XsiSZL6Z9mzUiQ5nuakvOOqqgCq6jtVdWf7+GqaE/N+vB+BSpIkSYO0rMQ4yWHAm4FfqqoHOsqflOQR7eOnAgcBN/UjUEmSJGmQepmu7TxgFtgnyWbgbTSzUDwauDQJPDQt288A/y3JduBB4A1V9a0BxS5JkiT1TS+zUhzbpfjMRepeCFy40qAkSZKkYfPKd5IkSRImxpIkSRJgYixJkiQBXnBbksZat6tmSZo+tvXxYI+xJEmShImxJEkjk+RDSbYm+VJH2duT3Jrk2vZ2eMeytyS5MckNSV4ymqil6WViLEnS6JwFHNal/N1VdXB7uwQgyTOAY4Bntuu8f/6iWpL6w8RYmjJJHpPks0n+Icn1SX6nLX9KkquSfDXJh5M8qi1/dPv8xnb5mlHGL60mVfVpoNcLYR0JnF9V36mqrwM3As8fWHDSKuTJd9L0+Q7wc1W1LckjgSuS/G/gN2l6oc5P8ifAicAZ7f1dVfW0JMcAvwe8alTBSwLglCSvAT4PrK+qu4D9gSs76mxuy3aQ5CTgJICZmRnm5uYGEuS2bdsGtu1BGmbc69du36Gs22t3q7fQzO691RuU5Xxmk/YdMTGWpkxVFbCtffrI9lbAzwH/ti0/G3g7TWJ8ZPsY4CPA+5Kk3Y6k4TsDeAdNu30HcDrwOiBd6nZtp1W1AdgAsG7dupqdnR1IoHNzcwxq24M0zLhP6DLbxKbjdnztbvUWWr92O6dfN7rUrVvcOzNp3xETY2kKteMOrwaeBvwx8DXg7qqa72ro7GnaH7gFoKq2J7kHeCJwx4JtDrwHatJ6FuYNMu5B9g6NuvdpuSb1e9Krqrp9/nGSDwAfb59uBg7sqHoAcNsQQ5OmnomxNIWq6kHg4CR7AR8DfrJbtfa+p16oYfRATVrPwrxBxt1LL9Jyjbr3abnOOmyPifye9CrJflW1pX36cmB+xoqLgb9M8i7gycBBwGdHEKJWqW5zLW867YgRRDI4k/cfUVLPquruJHPAC4G9kuzW9hp39jTN90JtTrIb8Hh6PxlI0gokOQ+YBfZJshl4GzCb5GCaH6ibgNcDVNX1SS4AvgxsB05ufwRL6hMTY2nKJHkS8L02Kd4d+HmaE+ouB14BnA8cD1zUrnJx+/zv2+V/6/hiaTiq6tguxWcuUf+dwDsHF5GGwavcjS8TY2n67Aec3Y4z/iHggqr6eJIvA+cn+V3gCzy08z0T+PMkN9L0FB8ziqAlSRq1nhLjJB8CXgZsrapntWV7Ax8G1tAc6jm6qu5KEuA9wOHAA8AJVXVN/0OX1E1VfRF4Tpfym+gy52lV/TPwyiGEJknSWOu1x/gs4H3AOR1lpwKXVdVpSU5tn78ZeCnNCQEHAS+gmXbmBf0KWNPPQ0ySJGkUerry3SJX5jmSZi5U2vujOsrPqcaVNCf87NePYCVJkqRBWckY45n56WSqakuSfdvyH8yJ2pqfL3UL0hjp7Jlev3Y7s6MLRZIkjYFBnHzX05yoXq5yaaOKu3Oy/87XX3gRgMWWbf3WPfzRuRd1LHtonc7ytfs/ftHXXcpi2174WS32PharM7P78i51KUmSpsdKEuPb5ychb4dKbG3Le7oyj5erXNqo4u68mEDnpR8XXmRgsWW9XjBg4WUlV3oRg6W2t9glLBfGffQEfk8kSVL/9DTGeBHzc5/CjnOiviaNFwL3dFzBR5IkSRpLvU7X1u3KPKcBFyQ5EbiZh6Z7uoRmqrYbaaZre22fY5YkSZL6rqfEeJEr8wAc2qVuASevJChJkiRp2FYylEKSJEmaGibGkiRJEibGkiRJEmBiLEmSJAEmxpIkSRJgYixJkiQBJsaSJEkSYGIsSZIkAT1e4EOTb82pn/jB402nHTHCSCRJksaTibFGojNRlyRJGgcOpZAkSZKwx1iSJEnL1O0I8CQP2bTHWJIkScLEWJIkSQIcSjFVFh7OGOShjHE7eW7c4pEkSZPHHmNJkiSJFfQYJ3k68OGOoqcC/xXYC/j/gG+25W+tqkuWHaEkSZI0BMvuMa6qG6rq4Ko6GHge8ADwsXbxu+eXmRRLktRdkg8l2ZrkSx1leye5NMlX2/sntOVJ8t4kNyb5YpLnji5yaTr1a4zxocDXquqfkvRpk5KWI8mBwDnAjwDfBzZU1XuS7E1zlGcNsAk4uqruStNo3wMcTvMD94SqumYUsU8zx8FrEWcB76Nps/NOBS6rqtOSnNo+fzPwUuCg9vYC4Iz2XlKf9CsxPgY4r+P5KUleA3weWF9Vdy1cIclJwEkAMzMzzM3N9SmUh9u2bdvAtj1Iy4l7/drtD3veuX7nsqW2u1i9hdtezMzuvdcdlsXeb2ecM7sv/blMmO007UvTPN0AAA2OSURBVO6aJI8Frk5yKXAC7mylsVJVn06yZkHxkcBs+/hsYI6mrR4JnFNVBVyZZK8k+1XVluFEK/WmsyNg/drtnHDqJyZmbuMVJ8ZJHgX8EvCWtugM4B1AtfenA69buF5VbQA2AKxbt65mZ2dXGkpXc3NzDGrbg7ScuE9YOCvFcbNdl3WWL7WNxdZfyvq12zn9uvGa7GSx93vCgoZ79AR+T7ppd5Jb2sf3JdkI7I87W2lSzMy3v6rakmTftnx/4JaOepvbsh3aqp1PSxtm3P3sLBrHzqedmY95Ur4n/chgXgpcU1W3A8zfAyT5APDxPryGpGVoe6KeA1xFH3a2kkaq21jF6lbRzqelDTPuXjuWejGOnU87Mx/zUp1y46Qfn+6xdAyjWNDT9HLgS13XkjRQSfYELgTeVFX3LjH+v6ed7TB6oKa592kce3kmsfcJJvd7sgtun9+XJtkP2NqWbwYO7Kh3AHDb0KOTptiKEuMkPwz8AvD6juLfT3IwzY5104JlkoYgySNpkuJzq+qjbfGKdrbD6IGa5t6nfvYa9csk9j4BnHXYHhP5PdkFFwPHA6e19xd1lJ+S5Hya8wDucciT1F8r+o9YVQ8AT1xQ9uoVRSRpRdpZJs4ENlbVuzoWubOVxkyS82jG/u+TZDPwNpo2ekGSE4GbgVe21S+hmT3mRpoZZF479IClKTd5XQWSduYQ4NXAdUmubcveijtbaexU1bGLLDq0S90CTh5sRNLqZmIsTZmquoLu44bBna0kSYsyMdaq4kUWJEnSYpZ9SWhJkiRpmthjrEXZuypJklYTe4wlSZIk7DGWJE2Y6269Z1nzQm867YgBRCM9xCOti1vssxm3dmliLEmStItMgqeTQykkSZIkTIwlSZIkwKEUkiRJS3LYxOphj7EkSZKEibEkSZIEmBhLkiRJgGOMpa46x5ON2xyLkiRpMOwxliRJkuhDj3GSTcB9wIPA9qpal2Rv4MPAGmATcHRV3bXS15IkSZIGpV9DKX62qu7oeH4qcFlVnZbk1Pb5m/v0WpIkSX3ntGwa1FCKI4Gz28dnA0cN6HUkSZKkvuhHj3EBn0pSwJ9W1QZgpqq2AFTVliT7LlwpyUnASQAzMzPMzc31IZQdbdu2bWDbHqTlxL1+7faHPe9cv3PZUttduI1dNbP7yrfRb4t9Dp1mdl/e5yVJkqZHPxLjQ6rqtjb5vTTJV3pZqU2gNwCsW7euZmdn+xDKjubm5hjUtgdpOXGfsOAQ0KbjZrsu6yzf2TZ21fq12zn9uvGa7GSxz6HT+rXbOXq2e72lPi9JkjQ9VjyUoqpua++3Ah8Dng/cnmQ/gPZ+60pfR5IkSRqkFSXGSfZI8tj5x8CLgS8BFwPHt9WOBy5ayetIkiRJg7bSY94zwMeSzG/rL6vqk0k+B1yQ5ETgZuCVK3wddfDiE7vGs4wlSVIvVpQYV9VNwLO7lN8JHLqSbUuSJEnDNF5nSWko7EGVJEnakZeEliRJkjAxliRJkgCHUkiSNJaSbALuAx4EtlfVuiR7Ax8G1gCbgKOr6q5RxShNG3uMpSmT5ENJtib5UkfZ3kkuTfLV9v4JbXmSvDfJjUm+mOS5o4tcUhc/W1UHV9W69vmpwGVVdRBwWftcUp+YGE+xNad+4gc3rSpnAYctKFtsZ/pS4KD2dhJwxpBilLQ8RwJnt4/PBo4aYSzS1HEohTRlqurTSdYsKD4SmG0fnw3MAW9uy8+pqgKuTLJXkv2qastwopW0hAI+laSAP62qDcDMfPusqi1J9u22YpKTaH7sMjMzw9zc3EAC3LZt28C2PUiLxb1+7fbhB7MLZnYf/xgX2lnM4/b9MTGWVofFdqb7A7d01Nvclu2QGA9jRzttO9lO47gzm8SdLCw/7gn8bh1SVbe17fXSJF/pdcU2id4AsG7dupqdnR1IgHNzcwxq24O0WNwnjPkR1vVrt3P6dZOVuu0s5k3HzQ4vmB5M1qcrqd/Spay6VRzGjnbadrKdxnGHO4k7WVh+3OO2A96Zqrqtvd+a5GPA84Hb54/qJNkP2DrSIKUp4xhjaXW4vd2JsmBnuhk4sKPeAcBtQ45N0gJJ9kjy2PnHwIuBLwEXA8e31Y4HLhpNhNJ0MjGWVofFdqYXA69pZ6d4IXCP44ulsTADXJHkH4DPAp+oqk8CpwG/kOSrwC+0zyX1yeQdQ5sAC2eB2HTaESOKRKtRkvNoTrTbJ8lm4G00O88LkpwI3Ay8sq1+CXA4cCPwAPDaoQcsaQdVdRPw7C7ldwKHDj8iaXUwMR5T1916zw/GJJpYa1dU1bGLLNphZ9rORnHyYCOaPgt//K5fu30sxxBLknaNibHUcr5nSZJWNxNjSZI09rp1XnhEVf227JPvkhyY5PIkG5Ncn+SNbfnbk9ya5Nr2dnj/wpUkSZIGYyU9xtuB9VV1TTulzNVJLm2Xvbuq/mDl4UmSJGlajduRgGUnxu2UTvNX0rovyUaaK2ZJkiRJE6cvY4yTrAGeA1wFHAKckuQ1wOdpepXv6rLO1F7HfeGlSpfz+p2XPF24fuf2O5eNw6Vdp/ESsxN4GVn1yBMuJUmdVpwYJ9kTuBB4U1Xdm+QM4B00l5V9B3A68LqF603zddwXTtu0nMuQ/tG5F/3gkqcL13/Y9q+7v2PJ6M+lnMpLzD7sM/ZkD0mSptWKrnyX5JE0SfG5VfVRgKq6vaoerKrvAx+guba7JEmSNNZWMitFgDOBjVX1ro7y/TqqvZzm2u6SJEnSWFvJMe9DgFcD1yW5ti17K3BskoNphlJsAl6/ogilMdM5LtVhFZI0mTzHQN2sZFaKK4B0WXTJ8sORJEmSRmNFY4wlSZKkaTF50wdMOA/DS5I0XAuHTTTTc5oCaUf2GEuSJEmYGEuSJEmAxxEkSdIUcbYJrYSJ8RjpbMzr144wEC3Lwn/GjiGXpMEyCVa/mRhLklaF5SZR/siVhqtbWx1WOzQxHgJ/0UqSJI0/T76TJEmSsMd4pOxJlvrDtiSNl8XapMNStFzDGl5hYiytgAmZJEnTY9Umxr1egW4crlRn8qXV4rpb7+EEv+/S1BrlSVVSL1ZtYryUXhNRE1ZJklbGZFnjxMR4F5gIS5IkTa9VlRgvltia8EqStDyD2Ie6X9aoTH1i7JhFSZIk9WJgiXGSw4D3AI8APlhVpw3qtaRxNw4ncS7F9ipNDtur1BjE+PSBJMZJHgH8MfALwGbgc0kurqovL3ebC9985xsf96RDGmeDaK+wvEOh69eu5BWl6TdO7RVg/drtrIKDz1pFBvVtfj5wY1XdBJDkfOBIYEUNt5PjjzTuJug7OvD2KqlvbK/SAKWq+r/R5BXAYVX1a+3zVwMvqKpTOuqcBJzUPn06cEPfA2nsA9wxoG0PknEP17jF/WNV9aRhvFAv7bUtH0abHbe/Q6+Me7jGMe6htNkxa68wnn+LXhj38IxjzIu210H1GKdL2cMy8KraAGwY0Os/FEjy+apaN+jX6TfjHq5JjbtPdtpeYThtdlL/DsY9XJMad5+MTXuFyf1bGPfwTFrMPzSg7W4GDux4fgBw24BeS9LK2F6lyWF7lQZoUInx54CDkjwlyaOAY4CLB/RaklbG9ipNDturNEADGUpRVduTnAL8Nc10Mh+qqusH8Vo9GPihpAEx7uGa1LhXzPbaF8Y9XJMa94qNWXuFyf1bGPfwTFTMAzn5TpIkSZo0gxpKIUmSJE0UE2NJkiSJKU6MkxyY5PIkG5Ncn+SNo46pV0kekeQLST4+6lh6lWSvJB9J8pX2M//pUcfUiyS/0X4/vpTkvCSPGXVMq9Ekt1ewzQ6TbXb0bK/DZ3sdnqlNjIHtwPqq+knghcDJSZ4x4ph69UZg46iD2EXvAT5ZVT8BPJsJiD/J/sB/ANZV1bNoTmQ5ZrRRrVqT3F7BNjsUttmxYXsdPtvrkExtYlxVW6rqmvbxfTRfov1HG9XOJTkAOAL44Khj6VWSxwE/A5wJUFXfraq7RxtVz3YDdk+yG/DDOB/oSExqewXb7AjYZkfM9jpcttfhmtrEuFOSNcBzgKtGG0lP/hD4z8D3Rx3ILngq8E3gz9rDUx9Msseog9qZqroV+APgZmALcE9VfWq0UWnC2ivYZofGNjt+bK9DYXsdoqlPjJPsCVwIvKmq7h11PEtJ8jJga1VdPepYdtFuwHOBM6rqOcD9wKmjDWnnkjwBOBJ4CvBkYI8kvzraqFa3SWqvYJsdNtvseLG9Do3tdYimOjFO8kiaRntuVX101PH04BDgl5JsAs4Hfi7JX4w2pJ5sBjZX1XyPwUdoGvG4+3ng61X1zar6HvBR4F+NOKZVawLbK9hmh802OyZsr0Nlex2iqU2Mk4RmPM7GqnrXqOPpRVW9paoOqKo1NAPU/7aqxv7XVVV9A7glydPbokOBL48wpF7dDLwwyQ+335dDmYATGqbRJLZXsM2OgG12DNheh8v2OlwDuST0mDgEeDVwXZJr27K3VtUlI4xpmv06cG6SRwE3Aa8dcTw7VVVXJfkIcA3NWdZfYMIuXTlFbK/DZ5vVctleh8/2OiReElqSJEliiodSSJIkSbvCxFiSJEnCxFiSJEkCTIwlSZIkwMRYkiRJAkyMJUmSJMDEWJIkSQLg/wHxKl2vFOJ4qgAAAABJRU5ErkJggg==",
             "text/plain": [
               "<Figure size 864x288 with 3 Axes>"
             ]
@@ -1432,26 +1429,24 @@
             "needs_background": "light"
           }
         }
-      ]
+      ],
+      "metadata": {
+        "id": "EFxa5Cwz_G_Q",
+        "outputId": "99ee4e8d-011f-4ade-9bf3-0afda60017e7"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "x5pGenYF_G_Q"
-      },
       "source": [
         "But we can also use built-in formulae too. Let's try all of them. "
-      ]
+      ],
+      "metadata": {
+        "id": "x5pGenYF_G_Q"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "jupyter": {
-          "outputs_hidden": false
-        },
-        "id": "pyK-B5KN_G_R",
-        "outputId": "1cc0db3e-afc2-441d-8676-a1211ed7ee4f"
-      },
+      "execution_count": null,
       "source": [
         "plt.figure(figsize=(20,4))\n",
         "\n",
@@ -1473,7 +1468,6 @@
         "plt.subplot(166)\n",
         "movies['IMDB_Rating'].hist(bins='sqrt')"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1490,7 +1484,7 @@
         {
           "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAABIQAAAD5CAYAAABWIe46AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nO3dfZDlZXnw+e8Fg0rQOKLSmQw8O1hOXF9mBe0CdqnNtqAJgpvRLVEMi4yymaQCiSa9FQb2qQ2JujVmBULWPCRj8GFw0YEFeaBgYiTIKR+qBCMvMsLoMuIsDMzDqAwDLaVJ47V/nPvAmZ7TPaf7vP3OOd9PVdc5v/v30lf3uU73ue/f/RKZiSRJkiRJksbHIYMOQJIkSZIkSf1lg5AkSZIkSdKYsUFIkiRJkiRpzNggJEmSJEmSNGZsEJIkSZIkSRozNghJkiRJkiSNmWWDDgDgda97Xa5ataor1/rZz37GEUcc0ZVrdYsxtWdQMd17770/yczX9/0bF93Kf1/T9hjTS8z93qliTFDNuAYR06jkPviatsuYXrJQ/kfEcuAfgLcBCXwc+AFwHbAK2Al8KDP3RkQAVwCnA88D6zLzvoW+t7nff8b0klH52+9r2p4qxgQV/NyTmQP/euc735ndcuedd3btWt1iTO0ZVEzAd3IE8t/XtD3G9BJzv3eqGFNmNeMaREwL5T7wCuDbwHeBh4C/KOXHAvcAj1CvHL+slL+8bO8o+1fNd+3scu5n+pq2y5hecpD83wz8L+X5y4DlwF8BG0rZBuCz5fnpwD8CAZwE3DPfddPcHxhjeomfe3rHmNpXtc89DhmTJEl6yS+AUzLz7cBxwGkRcRLwWeDyzFwN7AXOK8efB+zNzDcCl5fjpKETEb8K/CZwFUBm/mtmPgOspd5QRHl8f3m+Frim1DfuBpZHxIo+hy1J6oANQpIkSUWp3M6UzcPKVwKnADeU8rmV4kZl+Qbg1DKURho2bwB+DPzHiLg/Iv4hIo4AJjJzN0B5PKocvxJ4vOn8XaVMkjQkKjGHkCSpWiLiFcA3qQ+HWQbckJl/HhHHAluAI4H7gHMy818j4uXANcA7gZ8CH87MnQMJXupQRBwK3Au8Efhb4IfAM5k5Ww5prvi+WCnOzNmI2Ae8FvhJX4OWOrcMeAfwR5l5T0RcQX2I2HxaNXzmAQdFrAfWA0xMTFCr1boQKszMzHTtWt1iTO2pYkzSuLJBSJLUSmPYzExEHAbcFRH/CPwp9WEzWyLi76gPl7mSpmEzEXEW9WEzHx5U8FInMvMF4Lgywe5NwJtbHVYerRTPYUztqWBMu4BdmXlP2b6BeoPQUxGxIjN3lyFhe5qOP6bp/KOBJ+deNDM3AZsAJicnc2pqqivB1mo1unWtbjGm9lQxJmlc2SAkSTpAmYBuvmEzv1vKNwOXUG8QWlueQ70S8fmIiHIdaShl5jMRUaM+Ye7yiFhWegk1V3wbleJdEbEMeDXwdItrWSkeIGM6uMz8LxHxeES8KTN/AJwKPFy+zgU2lsebyym3ABdExBbgRGBfY2iZJGk4OIeQJKmliDg0Ih6gfjf4dhYxbAZoDJuRhkpEvL70DCIiDgfeDWwH7gQ+WA6bWyk+tzz/IPANG0I1xP4IuDYiHqQ+qfr/Qb0h6D0R8QjwnrINsBV4lPoKe18A/rD/4UqSOmEPIUlSS8MybKaCwy4qGRNUM64KxrQC2FzmEToEuD4zb42Ih4EtEfFp4H7KSkzl8UsRsYN6z6CzBhG01A2Z+QAw2WLXqS2OTeD8ngclSeoZG4SkBUTETuA54AVgNjMnI+JI4DpgFbAT+FBm7i2rylwBnA48D6zLzPsGEbfUTVUfNlO1YRdQzZigmnFVLabMfBA4vkX5o8AJLcp/DpzZh9AkSZK6yiFj0sG9KzOPy8zGHbMNwB2ZuRq4g5dW4HgvsLp8rac+r4o0lBw2I0mSJI02ewjpoFZtuG2/7Z0bzxhQJJWxFpgqzzcDNeDCUn5NqQTfHRHLG6tyDCRKLdncnJ9rTN4DDpsZU63yf0xyXjqA7weNmoN9xmlmrmtcNb9PRv19YIOQtLAEvh4RCfx9Ge4y0WjkKUuwHlWOfXFS3aIx4a4NQho6DpuRJEmSRpsNQtLCTs7MJ0ujz+0R8f0Fjm1rUl1wYt1Baiem6TWzC+7v9s9Uxd+TJEmSpNFmg5C0gMx8sjzuiYibqPeMeKoxFCwiVlBfkhtemlS3oXnC3bnXdWLdAWknpnUHGzJ29sLnL1YVf09Ss/mGGIx6N2qNhlUbbmN6zex+f9vNXUmSnFRamldEHBERr2o8B34L+B77T547d1Ldj0bdScA+5w+SJEmSJFXRQRuEIuIVEfHtiPhuRDwUEX9Ryo+NiHsi4pGIuC4iXlbKX162d5T9q3r7I0g9MwHcFRHfBb4N3JaZXwM2Au+JiEeA95RtgK3Ao8AO4AvAH/Y/ZEmSJEmLERHHRMSdEbG91Hk/UcqPjIjbS5339oh4TSmPiPibUud9MCLeMdifQFqadoaM/QI4JTNnIuIw6hXkfwT+FLg8M7dExN8B51FfZvs8YG9mvjEizgI+C3y4R/FLPVMmz317i/KfAqe2KE/g/D6EJkmSJPXUmK1INgtMZ+Z9ZYTAvRFxO7AOuCMzN0bEBmAD9dWF3wusLl8nUq8HnziQyKUOHLRBqFRyZ8rmYeUrgVOA3y3lm4FLqL8R1pbnADcAn4+IKNeRJEkVsJgP+pIkjbIyzUNjFeHnImI79dWC1wJT5bDNQI16g9Ba4JpSx707IpY35hjtd+xSJ9qaQygiDo2IB6hPnns78EPgmcxsLMXTWF4bmpbeLvv3Aa/tZtCSJEmSJHVbmfLkeOAeYKLRyFMejyqHvVjnLZrrw9LQaGuVscx8ATguIpYDNwFvbnVYeWxr6e1eLLsN1Vy+edhjmrsEd69+lir+niRJkiSNh4h4JXAj8MnMfDaiVdW2fmiLsr7UeatYZxq1mJrrv93+uar2u1rUsvOZ+UxE1ICTgOURsaz0AmpeXrux9PauiFgGvBp4usW1ur7sNlRz+eZhj2nuEtzdXnK7oYq/J42ebU/sO+iy8pKk0dZqyOQIzIEiqQNlvtwbgWsz86ul+KnGULCIWEF9xAy8VOdtaK4Pv6gXdd4q1plGLabmukK3675V+121s8rY60vPICLicODdwHbgTuCD5bC5S283luT+IPAN5w+SJEmSJFVR1LsCXQVsz8zLmnY1123n1nk/WlYbOwnY5/xBGkbt9BBaAWyOiEOpNyBdn5m3RsTDwJaI+DRwP/U3EOXxSxGxg3rPoLN6ELckSZIkSd1wMnAOsK3MnQtwMbARuD4izgMeA84s+7YCpwM7gOeBj/U3XKk72lll7EHqk2rNLX8UOKFF+c956Y0iSZIkSVJlZeZdtJ4XCODUFscncH5Pg5L6oK1VxiRJkiRJkjQ6FjWptCRJkjTOnJBakjQqbBCSJGnENSqw02tmXWVPkiRJgA1CkiRJkiRpBDX36rQ354FsEJIkSUvSaugM+IFLkiRpGDiptCRJkiRJ0pixQUiSJEmSJGnM2CAkSZIkSZI0ZmwQkiRJkiRJGjNOKi1JkiRJksbCUlYeG9XVyuwhJEmSJEmSNGZsEJIkSZJEROyMiG0R8UBEfKeUHRkRt0fEI+XxNaU8IuJvImJHRDwYEe8YbPSSpMVyyJgkSVIREccA1wC/BvwS2JSZV0TEJcDvAT8uh16cmVvLORcB5wEvAH+cmf/U98Cl7nlXZv6kaXsDcEdmboyIDWX7QuC9wOrydSJwZXlUnzUPZZlres0s6xbYL2m82SAkSZL0kllgOjPvi4hXAfdGxO1l3+WZ+bnmgyPiLcBZwFuBXwf+OSJ+IzNf6GvUUu+sBabK881AjXqD0FrgmsxM4O6IWB4RKzJz90CilCQtmkPGJEkHiIhjIuLOiNgeEQ9FxCdK+SUR8UQZTvBARJzedM5FZejADyLitwcXvbR0mbk7M+8rz58DtgMrFzhlLbAlM3+RmT8CdgAn9D5SqScS+HpE3BsR60vZRKORpzweVcpXAo83nbuLhd8rkqSKsYeQJKkVe0lo7EXEKuB44B7gZOCCiPgo8B3q74+91CvAdzedZqVYw+zkzHwyIo4Cbo+I7y9wbLQoywMOqjcsrQeYmJigVqt1JdCZmZmuXatbBhXT9JrZefdNHL7w/m5ZzM9dxddOGlc2CEmSDlDuAjfuCD8XEW33kgB+FBGNXhLf6nmwUg9ExCuBG4FPZuazEXEl8CnqFd5PAZcCH8dK8QGqFtP0mtm2KsWtYm63Ir2Un7dqvyeAzHyyPO6JiJuo/x1/qjEULCJWAHvK4buAY5pOPxp4ssU1NwGbACYnJ3NqaqorsdZqNbp1rW4ZVEwLzRE0vWaWS7f1vsq38+ypto+t4msXEV8E3gfsycy3lbLrgDeVQ5YDz2TmceVmwXbgB2Xf3Zn5B/2NWOoOG4QkSQuyl4TGTUQcRr0x6NrM/CpAZj7VtP8LwK1l00rxHFWLad2G29qqFLeq0LY7Ge9iKsMNVfs9RcQRwCHlJsARwG8BfwncApwLbCyPN5dTbqH+/2AL9cmk9zl/kIbY1cDnqS8qAEBmfrjxPCIuBfY1Hf/DzDyub9FJPWKDkCRpXsPQS6KKd9mrFlOjl4NDBw4uIgK4CtiemZc1lTdPlvsB4Hvl+S3AlyPiMurDJVcD3+5jyFK3TAA31d8CLAO+nJlfi4h/Aa6PiPOAx4Azy/FbgdOpz5v1PPCx/ocsdUdmfrPcADtA+b/wIeCUfsYk9YMNQpKkloall0TV7rJD9WJq9HJw6EBbTgbOAbZFxAOl7GLgIxFxHPWGzp3A7wNk5kMRcT3wMPW5t8537iwNo8x8FHh7i/KfAqe2KE/g/D6EJg3afw88lZmPNJUdGxH3A88C/z4z/3OrE70RNjiNmJpvhDVibFXWbCnnLDauqrBBSJJ0AHtJaFxl5l207vG2dYFzPgN8pmdBSZIG6SPAV5q2dwP/LjN/GhHvBP5TRLw1M5+de6I3wganEVPz0N/GDatWZc2Wcs5i46oKG4QkSa3YS0KSJI21iFgG/E/AOxtlZQGNX5Tn90bED4HfoD63ojRUbBCSJB3AXhKSJEm8G/h+Zu5qFETE64GnM/OFiHgD9V7Rjw4qQKkThww6AEmSJEmSBiUivgJ8C3hTROwqk6gDnMX+w8UAfhN4MCK+C9wA/EFmPt2/aKXuOWgPoYg4hvrye78G/BLYlJlXRMQlwO8BPy6HXpyZW8s5FwHnAS8Af5yZ/9SD2CVJkiRJ6khmfmSe8nUtym6kvuiGNPTaGTI2C0xn5n0R8Srg3oi4vey7PDM/13xwRLyFekvqW6lPLPrPEfEbziWhYRURh1IfE/xEZr4vIo4FtgBHAvcB52Tmv0bEy6k3nr4T+Cnw4czcOaCwJUmSJEma10GHjGXm7sy8rzx/DtgOrFzglLXAlsz8RWb+CNgBnNCNYKUB+QT1vG/4LPXG0NXAXuq94SiPezPzjcDl5ThJkiRJkipnUXMIRcQq4HjgnlJ0QUQ8GBFfjIjXlLKVwONNp+1i4QYkqbIi4mjgDOAfynYAp1AfLwywGXh/eb62bFP2n1qOlyRJkiSpUtpeZSwiXkl9rOQnM/PZiLgS+BT1pYc/BVwKfJzWq9Jki+utB9YDTExMUKvVFh18KzMzM127VrcMe0zTa2b32+7Vz1LF3xPw18CfAa8q268FnsnMxi+lucHzxcbQzJyNiH3l+J/0L1xJ42zVhtsGHYIkSZKGRFsNQhFxGPXGoGsz86sAmflU0/4vALeWzV3AMU2nHw08OfeambkJ2AQwOTmZU1NTSwj/QLVajW5dq1uGPaZ1cyoYO89u77zFqtrvKSLeB+zJzHsjYqpR3OLQbGPf3Gt3vUG0ig1qVYxp4vADGzkXq9s/UxV/T5IkSZJGWzurjAVwFbA9My9rKl+RmbvL5geA75XntwBfjojLqE8qvRr4dlejlvrjZOB3IuJ04BXAr1LvMbQ8IpaVXkLNDZ6NxtBdEbEMeDXQcgnKXjSIVq1BDaoZ0/917c1cuq3tzpEtdbtRtIq/J0mSJEmjrZ05hE4GzgFOiYgHytfpwF9FxLaIeBB4F/AnAJn5EHA98DDwNeB8VxjTMMrMizLz6MxcRX3lvG9k5tnAncAHy2HnAjeX57eUbcr+b2Rmyx5CkiRJkiQN0kFvk2fmXbQeCrN1gXM+A3ymg7ikKrsQ2BIRnwbup96DjvL4pYjYQb1n0FkDik+SJEmSpAV1Nm5CGhOZWQNq5fmjwAktjvk5cGZfA5MkSZIkaQkWtey8JEmSJEmShp89hCRJUletmrM6JcDOjWcMIBJJkiTNxx5CkiRJkiRpqK3acFvLm1Kanz2EJEmSNHTsiSZJUmfsISRJkiRJkjRmbBCSJEmSJEkaMzYISZIkSZLGVkR8MSL2RMT3msouiYgnIuKB8nV6076LImJHRPwgIn57MFFLnbNBSJIkSZI0zq4GTmtRfnlmHle+tgJExFuAs4C3lnP+Q0Qc2rdIpS6yQUiSJEmSNLYy85vA020evhbYkpm/yMwfATuAE3oWnNRDrjImSZKksedSxZJauCAiPgp8B5jOzL3ASuDupmN2lTJp6NggJEmSJEnS/q4EPgVkebwU+DgQLY7NVheIiPXAeoCJiQlqtVrHQc3MzHTlOt1UlZim18wCUKvVXoypUdYobz6uuazVdRZzTruq8rtqsEFIkiRJkqQmmflU43lEfAG4tWzuAo5pOvRo4Ml5rrEJ2AQwOTmZU1NTHcdVq9XoxnW6qSoxrSs9PXeePfViTOuaen/uPHtqv+Oay1pdZzHntKsqv6sG5xCSJEmSBEBEHBoR90fErWX72Ii4JyIeiYjrIuJlpfzlZXtH2b9qkHFL3RYRK5o2PwA0ViC7BTirvAeOBVYD3+53fFI32CAkSZJURMQxEXFnRGyPiIci4hOl/MiIuL1Uim+PiNeU8oiIvymV4gcj4h2D/Qmkjn0C2N60/VnqKy2tBvYC55Xy84C9mflG4PJynDSUIuIrwLeAN0XErog4D/iriNgWEQ8C7wL+BCAzHwKuBx4Gvgacn5kvDCh0qSMOGZOkRWpn4tGdG8/oQySSemCW+sSh90XEq4B7I+J2YB1wR2ZujIgNwAbgQuC91O8OrwZOpD7nxIkDiVzqUEQcDZwBfAb404gI4BTgd8shm4FLqOf52vIc4Abg8xERmdlyLhWpyjLzIy2Kr1rg+M9Qf59IQ80eQpKkA9hLQuMqM3dn5n3l+XPUe0qspF753VwO2wy8vzxfC1yTdXcDy+cMM5CGyV8Dfwb8smy/FngmMxuzqTavprQSeByg7N9XjpeksbNqw20vfg0TewhJklqxl4TGXpkT5XjgHmAiM3dDvdEoIo4qh71YKS4aFebd/YtU6lxEvA/Yk5n3RsRUo7jFodnGvubrdn2VJajeSj0wuJiaVz+aa+Lwhfd3y2J+7iq+dtK4skFIknSAUvFtVH6fi4jmXhJT5bDNQI16g9CLvSSAuyNieUSsaFSgpWETEa8EbgQ+mZnP1kfOtD60RZmV4j7E1KqSO9/ywb2uFC/l563ga3cy8DsRcTrwCuBXqfcYWh4Ry0ovoObVlBorLe2KiGXAq4Gn5160F6ssQfVW6oHBxbRugR4J02tmuXRb76t8i1l1qYqvnTSubBCSJC3IXhIaNxFxGPXGoGsz86ul+KlGI2cZEranlLe1/LCV4u5rVQmeb/ngXleKl7IEcdVeu8y8CLgIoPQQ+l8z8+yI+H+ADwJbgHOBm8spt5Ttb5X933D+IEkaLjYISZLmNQy9JCp4l72Swwagf0MHWpnv91G1169MonsVsD0zL2va1aj8buTASvEFEbGF+jDJffaM04i5ENgSEZ8G7ueliXavAr4UETuo9ww6a0DxSZKWyAYhSeqBg00oNwyrkA1LL4mq3WWHag4bgP4NHWhlvh4UFXz9TgbOAbZFxAOl7GLqDUHXl6WIHwPOLPu2AqcDO4DngY/1N1yp+zKzRn1IMJn5KHBCi2N+zkvvA0nSELJBSJJ0AHtJaFxl5l207vEGcGqL4xM4v6dBSVLFLWZlpatPO6KHkUhaDBuEJEmt2EtCkiRJGmEHbRCKiGOAa4BfA34JbMrMKyLiSOA6YBWwE/hQZu4td5WvoF4xeB5Yl5n39SZ8SVIv2EtCkiRJGm2HtHHMLDCdmW8GTgLOj4i3ABuAOzJzNXBH2QZ4L7C6fK0Hrux61JIkSZIkSVqyg/YQKnNANJYYfi4itlNfSngtMFUO20x94rkLS/k15W7x3RGxvDEBaffDlyRpPC1mvgZJ/dfqPToMCwpIksZHOz2EXhQRq4DjgXuAiUYjT3k8qhy2Eni86bRdpUySJEmSJEkV0Pak0hHxSurLD38yM5+tTxXU+tAWZdnieuupDyljYmKCWq3WbigLmpmZ6dq1umXYY5peM7vfdq9+lir+niRJkiRJGkVtNQhFxGHUG4OuzcyvluKnGkPBImIFsKeU7wKOaTr9aODJudfMzE3AJoDJycmcmppa2k8wR61Wo1vX6pZhj2ndnC7PO89u77zFquLvSZIkSZKkUXTQIWNl1bCrgO2ZeVnTrluAc8vzc4Gbm8o/GnUnAfucP0iSJEmSJKk62ukhdDJwDrAtIh4oZRcDG4HrI+I84DHgzLJvK/Ul53dQX3b+Y12NWB1bteE2ptfMvtjzxwkONSramWR3ek0fApEkSZKkimtnlbG7aD0vEMCpLY5P4PwO45IkSZIkqeci4ovA+4A9mfm2UvZ/Av8j8K/AD4GPZeYzZaGl7cAPyul3Z+Yf9D1oqQsWtcqYNE4i4hUR8e2I+G5EPBQRf1HKj42IeyLikYi4LiJeVspfXrZ3lP2rBhm/JEmSpLZcDZw2p+x24G2Z+d8A/y9wUdO+H2bmceXLxiANrbZXGVN1zR0m4xCwrvkFcEpmzpSJ1e+KiH8E/hS4PDO3RMTfAecBV5bHvZn5xog4C/gs8OFBBS9JkiTp4DLzm3Nv5mbm15s27wY+2M+YpH6wQUiLNi4NUGX440zZPKx8JXAK8LulfDNwCfUGobXlOcANwOcjIsp1JEmSJA2njwPXNW0fGxH3A88C/z4z//NgwpI6Y4OQtICIOBS4F3gj8LfUxw8/k5mz5ZBdwMryfCXwOEBmzkbEPuC1wE/6GrQkSZKkroiI/w2YBa4tRbuBf5eZP42IdwL/KSLempnPtjh3PbAeYGJiglqt1nE8MzMzXblON/Urpm1P7ANgzcpXt9w/vaZeRavVai/G1ChrlDcf11zW6jqdntNK1V4/G4TUsVHuMZSZLwDHRcRy4Cbgza0OK4+tJl9v2TvIfw690fyHeD4Th7d3XK81/16q+NpJkiSNu4g4l/pk06c2ev1n5i+oTy1BZt4bET8EfgP4ztzzM3MTsAlgcnIyp6amOo6pVqvRjet0U79ienGV7LNbf6/m/Y2Y1jXVVRvntSprdZ1Oz2mlaq+fDUJqa6nucVdWFKgBJwHLI2JZ6SV0NPBkOWwXcAywKyKWAa8Gnp7nev5z6IF1bS07P8ul2wb/p6/5H0UVXztJkqRxFhGnARcC/0NmPt9U/nrg6cx8ISLeAKwGHh1QmFJHBl8rkiqq/LH/t9IYdDjwbuoTRd9JfVK5LcC5wM3llFvK9rfK/m84f5AkSZ3z5pWkXoqIrwBTwOsiYhfw59RXFXs5cHtEwEvLy/8m8JcRMQu8APxBZra8CSxVnQ1C0vxWAJvLPEKHANdn5q0R8TCwJSI+DdwPXFWOvwr4UkTsoN4z6KxBBC1JkiSpfZn5kRbFV7UoIzNvBG7sbURSf9ggJM0jMx8Ejm9R/ihwQovynwNn9iE0SZIkSZI6csigA5AkSZIkSVJ/2SAkSZIkSZI0ZmwQkiRJkiRJ6rJVG26r9MIIziEkaWhU+Y+pJEmSJA0TG4QkSVLPzdege/VpR/Q5EkmqPm+CSeoHh4xJkiRJkiSNGXsISZIkaSTYq0KSpPbZQ0iSJEkacxHxioj4dkR8NyIeioi/KOXHRsQ9EfFIRFwXES8r5S8v2zvK/lWDjF+StHg2CEmSJBUR8cWI2BMR32squyQinoiIB8rX6U37LioV4h9ExG8PJmqpK34BnJKZbweOA06LiJOAzwKXZ+ZqYC9wXjn+PGBvZr4RuLwcJ0kaIjYISZIOYKVYY+xq4LQW5Zdn5nHlaytARLwFOAt4aznnP0TEoX2LVOqirJspm4eVrwROAW4o5ZuB95fna8s2Zf+pERF9CleSuq7qS8T3gnMIqevmvol2bjxjQJFI6sDVwOeBa+aUX56Zn2sumFMp/nXgnyPiNzLzhX4EKnVTZn5zEUNf1gJbMvMXwI8iYgdwAvCtHoUn9VRp0LwXeCPwt8APgWcyc7YcsgtYWZ6vBB4HyMzZiNgHvBb4SV+DliQtmQ1CkqQDWCmWDnBBRHwU+A4wnZl7qVeI7246prmyvJ+IWA+sB5iYmKBWq3UlqJmZma5dq1t6EdP0mtmDH7SAicM7v8ZCWv28rb5f83FVfO1KQ/5xEbEcuAl4c6vDymOr3kA5t8DcX5pu5Wuvc38pqvjaSePKBiFJ0mJ0VCmWhtSVwKeoV3Y/BVwKfJw2K8QAmbkJ2AQwOTmZU1NTXQmsVqvRrWt1Sy9iWtdhF/7pNbNcuq2HH3u3/axF4YHfb+fZUy8+r+Jr15CZz0REDTgJWB4Ry0ovoaOBJ8thu4BjgF0RsQx4NfB0i2uZ+0vQac439Dz3l+Dq046o3Gsnjatq/XWQJFVZx5XiXtwpruKdxn7EtJQ7vt4pXprMfKrxPCK+ANxaNhsV4obmyrI0VCLi9cC/lcagw4F3U58o+k7gg8AW4Fzg5nLKLWX7W2X/NzKz5d9+SVI12SA0BsZtYixJvdGNSnEv7hSP+l3i+Szl7rF3ipcmIlZk5u6y+QGgMdn6LcCXI+Iy6vNnrQa+PYAQpW5YAWwu8wgdAlyfmbdGxMPAloj4NHA/cFU5/irgS2WY8NPU55KTJA2Rg34qjIgvAu8D9mTm20rZJcDvAT8uh13ctOLGRdSXoXwB+OPM/FjlTosAABe8SURBVKcexC1J6jMrxRoHEfEVYAp4XUTsAv4cmIqI46j3fNsJ/D5AZj4UEdcDDwOzwPlOpq5hlZkPAse3KH+U+rxwc8t/DpzZh9CknpunznskcB2wivrf/g9l5t6ymt4VwOnA88C6zLxvEHFLnWrnNuHVuNLMULFHkKROWSnWuMrMj7QovqpFWeP4zwCf6V1EkqQ+uJoD67wbgDsyc2NEbCjbFwLvpX7zazVwIvUh9Sf2NVqpSw7aIORKM5I0fqwUS5KkcTFPnXct9ZtjAJuBGvUGobXANWXOrLsjYvmcXtTS0OhkIgFXmpEkSZIkjaKJRiNPZu6OiKNK+Urg8abjGnVeG4SG0LiPrllqg1AlV5qBaq5W0uuYqr7STLs/exVfO0mSJElq4uqqc/Qrpkb9db7v1by/EVNznbdx3mLqwa3OafX959s/N+aqvX5LahCq6kozMJ6rzVR9pZmdZ0+1dVwVXztJkiRJY+mpxlCwiFgB7Cnlrq46R79iatR756tfNu9vxNRcV26ct5j6c6tzWn3/+fbPjblqr98hSzmpvCEa5q40c1ZEvDwijsWVZiRJkiRJw+cW4Nzy/Fzg5qbyj0bdScA+5w/SsGpn2XlXmlFH5o7L3LnxjAFFIkmSJEn7m6fOuxG4PiLOAx4DziyHb6W+5PwO6svOf6zvAUtd0s4qY640I0mSJEkaSfPUeQFObXFsAuf3NiKpP5Y0ZEySJEmSJKlqVm24jW1P7Bv7FcTa0Z9ZhSVJkqQx11w5mV4zy7oNtzmUXpI0MDYISZIkqTK8oytJ6gX/vxzIIWOSJEmSJEljxh5CkiRVgHetJEmS1E/2EJIkSZIkSRozNghJkiRJkiSNGRuENHCrNtzm0oCSJEmSJOClOqJ6ywYhaR4RcUxE3BkR2yPioYj4RCk/MiJuj4hHyuNrSnlExN9ExI6IeDAi3jHYn0CSJEmSpNZsEJLmNwtMZ+abgZOA8yPiLcAG4I7MXA3cUbYB3gusLl/rgSv7H7IkSZIkSQdng5A0j8zcnZn3lefPAduBlcBaYHM5bDPw/vJ8LXBN1t0NLI+IFX0OW5IkSZKkg3LZeakNEbEKOB64B5jIzN1QbzSKiKPKYSuBx5tO21XKdvcvUkmSJEmqtsb8QDs3njHgSBaveW6jYYy/mQ1C0kFExCuBG4FPZuazETHvoS3Kcp5rrqc+rIyJiQlqtVrHcc7MzHTlOt3U7Zim18x2fI2Jw7tznU41/16q+NpJkiRJ427UJ7a2QUhaQEQcRr0x6NrM/GopfioiVpTeQSuAPaV8F3BM0+lHA0+2um5mbgI2AUxOTubU1FTHsdZqNbpxnW7qdkzruvAHeXrNLJduG/yfvp1nT734vIqvndQv257Yd8B7e9jvtkmSJA0D5xCS5hH1rkBXAdsz87KmXbcA55bn5wI3N5V/tKw2dhKwrzG0TJIkSZKkKhn8bXKpuk4GzgG2RcQDpexiYCNwfUScBzwGnFn2bQVOB3YAzwMf62+4kiRJkqR+GfYhZTYISfPIzLtoPS8QwKktjk/g/J4GJUmSJKkvIuJNwHVNRW8A/ndgOfB7wI9L+cWZubXP4Ukds0FIkiRJkqQ5MvMHwHEAEXEo8ARwE/WRAJdn5ucGGN7YGqVVvgbNBiFJkiRJkhZ2KvDDzPz/Flh1WH027EO2Bs0GIfWdb1pJUlVFxBeB9wF7MvNtpexI6kMGVgE7gQ9l5t6y+MAV1OePex5Yl5n3DSJuqVMRcQxwDfBrwC+BTZl5hfnfHX7+HQlnAV9p2r4gIj4KfAeYzsy9c0+IiPXAeoCJiQlqtVrHQczMzHTlOt20lJim18wCzHteq/2NsnZMHL6447upVcyNsqq9fjYISZIOYKVYY+xq4PPUK8YNG4A7MnNjRGwo2xcC7wVWl68TgSvLozSMZqlXau+LiFcB90bE7cA6zH+NuYh4GfA7wEWl6ErgU0CWx0uBj889LzM3AZsAJicnc2pqquNYarUa3bhONy0lpnWlkXTn2a3Pa7V/3SIaVqfXzHLptsE0d7SKuVFWtdfPZeclSa1cDZw2p6xRKV4N3FG2Yf9KwXrqH5KkoZSZ3wSenlO8Fthcnm8G3t9Ufk3W3Q0sj4gV/YlU6q7M3N1ozM/M54DtwErMfwnqn3Xuy8ynADLzqcx8ITN/CXwBOGGg0UlLZIOQJOkAVoql/Uxk5m6oV5qBo0r5SuDxpuN2lTJpqEXEKuB44B7MfwngIzQNF5vzOecDwPf6HpHUBQ4ZkyS1a79KQUQcrFKwu8/xSf3WalbRbHlgD+aRgOrNRQCdx9SLOR8GOZfEfBoxVe31i4hXAjcCn8zMZxeYPLet/Df36waVf1XM/Sq+dguJiF8B3gP8flPxX0XEcdRzfuecfdLQOGiDkPNISOoHJ1scagOtFFfxg2Unkyv2UhUrBq1iqtrrCTwVEStKQ+gKYE8p3wUc03Tc0cCTrS7Qi3kkoHpzEUDnMS1mjoh2DXIuifk0Yppv/oxBiIjDqDcGXZuZXy3FHeW/uV/Xi7xuRxVz/+rTjqjca7eQzHweeO2csnMGFI7UVe38dbgaJ1eUJFW0UjxslYL59KOyUMWKQauYqlRBLm4BzgU2lsebm8oviIgt1D/v7Gv0opOGTbmxexWwPTMva9pl/kvSiDrop8LM/GYZR9xsLTBVnm8GatQbhF6cRwK4OyKWNyoP3QpYkkZBc4+o6TWzLRsDdm48o58htcNKgUZeRHyF+mec10XELuDPqef89RFxHvAYcGY5fCv1XtE7qPeM/ljfA5a652TgHGBbRDxQyi7G/JekkbXU24TOIyFJI8xKscZVZn5knl2ntjg2gfN7G5HUH5l5F62HAIP5L0kjqdv9xp1csYVex7SU+SCqPI9E1V4/aRxZKZYkSdKgOc9oby21QaiS80jA6MwlsRhLmXeiyvNIVHDuCEmSJEmSRspSWwScR0KSJEmSJGkRmns9DXrO0HaWnXceCUmSJEmSpBHSzipjziMhSZIkSerYtif2tT3lxaB7T0ij7pBBByBJkiRJkqT+qtaswpIkSRobrh4jSdLg2ENIkiRJkiRpzNhDaAh5N02SJA0bP79IklQtNggNAT9ASdJo8e+6JEmSBs0GoQqyoiBJkiRJknrJOYQkSZIkSZLGjA1CkiRJkiRJY8YhY5IkSZIktRARO4HngBeA2cycjIgjgeuAVcBO4EOZuXdQMUpLZQ8hSZIkSZLm967MPC4zJ8v2BuCOzFwN3FG2paFjDyFJkiRJktq3FpgqzzcDNeDCQQWj6mssHDW9ZpYqNcNUJxJJkiRJkqolga9HRAJ/n5mbgInM3A2Qmbsj4qhWJ0bEemA9wMTEBLVareNgZmZmunKdblpKTPWGEeY9r7F/qSYO7/waS9X8M82NYW5cg34tbRCSJEmSJKm1kzPzydLoc3tEfL/dE0vj0SaAycnJnJqa6jiYWq1GN67TTUuJaV3pMbPz7NbnNfYv1fSaWS7dNpjmjuafae7PMTeu+X7+fnEOIUmSJEmSWsjMJ8vjHuAm4ATgqYhYAVAe9wwuQmnp7CEkqS9WddjKL0mSJPVTRBwBHJKZz5XnvwX8JXALcC6wsTzePLgopaWzQUiSJEmSpANNADdFBNTrzl/OzK9FxL8A10fEecBjwJkDjLHSmm8K79x4xgAj6Z9huhFug5C0gIj4IvA+YE9mvq2UHQlcB6wCdgIfysy9Uf9PcQVwOvA8sC4z7xtE3JIkSZI6k5mPAm9vUf5T4NT+RzR6xrHBqEqcQ0ha2NXAaXPKNgB3ZOZq4I6yDfBeYHX5Wg9c2acYJUmSJElaFBuEpAVk5jeBp+cUrwU2l+ebgfc3lV+TdXcDyxuTzUmSJEmSVCU2CEmLN5GZuwHK41GlfCXweNNxu0qZJEmSJEmV4hxCUvdEi7JseWDEeurDypiYmKBWq3X8zWdmZrpynW5qjml6zexggykmDq9OLA3zxVS111Pql/kmY3RuAUmSRtcwTcY8KmwQkhbvqYhYkZm7y5CwPaV8F3BM03FHA0+2ukBmbgI2AUxOTubU1FTHQdVqNbpxnW5qjmldRf7AT6+Z5dJt1frTN19MO8+e6n8wkqSx5WIakjReqlUrGlO2hA6dW4BzgY3l8eam8gsiYgtwIrCvMbRMGiURsRN4DngBmM3MyfkqDIOKUeoFc1+90Opz4AB7w10NfB64pqmssZjGxojYULYvZP/FNE6kvpjGiX2NVpLUEecQkhYQEV8BvgW8KSJ2RcR51BuC3hMRjwDvKdsAW4FHgR3AF4A/HEDIUr+8KzOPy8zJsj3f6nvSqDH3NbJcTEOSxktHPYS8U6ZRl5kfmWfXqS2OTeD83kYkVdZaYKo83wzUqN9BHmv2AB0L5n4L5v5I2W8xjYg42GIa9o6WpCHRjSFj78rMnzRtz9etVGrL3A+RTiIqVU4CX4+IBP6+zIk1X4VBGiVLzv1eLCYA1V1QYHrNC4MOYz/DtKAADM2iAm0tpjFuuT9fTIPKv2HL/bmq9hpLo6YXcwh5p0ySRtvJmflkqfjeHhHfb/fEcVthb5g/hPfLkFUMlpz7vVhMAKq7oMCld/1s0GHsZ5gWFIDKLSrQ0WIa45b788U0qMU1hi3356rYe0Edsvdo9XT618G7xJI0ZjLzyfK4JyJuAk5g/grD3HPHaoW9qqyu12DFoDOd5L40xFxMQ5JGVKefCit1lxiqfad4PoO4WztMd4mr9npK4ywijgAOycznyvPfAv6S+SsM0kgw9zUOymIaU8DrImIX8OfUc/v6srDGY8CZ5fCt1Jec30F92fmP9T1gSVJHOmoQqtpdYqj2neL5DOIO8jDdJR70HWFJ+5kAbooIqP8P+XJmfi0i/oXWFQZpVJj76ptBLUXvYhqSNF6W3CLgnbKlc+ykpHYc7G/FICZcz8xHgbe3KP8pLSoM0qgYx9wfVKOENCzmvkem18xWbqiwtFTN+e3f/tHVSRcR75RJkiRJkiQNoSU3CI3jnTJJkiRJ0niIiGOAa4BfA34JbMrMKyLiEuD3gB+XQy/OzK2DiVJaumpNIiNJkiRJUjXMAtOZeV9EvAq4NyJuL/suz8zPDTC2ynGY2fCxQUhSx+ab68ax9Bp2zqEiSdL4yszdwO7y/LmI2A6sHGxUUvfYINQH257YZ6VYkiRJkoZURKwCjgfuAU4GLoiIjwLfod6LaO/gopOWxgYhVd7cO/TenZdURc1/q+wdJ0nDydWA1UpEvBK4EfhkZj4bEVcCnwKyPF4KfLzFeeuB9QATExPUarWOY5mZmenKdQ5mes3si88P9v0aMbU6p7msnyYOH9z3XsjcuPrxWi7EBiFJkiRJklqIiMOoNwZdm5lfBcjMp5r2fwG4tdW5mbkJ2AQwOTmZU1NTHcdTq9XoxnUOpvnG1s6zF/5+jZj2uxm27WflyWCaHKbXzHLptuo1d8yNq/G7HdT8S4f07TtJkiRJkjQkIiKAq4DtmXlZU/mKpsM+AHyv37FJ3VC9JjNJkiRJkgbvZOAcYFtEPFDKLgY+EhHHUR8ythP4/cGEJ3XGBqElcE4bjRvH00sv8f0gSdJ4yMy7gGixa2u/Y6kCl5XvvlafKxtl/fgd2yAkSZKktrT64GqlQJKk4eQcQpIkSZIkSWPGHkKSJGko2Dulmua+LvXldP2IKUlS1fnfWpIkSao4G0QlSd1mg1APHHinbECBSJIkSZIkteAcQpIkSZIkSWPGHkKSJEmSJKlt/VwaXfuPQurm79wGoTa0GrMtSZIkSeqdxdbDbJzojPXe8WODUBf4xpEkSVXkRMSSJGk+Nghp6Mz9cOsHW0ntmq8B378jkiRJi7dqw21Mr5llnZ0khpINQtKYs4ebJI0Xew1p3PhZR5Jas0EIe5wMO18/Sa0spgJgZUGSJA27Xk08rMHox+fTsWwQ8oO/xon5PrraeW39MCBJGkXbntjnEBWpTa4IpvmMZYOQJEkaDeM6L1Tj526et6GTn9mbB5I0Wg72d92e1AIbhKSh1vzH2cncNK68SyzV+YFdkrQQ/09orpFsEOo00X2jSJIkSZKqyvmC1A2H9OrCEXFaRPwgInZExIZefR+pasx9jStzX+PM/Ne4Mvc1rgaV+9ue2HdAB4ZVG26zU4OWpCc9hCLiUOBvgfcAu4B/iYhbMvPhXnw/qdkgVx0z9zWuzH2NM/Nfg9KqAujnHqn3zH1VQTd6ifVqyNgJwI7MfBQgIrYAa4FFv0EW29I5vWaWER0Jp+HQtdwHhy9qqAws96fXLOU7SF01sM890oD5t1/jqme536jYOyRM/dCrlpOVwONN27uAE3v0vaQqMfc1rsx9jTPzX+PK3Ne46lnue2NAB9PNHOlVg1C0KMv9DohYD6wvmzMR8YNufOM/htcBP+nGtbrFmNrTq5jiswc95L/q5rdrUZYHHNSD/B+n17QT4xbTQfLf3O+RKsYE1YxrQH/7u5n74Oee/RhTe8blc4+5P1jjFtOofu6Z83ON1Wu6VFWMCar3uadXDUK7gGOato8Gnmw+IDM3AZu6/Y0j4juZOdnt63bCmNpTxZiW4KC5D73J/yr+/oypPVWMaQnM/SZVjAmqGVcVY1oCP/c0Mab2VDGmJTD3mxhTe6oY0xL4uaeJMbWvanH1apWxfwFWR8SxEfEy4Czglh59L6lKzH2NK3Nf48z817gy9zWuzH2NhJ70EMrM2Yi4APgn4FDgi5n5UC++l1Ql5r7GlbmvcWb+a1yZ+xpX5r5GRc+W48rMrcDWXl1/AV3vktoFxtSeKsa0aOb+foypPVWMadHM/f1UMSaoZlxVjGnRzP/9GFN7qhjTopn7+zGm9lQxpkUz9/djTO2rVFyRecDcV5IkSZIkSRphvZpDSJIkSZIkSRU1Eg1CEXFMRNwZEdsj4qGI+MSgY2qIiEMj4v6IuHXQsQBExPKIuCEivl9+X//toGMCiIg/Ka/d9yLiKxHxikHHNAzM/cWpYv6b+0tn/rfP3B8t5n77qpj7YP4vlbm/OFXMf3N/6cz/9pn77RuJBiFgFpjOzDcDJwHnR8RbBhxTwyeA7YMOoskVwNcy878G3k4FYouIlcAfA5OZ+TbqE7OdNdiohoa5vziVyn9zv2Pmf/vM/dFi7revUrkP5n+HzP3FqVT+m/sdM//bZ+63aSQahDJzd2beV54/R/0FXznYqCAijgbOAP5h0LEARMSvAr8JXAWQmf+amc8MNqoXLQMOj4hlwK8ATw44nqFg7revwvlv7i+R+d8ec3/0mPvtqXDug/m/JOZ++yqc/+b+Epn/7TH3F2ckGoSaRcQq4HjgnsFGAsBfA38G/HLQgRRvAH4M/MfSpe8fIuKIQQeVmU8AnwMeA3YD+zLz64ONaviY+wdVufw397vH/F+QuT/CzP0FVS73wfzvFnP/oCqX/+Z+95j/CzL3F2GkGoQi4pXAjcAnM/PZAcfyPmBPZt47yDjmWAa8A7gyM48HfgZsGGxIEBGvAdYCxwK/DhwREf/zYKMaLuZ+WyqX/+Z+d5j/B2Xujyhz/6Aql/tg/neDud+WyuW/ud8d5v9BmfuLMDINQhFxGPU3xrWZ+dVBxwOcDPxOROwEtgCnRMT/PdiQ2AXsysxGS/IN1N8sg/Zu4EeZ+ePM/Dfgq8B/N+CYhoa537Yq5r+53yHzvy3m/ggy99tSxdwH878j5n7bqpj/5n6HzP+2mPuLMBINQhER1McIbs/MywYdD0BmXpSZR2fmKuoTRn0jMwfaCpiZ/wV4PCLeVIpOBR4eYEgNjwEnRcSvlNfyVKo1KVllmfvtq2j+m/sdMP/bjsncHzHmftsxVTH3wfxfMnO/fRXNf3O/A+Z/2zGZ+4uwbNABdMnJwDnAtoh4oJRdnJlbBxhTVf0RcG1EvAx4FPjYgOMhM++JiBuA+6jPnn8/sGmwUQ0Nc39xKpX/5n7HzP/2mfujxdxvX6VyH8z/Dpn7i1Op/Df3O2b+t8/cb1Nk5qBjkCRJkiRJUh+NxJAxSZIkSZIktc8GIUmSJEmSpDFjg5AkSZIkSdKYsUFIkiRJkiRpzNggJEmSJEmSNGZsEJIkSZIkSRozNghJkiRJkiSNGRuEJEmSJEmSxsz/D1Vlq6BPuEXiAAAAAElFTkSuQmCC\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAABIQAAAD5CAYAAABWIe46AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nO3dfZDlZXnw+e8Fg0rQOKLSmQw8O1hOXF9mBe0CdqnNtqAJgpvRLVEMi4yymaQCiSa9FQb2qQ2JujVmBULWPCRj8GFw0YEFeaBgYiTIKR+qBCMvMsLoMuIsDMzDqAwDLaVJ47V/nPvAmZ7TPaf7vP3OOd9PVdc5v/v30lf3uU73ue/f/RKZiSRJkiRJksbHIYMOQJIkSZIkSf1lg5AkSZIkSdKYsUFIkiRJkiRpzNggJEmSJEmSNGZsEJIkSZIkSRozNghJkiRJkiSNmWWDDgDgda97Xa5ataor1/rZz37GEUcc0ZVrdYsxtWdQMd17770/yczX9/0bF93Kf1/T9hjTS8z93qliTFDNuAYR06jkPviatsuYXrJQ/kfEcuAfgLcBCXwc+AFwHbAK2Al8KDP3RkQAVwCnA88D6zLzvoW+t7nff8b0klH52+9r2p4qxgQV/NyTmQP/euc735ndcuedd3btWt1iTO0ZVEzAd3IE8t/XtD3G9BJzv3eqGFNmNeMaREwL5T7wCuDbwHeBh4C/KOXHAvcAj1CvHL+slL+8bO8o+1fNd+3scu5n+pq2y5hecpD83wz8L+X5y4DlwF8BG0rZBuCz5fnpwD8CAZwE3DPfddPcHxhjeomfe3rHmNpXtc89DhmTJEl6yS+AUzLz7cBxwGkRcRLwWeDyzFwN7AXOK8efB+zNzDcCl5fjpKETEb8K/CZwFUBm/mtmPgOspd5QRHl8f3m+Frim1DfuBpZHxIo+hy1J6oANQpIkSUWp3M6UzcPKVwKnADeU8rmV4kZl+Qbg1DKURho2bwB+DPzHiLg/Iv4hIo4AJjJzN0B5PKocvxJ4vOn8XaVMkjQkKjGHkCSpWiLiFcA3qQ+HWQbckJl/HhHHAluAI4H7gHMy818j4uXANcA7gZ8CH87MnQMJXupQRBwK3Au8Efhb4IfAM5k5Ww5prvi+WCnOzNmI2Ae8FvhJX4OWOrcMeAfwR5l5T0RcQX2I2HxaNXzmAQdFrAfWA0xMTFCr1boQKszMzHTtWt1iTO2pYkzSuLJBSJLUSmPYzExEHAbcFRH/CPwp9WEzWyLi76gPl7mSpmEzEXEW9WEzHx5U8FInMvMF4Lgywe5NwJtbHVYerRTPYUztqWBMu4BdmXlP2b6BeoPQUxGxIjN3lyFhe5qOP6bp/KOBJ+deNDM3AZsAJicnc2pqqivB1mo1unWtbjGm9lQxJmlc2SAkSTpAmYBuvmEzv1vKNwOXUG8QWlueQ70S8fmIiHIdaShl5jMRUaM+Ye7yiFhWegk1V3wbleJdEbEMeDXwdItrWSkeIGM6uMz8LxHxeES8KTN/AJwKPFy+zgU2lsebyym3ABdExBbgRGBfY2iZJGk4OIeQJKmliDg0Ih6gfjf4dhYxbAZoDJuRhkpEvL70DCIiDgfeDWwH7gQ+WA6bWyk+tzz/IPANG0I1xP4IuDYiHqQ+qfr/Qb0h6D0R8QjwnrINsBV4lPoKe18A/rD/4UqSOmEPIUlSS8MybKaCwy4qGRNUM64KxrQC2FzmEToEuD4zb42Ih4EtEfFp4H7KSkzl8UsRsYN6z6CzBhG01A2Z+QAw2WLXqS2OTeD8ngclSeoZG4SkBUTETuA54AVgNjMnI+JI4DpgFbAT+FBm7i2rylwBnA48D6zLzPsGEbfUTVUfNlO1YRdQzZigmnFVLabMfBA4vkX5o8AJLcp/DpzZh9AkSZK6yiFj0sG9KzOPy8zGHbMNwB2ZuRq4g5dW4HgvsLp8rac+r4o0lBw2I0mSJI02ewjpoFZtuG2/7Z0bzxhQJJWxFpgqzzcDNeDCUn5NqQTfHRHLG6tyDCRKLdncnJ9rTN4DDpsZU63yf0xyXjqA7weNmoN9xmlmrmtcNb9PRv19YIOQtLAEvh4RCfx9Ge4y0WjkKUuwHlWOfXFS3aIx4a4NQho6DpuRJEmSRpsNQtLCTs7MJ0ujz+0R8f0Fjm1rUl1wYt1Baiem6TWzC+7v9s9Uxd+TJEmSpNFmg5C0gMx8sjzuiYibqPeMeKoxFCwiVlBfkhtemlS3oXnC3bnXdWLdAWknpnUHGzJ29sLnL1YVf09Ss/mGGIx6N2qNhlUbbmN6zex+f9vNXUmSnFRamldEHBERr2o8B34L+B77T547d1Ldj0bdScA+5w+SJEmSJFXRQRuEIuIVEfHtiPhuRDwUEX9Ryo+NiHsi4pGIuC4iXlbKX162d5T9q3r7I0g9MwHcFRHfBb4N3JaZXwM2Au+JiEeA95RtgK3Ao8AO4AvAH/Y/ZEmSJEmLERHHRMSdEbG91Hk/UcqPjIjbS5339oh4TSmPiPibUud9MCLeMdifQFqadoaM/QI4JTNnIuIw6hXkfwT+FLg8M7dExN8B51FfZvs8YG9mvjEizgI+C3y4R/FLPVMmz317i/KfAqe2KE/g/D6EJkmSJPXUmK1INgtMZ+Z9ZYTAvRFxO7AOuCMzN0bEBmAD9dWF3wusLl8nUq8HnziQyKUOHLRBqFRyZ8rmYeUrgVOA3y3lm4FLqL8R1pbnADcAn4+IKNeRJEkVsJgP+pIkjbIyzUNjFeHnImI79dWC1wJT5bDNQI16g9Ba4JpSx707IpY35hjtd+xSJ9qaQygiDo2IB6hPnns78EPgmcxsLMXTWF4bmpbeLvv3Aa/tZtCSJEmSJHVbmfLkeOAeYKLRyFMejyqHvVjnLZrrw9LQaGuVscx8ATguIpYDNwFvbnVYeWxr6e1eLLsN1Vy+edhjmrsEd69+lir+niRJkiSNh4h4JXAj8MnMfDaiVdW2fmiLsr7UeatYZxq1mJrrv93+uar2u1rUsvOZ+UxE1ICTgOURsaz0AmpeXrux9PauiFgGvBp4usW1ur7sNlRz+eZhj2nuEtzdXnK7oYq/J42ebU/sO+iy8pKk0dZqyOQIzIEiqQNlvtwbgWsz86ul+KnGULCIWEF9xAy8VOdtaK4Pv6gXdd4q1plGLabmukK3675V+121s8rY60vPICLicODdwHbgTuCD5bC5S283luT+IPAN5w+SJEmSJFVR1LsCXQVsz8zLmnY1123n1nk/WlYbOwnY5/xBGkbt9BBaAWyOiEOpNyBdn5m3RsTDwJaI+DRwP/U3EOXxSxGxg3rPoLN6ELckSZIkSd1wMnAOsK3MnQtwMbARuD4izgMeA84s+7YCpwM7gOeBj/U3XKk72lll7EHqk2rNLX8UOKFF+c956Y0iSZIkSVJlZeZdtJ4XCODUFscncH5Pg5L6oK1VxiRJkiRJkjQ6FjWptCRJkjTOnJBakjQqbBCSJGnENSqw02tmXWVPkiRJgA1CkiRJkiRpBDX36rQ354FsEJIkSUvSaugM+IFLkiRpGDiptCRJkiRJ0pixQUiSJEmSJGnM2CAkSZIkSZI0ZmwQkiRJkiRJGjNOKi1JkiRJksbCUlYeG9XVyuwhJEmSJEmSNGZsEJIkSZJEROyMiG0R8UBEfKeUHRkRt0fEI+XxNaU8IuJvImJHRDwYEe8YbPSSpMVyyJgkSVIREccA1wC/BvwS2JSZV0TEJcDvAT8uh16cmVvLORcB5wEvAH+cmf/U98Cl7nlXZv6kaXsDcEdmboyIDWX7QuC9wOrydSJwZXlUnzUPZZlres0s6xbYL2m82SAkSZL0kllgOjPvi4hXAfdGxO1l3+WZ+bnmgyPiLcBZwFuBXwf+OSJ+IzNf6GvUUu+sBabK881AjXqD0FrgmsxM4O6IWB4RKzJz90CilCQtmkPGJEkHiIhjIuLOiNgeEQ9FxCdK+SUR8UQZTvBARJzedM5FZejADyLitwcXvbR0mbk7M+8rz58DtgMrFzhlLbAlM3+RmT8CdgAn9D5SqScS+HpE3BsR60vZRKORpzweVcpXAo83nbuLhd8rkqSKsYeQJKkVe0lo7EXEKuB44B7gZOCCiPgo8B3q74+91CvAdzedZqVYw+zkzHwyIo4Cbo+I7y9wbLQoywMOqjcsrQeYmJigVqt1JdCZmZmuXatbBhXT9JrZefdNHL7w/m5ZzM9dxddOGlc2CEmSDlDuAjfuCD8XEW33kgB+FBGNXhLf6nmwUg9ExCuBG4FPZuazEXEl8CnqFd5PAZcCH8dK8QGqFtP0mtm2KsWtYm63Ir2Un7dqvyeAzHyyPO6JiJuo/x1/qjEULCJWAHvK4buAY5pOPxp4ssU1NwGbACYnJ3NqaqorsdZqNbp1rW4ZVEwLzRE0vWaWS7f1vsq38+ypto+t4msXEV8E3gfsycy3lbLrgDeVQ5YDz2TmceVmwXbgB2Xf3Zn5B/2NWOoOG4QkSQuyl4TGTUQcRr0x6NrM/CpAZj7VtP8LwK1l00rxHFWLad2G29qqFLeq0LY7Ge9iKsMNVfs9RcQRwCHlJsARwG8BfwncApwLbCyPN5dTbqH+/2AL9cmk9zl/kIbY1cDnqS8qAEBmfrjxPCIuBfY1Hf/DzDyub9FJPWKDkCRpXsPQS6KKd9mrFlOjl4NDBw4uIgK4CtiemZc1lTdPlvsB4Hvl+S3AlyPiMurDJVcD3+5jyFK3TAA31d8CLAO+nJlfi4h/Aa6PiPOAx4Azy/FbgdOpz5v1PPCx/ocsdUdmfrPcADtA+b/wIeCUfsYk9YMNQpKkloall0TV7rJD9WJq9HJw6EBbTgbOAbZFxAOl7GLgIxFxHPWGzp3A7wNk5kMRcT3wMPW5t8537iwNo8x8FHh7i/KfAqe2KE/g/D6EJg3afw88lZmPNJUdGxH3A88C/z4z/3OrE70RNjiNmJpvhDVibFXWbCnnLDauqrBBSJJ0AHtJaFxl5l207vG2dYFzPgN8pmdBSZIG6SPAV5q2dwP/LjN/GhHvBP5TRLw1M5+de6I3wganEVPz0N/GDatWZc2Wcs5i46oKG4QkSa3YS0KSJI21iFgG/E/AOxtlZQGNX5Tn90bED4HfoD63ojRUbBCSJB3AXhKSJEm8G/h+Zu5qFETE64GnM/OFiHgD9V7Rjw4qQKkThww6AEmSJEmSBiUivgJ8C3hTROwqk6gDnMX+w8UAfhN4MCK+C9wA/EFmPt2/aKXuOWgPoYg4hvrye78G/BLYlJlXRMQlwO8BPy6HXpyZW8s5FwHnAS8Af5yZ/9SD2CVJkiRJ6khmfmSe8nUtym6kvuiGNPTaGTI2C0xn5n0R8Srg3oi4vey7PDM/13xwRLyFekvqW6lPLPrPEfEbziWhYRURh1IfE/xEZr4vIo4FtgBHAvcB52Tmv0bEy6k3nr4T+Cnw4czcOaCwJUmSJEma10GHjGXm7sy8rzx/DtgOrFzglLXAlsz8RWb+CNgBnNCNYKUB+QT1vG/4LPXG0NXAXuq94SiPezPzjcDl5ThJkiRJkipnUXMIRcQq4HjgnlJ0QUQ8GBFfjIjXlLKVwONNp+1i4QYkqbIi4mjgDOAfynYAp1AfLwywGXh/eb62bFP2n1qOlyRJkiSpUtpeZSwiXkl9rOQnM/PZiLgS+BT1pYc/BVwKfJzWq9Jki+utB9YDTExMUKvVFh18KzMzM127VrcMe0zTa2b32+7Vz1LF3xPw18CfAa8q268FnsnMxi+lucHzxcbQzJyNiH3l+J/0L1xJ42zVhtsGHYIkSZKGRFsNQhFxGPXGoGsz86sAmflU0/4vALeWzV3AMU2nHw08OfeambkJ2AQwOTmZU1NTSwj/QLVajW5dq1uGPaZ1cyoYO89u77zFqtrvKSLeB+zJzHsjYqpR3OLQbGPf3Gt3vUG0ig1qVYxp4vADGzkXq9s/UxV/T5IkSZJGWzurjAVwFbA9My9rKl+RmbvL5geA75XntwBfjojLqE8qvRr4dlejlvrjZOB3IuJ04BXAr1LvMbQ8IpaVXkLNDZ6NxtBdEbEMeDXQcgnKXjSIVq1BDaoZ0/917c1cuq3tzpEtdbtRtIq/J0mSJEmjrZ05hE4GzgFOiYgHytfpwF9FxLaIeBB4F/AnAJn5EHA98DDwNeB8VxjTMMrMizLz6MxcRX3lvG9k5tnAncAHy2HnAjeX57eUbcr+b2Rmyx5CkiRJkiQN0kFvk2fmXbQeCrN1gXM+A3ymg7ikKrsQ2BIRnwbup96DjvL4pYjYQb1n0FkDik+SJEmSpAV1Nm5CGhOZWQNq5fmjwAktjvk5cGZfA5MkSZIkaQkWtey8JEmSJEmShp89hCRJUletmrM6JcDOjWcMIBJJkiTNxx5CkiRJkiRpqK3acFvLm1Kanz2EJEmSNHTsiSZJUmfsISRJkiRJkjRmbBCSJEmSJEkaMzYISZIkSZLGVkR8MSL2RMT3msouiYgnIuKB8nV6076LImJHRPwgIn57MFFLnbNBSJIkSZI0zq4GTmtRfnlmHle+tgJExFuAs4C3lnP+Q0Qc2rdIpS6yQUiSJEmSNLYy85vA020evhbYkpm/yMwfATuAE3oWnNRDrjImSZKksedSxZJauCAiPgp8B5jOzL3ASuDupmN2lTJp6NggJEmSJEnS/q4EPgVkebwU+DgQLY7NVheIiPXAeoCJiQlqtVrHQc3MzHTlOt1UlZim18wCUKvVXoypUdYobz6uuazVdRZzTruq8rtqsEFIkiRJkqQmmflU43lEfAG4tWzuAo5pOvRo4Ml5rrEJ2AQwOTmZU1NTHcdVq9XoxnW6qSoxrSs9PXeePfViTOuaen/uPHtqv+Oay1pdZzHntKsqv6sG5xCSJEmSBEBEHBoR90fErWX72Ii4JyIeiYjrIuJlpfzlZXtH2b9qkHFL3RYRK5o2PwA0ViC7BTirvAeOBVYD3+53fFI32CAkSZJURMQxEXFnRGyPiIci4hOl/MiIuL1Uim+PiNeU8oiIvymV4gcj4h2D/Qmkjn0C2N60/VnqKy2tBvYC55Xy84C9mflG4PJynDSUIuIrwLeAN0XErog4D/iriNgWEQ8C7wL+BCAzHwKuBx4Gvgacn5kvDCh0qSMOGZOkRWpn4tGdG8/oQySSemCW+sSh90XEq4B7I+J2YB1wR2ZujIgNwAbgQuC91O8OrwZOpD7nxIkDiVzqUEQcDZwBfAb404gI4BTgd8shm4FLqOf52vIc4Abg8xERmdlyLhWpyjLzIy2Kr1rg+M9Qf59IQ80eQpKkA9hLQuMqM3dn5n3l+XPUe0qspF753VwO2wy8vzxfC1yTdXcDy+cMM5CGyV8Dfwb8smy/FngmMxuzqTavprQSeByg7N9XjpeksbNqw20vfg0TewhJklqxl4TGXpkT5XjgHmAiM3dDvdEoIo4qh71YKS4aFebd/YtU6lxEvA/Yk5n3RsRUo7jFodnGvubrdn2VJajeSj0wuJiaVz+aa+Lwhfd3y2J+7iq+dtK4skFIknSAUvFtVH6fi4jmXhJT5bDNQI16g9CLvSSAuyNieUSsaFSgpWETEa8EbgQ+mZnP1kfOtD60RZmV4j7E1KqSO9/ywb2uFC/l563ga3cy8DsRcTrwCuBXqfcYWh4Ry0ovoObVlBorLe2KiGXAq4Gn5160F6ssQfVW6oHBxbRugR4J02tmuXRb76t8i1l1qYqvnTSubBCSJC3IXhIaNxFxGPXGoGsz86ul+KlGI2cZEranlLe1/LCV4u5rVQmeb/ngXleKl7IEcdVeu8y8CLgIoPQQ+l8z8+yI+H+ADwJbgHOBm8spt5Ttb5X933D+IEkaLjYISZLmNQy9JCp4l72Swwagf0MHWpnv91G1169MonsVsD0zL2va1aj8buTASvEFEbGF+jDJffaM04i5ENgSEZ8G7ueliXavAr4UETuo9ww6a0DxSZKWyAYhSeqBg00oNwyrkA1LL4mq3WWHag4bgP4NHWhlvh4UFXz9TgbOAbZFxAOl7GLqDUHXl6WIHwPOLPu2AqcDO4DngY/1N1yp+zKzRn1IMJn5KHBCi2N+zkvvA0nSELJBSJJ0AHtJaFxl5l207vEGcGqL4xM4v6dBSVLFLWZlpatPO6KHkUhaDBuEJEmt2EtCkiRJGmEHbRCKiGOAa4BfA34JbMrMKyLiSOA6YBWwE/hQZu4td5WvoF4xeB5Yl5n39SZ8SVIv2EtCkiRJGm2HtHHMLDCdmW8GTgLOj4i3ABuAOzJzNXBH2QZ4L7C6fK0Hrux61JIkSZIkSVqyg/YQKnNANJYYfi4itlNfSngtMFUO20x94rkLS/k15W7x3RGxvDEBaffDlyRpPC1mvgZJ/dfqPToMCwpIksZHOz2EXhQRq4DjgXuAiUYjT3k8qhy2Eni86bRdpUySJEmSJEkV0Pak0hHxSurLD38yM5+tTxXU+tAWZdnieuupDyljYmKCWq3WbigLmpmZ6dq1umXYY5peM7vfdq9+lir+niRJkiRJGkVtNQhFxGHUG4OuzcyvluKnGkPBImIFsKeU7wKOaTr9aODJudfMzE3AJoDJycmcmppa2k8wR61Wo1vX6pZhj2ndnC7PO89u77zFquLvSZIkSZKkUXTQIWNl1bCrgO2ZeVnTrluAc8vzc4Gbm8o/GnUnAfucP0iSJEmSJKk62ukhdDJwDrAtIh4oZRcDG4HrI+I84DHgzLJvK/Ul53dQX3b+Y12NWB1bteE2ptfMvtjzxwkONSramWR3ek0fApEkSZKkimtnlbG7aD0vEMCpLY5P4PwO45IkSZIkqeci4ovA+4A9mfm2UvZ/Av8j8K/AD4GPZeYzZaGl7cAPyul3Z+Yf9D1oqQsWtcqYNE4i4hUR8e2I+G5EPBQRf1HKj42IeyLikYi4LiJeVspfXrZ3lP2rBhm/JEmSpLZcDZw2p+x24G2Z+d8A/y9wUdO+H2bmceXLxiANrbZXGVN1zR0m4xCwrvkFcEpmzpSJ1e+KiH8E/hS4PDO3RMTfAecBV5bHvZn5xog4C/gs8OFBBS9JkiTp4DLzm3Nv5mbm15s27wY+2M+YpH6wQUiLNi4NUGX440zZPKx8JXAK8LulfDNwCfUGobXlOcANwOcjIsp1JEmSJA2njwPXNW0fGxH3A88C/z4z//NgwpI6Y4OQtICIOBS4F3gj8LfUxw8/k5mz5ZBdwMryfCXwOEBmzkbEPuC1wE/6GrQkSZKkroiI/w2YBa4tRbuBf5eZP42IdwL/KSLempnPtjh3PbAeYGJiglqt1nE8MzMzXblON/Urpm1P7ANgzcpXt9w/vaZeRavVai/G1ChrlDcf11zW6jqdntNK1V4/G4TUsVHuMZSZLwDHRcRy4Cbgza0OK4+tJl9v2TvIfw690fyHeD4Th7d3XK81/16q+NpJkiSNu4g4l/pk06c2ev1n5i+oTy1BZt4bET8EfgP4ztzzM3MTsAlgcnIyp6amOo6pVqvRjet0U79ienGV7LNbf6/m/Y2Y1jXVVRvntSprdZ1Oz2mlaq+fDUJqa6nucVdWFKgBJwHLI2JZ6SV0NPBkOWwXcAywKyKWAa8Gnp7nev5z6IF1bS07P8ul2wb/p6/5H0UVXztJkqRxFhGnARcC/0NmPt9U/nrg6cx8ISLeAKwGHh1QmFJHBl8rkiqq/LH/t9IYdDjwbuoTRd9JfVK5LcC5wM3llFvK9rfK/m84f5AkSZ3z5pWkXoqIrwBTwOsiYhfw59RXFXs5cHtEwEvLy/8m8JcRMQu8APxBZra8CSxVnQ1C0vxWAJvLPEKHANdn5q0R8TCwJSI+DdwPXFWOvwr4UkTsoN4z6KxBBC1JkiSpfZn5kRbFV7UoIzNvBG7sbURSf9ggJM0jMx8Ejm9R/ihwQovynwNn9iE0SZIkSZI6csigA5AkSZIkSVJ/2SAkSZIkSZI0ZmwQkiRJkiRJ6rJVG26r9MIIziEkaWhU+Y+pJEmSJA0TG4QkSVLPzdege/VpR/Q5EkmqPm+CSeoHh4xJkiRJkiSNGXsISZIkaSTYq0KSpPbZQ0iSJEkacxHxioj4dkR8NyIeioi/KOXHRsQ9EfFIRFwXES8r5S8v2zvK/lWDjF+StHg2CEmSJBUR8cWI2BMR32squyQinoiIB8rX6U37LioV4h9ExG8PJmqpK34BnJKZbweOA06LiJOAzwKXZ+ZqYC9wXjn+PGBvZr4RuLwcJ0kaIjYISZIOYKVYY+xq4LQW5Zdn5nHlaytARLwFOAt4aznnP0TEoX2LVOqirJspm4eVrwROAW4o5ZuB95fna8s2Zf+pERF9CleSuq7qS8T3gnMIqevmvol2bjxjQJFI6sDVwOeBa+aUX56Zn2sumFMp/nXgnyPiNzLzhX4EKnVTZn5zEUNf1gJbMvMXwI8iYgdwAvCtHoUn9VRp0LwXeCPwt8APgWcyc7YcsgtYWZ6vBB4HyMzZiNgHvBb4SV+DliQtmQ1CkqQDWCmWDnBBRHwU+A4wnZl7qVeI7246prmyvJ+IWA+sB5iYmKBWq3UlqJmZma5dq1t6EdP0mtmDH7SAicM7v8ZCWv28rb5f83FVfO1KQ/5xEbEcuAl4c6vDymOr3kA5t8DcX5pu5Wuvc38pqvjaSePKBiFJ0mJ0VCmWhtSVwKeoV3Y/BVwKfJw2K8QAmbkJ2AQwOTmZU1NTXQmsVqvRrWt1Sy9iWtdhF/7pNbNcuq2HH3u3/axF4YHfb+fZUy8+r+Jr15CZz0REDTgJWB4Ry0ovoaOBJ8thu4BjgF0RsQx4NfB0i2uZ+0vQac439Dz3l+Dq046o3Gsnjatq/XWQJFVZx5XiXtwpruKdxn7EtJQ7vt4pXprMfKrxPCK+ANxaNhsV4obmyrI0VCLi9cC/lcagw4F3U58o+k7gg8AW4Fzg5nLKLWX7W2X/NzKz5d9+SVI12SA0BsZtYixJvdGNSnEv7hSP+l3i+Szl7rF3ipcmIlZk5u6y+QGgMdn6LcCXI+Iy6vNnrQa+PYAQpW5YAWwu8wgdAlyfmbdGxMPAloj4NHA/cFU5/irgS2WY8NPU55KTJA2Rg34qjIgvAu8D9mTm20rZJcDvAT8uh13ctOLGRdSXoXwB+OPM/FjlTosAABe8SURBVKcexC1J6jMrxRoHEfEVYAp4XUTsAv4cmIqI46j3fNsJ/D5AZj4UEdcDDwOzwPlOpq5hlZkPAse3KH+U+rxwc8t/DpzZh9CknpunznskcB2wivrf/g9l5t6ymt4VwOnA88C6zLxvEHFLnWrnNuHVuNLMULFHkKROWSnWuMrMj7QovqpFWeP4zwCf6V1EkqQ+uJoD67wbgDsyc2NEbCjbFwLvpX7zazVwIvUh9Sf2NVqpSw7aIORKM5I0fqwUS5KkcTFPnXct9ZtjAJuBGvUGobXANWXOrLsjYvmcXtTS0OhkIgFXmpEkSZIkjaKJRiNPZu6OiKNK+Urg8abjGnVeG4SG0LiPrllqg1AlV5qBaq5W0uuYqr7STLs/exVfO0mSJElq4uqqc/Qrpkb9db7v1by/EVNznbdx3mLqwa3OafX959s/N+aqvX5LahCq6kozMJ6rzVR9pZmdZ0+1dVwVXztJkiRJY+mpxlCwiFgB7Cnlrq46R79iatR756tfNu9vxNRcV26ct5j6c6tzWn3/+fbPjblqr98hSzmpvCEa5q40c1ZEvDwijsWVZiRJkiRJw+cW4Nzy/Fzg5qbyj0bdScA+5w/SsGpn2XlXmlFH5o7L3LnxjAFFIkmSJEn7m6fOuxG4PiLOAx4DziyHb6W+5PwO6svOf6zvAUtd0s4qY640I0mSJEkaSfPUeQFObXFsAuf3NiKpP5Y0ZEySJEmSJKlqVm24jW1P7Bv7FcTa0Z9ZhSVJkqQx11w5mV4zy7oNtzmUXpI0MDYISZIkqTK8oytJ6gX/vxzIIWOSJEmSJEljxh5CkiRVgHetJEmS1E/2EJIkSZIkSRozNghJkiRJkiSNGRuENHCrNtzm0oCSJEmSJOClOqJ6ywYhaR4RcUxE3BkR2yPioYj4RCk/MiJuj4hHyuNrSnlExN9ExI6IeDAi3jHYn0CSJEmSpNZsEJLmNwtMZ+abgZOA8yPiLcAG4I7MXA3cUbYB3gusLl/rgSv7H7IkSZIkSQdng5A0j8zcnZn3lefPAduBlcBaYHM5bDPw/vJ8LXBN1t0NLI+IFX0OW5IkSZKkg3LZeakNEbEKOB64B5jIzN1QbzSKiKPKYSuBx5tO21XKdvcvUkmSJEmqtsb8QDs3njHgSBaveW6jYYy/mQ1C0kFExCuBG4FPZuazETHvoS3Kcp5rrqc+rIyJiQlqtVrHcc7MzHTlOt3U7Zim18x2fI2Jw7tznU41/16q+NpJkiRJ427UJ7a2QUhaQEQcRr0x6NrM/GopfioiVpTeQSuAPaV8F3BM0+lHA0+2um5mbgI2AUxOTubU1FTHsdZqNbpxnW7qdkzruvAHeXrNLJduG/yfvp1nT734vIqvndQv257Yd8B7e9jvtkmSJA0D5xCS5hH1rkBXAdsz87KmXbcA55bn5wI3N5V/tKw2dhKwrzG0TJIkSZKkKhn8bXKpuk4GzgG2RcQDpexiYCNwfUScBzwGnFn2bQVOB3YAzwMf62+4kiRJkqR+GfYhZTYISfPIzLtoPS8QwKktjk/g/J4GJUmSJKkvIuJNwHVNRW8A/ndgOfB7wI9L+cWZubXP4Ukds0FIkiRJkqQ5MvMHwHEAEXEo8ARwE/WRAJdn5ucGGN7YGqVVvgbNBiFJkiRJkhZ2KvDDzPz/Flh1WH027EO2Bs0GIfWdb1pJUlVFxBeB9wF7MvNtpexI6kMGVgE7gQ9l5t6y+MAV1OePex5Yl5n3DSJuqVMRcQxwDfBrwC+BTZl5hfnfHX7+HQlnAV9p2r4gIj4KfAeYzsy9c0+IiPXAeoCJiQlqtVrHQczMzHTlOt20lJim18wCzHteq/2NsnZMHL6447upVcyNsqq9fjYISZIOYKVYY+xq4PPUK8YNG4A7MnNjRGwo2xcC7wVWl68TgSvLozSMZqlXau+LiFcB90bE7cA6zH+NuYh4GfA7wEWl6ErgU0CWx0uBj889LzM3AZsAJicnc2pqquNYarUa3bhONy0lpnWlkXTn2a3Pa7V/3SIaVqfXzHLptsE0d7SKuVFWtdfPZeclSa1cDZw2p6xRKV4N3FG2Yf9KwXrqH5KkoZSZ3wSenlO8Fthcnm8G3t9Ufk3W3Q0sj4gV/YlU6q7M3N1ozM/M54DtwErMfwnqn3Xuy8ynADLzqcx8ITN/CXwBOGGg0UlLZIOQJOkAVoql/Uxk5m6oV5qBo0r5SuDxpuN2lTJpqEXEKuB44B7MfwngIzQNF5vzOecDwPf6HpHUBQ4ZkyS1a79KQUQcrFKwu8/xSf3WalbRbHlgD+aRgOrNRQCdx9SLOR8GOZfEfBoxVe31i4hXAjcCn8zMZxeYPLet/Df36waVf1XM/Sq+dguJiF8B3gP8flPxX0XEcdRzfuecfdLQOGiDkPNISOoHJ1scagOtFFfxg2Unkyv2UhUrBq1iqtrrCTwVEStKQ+gKYE8p3wUc03Tc0cCTrS7Qi3kkoHpzEUDnMS1mjoh2DXIuifk0Yppv/oxBiIjDqDcGXZuZXy3FHeW/uV/Xi7xuRxVz/+rTjqjca7eQzHweeO2csnMGFI7UVe38dbgaJ1eUJFW0UjxslYL59KOyUMWKQauYqlRBLm4BzgU2lsebm8oviIgt1D/v7Gv0opOGTbmxexWwPTMva9pl/kvSiDrop8LM/GYZR9xsLTBVnm8GatQbhF6cRwK4OyKWNyoP3QpYkkZBc4+o6TWzLRsDdm48o58htcNKgUZeRHyF+mec10XELuDPqef89RFxHvAYcGY5fCv1XtE7qPeM/ljfA5a652TgHGBbRDxQyi7G/JekkbXU24TOIyFJI8xKscZVZn5knl2ntjg2gfN7G5HUH5l5F62HAIP5L0kjqdv9xp1csYVex7SU+SCqPI9E1V4/aRxZKZYkSdKgOc9oby21QaiS80jA6MwlsRhLmXeiyvNIVHDuCEmSJEmSRspSWwScR0KSJEmSJGkRmns9DXrO0HaWnXceCUmSJEmSpBHSzipjziMhSZIkSerYtif2tT3lxaB7T0ij7pBBByBJkiRJkqT+qtaswpIkSRobrh4jSdLg2ENIkiRJkiRpzNhDaAh5N02SJA0bP79IklQtNggNAT9ASdJo8e+6JEmSBs0GoQqyoiBJkiRJknrJOYQkSZIkSZLGjA1CkiRJkiRJY8YhY5IkSZIktRARO4HngBeA2cycjIgjgeuAVcBO4EOZuXdQMUpLZQ8hSZIkSZLm967MPC4zJ8v2BuCOzFwN3FG2paFjDyFJkiRJktq3FpgqzzcDNeDCQQWj6mssHDW9ZpYqNcNUJxJJkiRJkqolga9HRAJ/n5mbgInM3A2Qmbsj4qhWJ0bEemA9wMTEBLVareNgZmZmunKdblpKTPWGEeY9r7F/qSYO7/waS9X8M82NYW5cg34tbRCSJEmSJKm1kzPzydLoc3tEfL/dE0vj0SaAycnJnJqa6jiYWq1GN67TTUuJaV3pMbPz7NbnNfYv1fSaWS7dNpjmjuafae7PMTeu+X7+fnEOIUmSJEmSWsjMJ8vjHuAm4ATgqYhYAVAe9wwuQmnp7CEkqS9WddjKL0mSJPVTRBwBHJKZz5XnvwX8JXALcC6wsTzePLgopaWzQUiSJEmSpANNADdFBNTrzl/OzK9FxL8A10fEecBjwJkDjLHSmm8K79x4xgAj6Z9huhFug5C0gIj4IvA+YE9mvq2UHQlcB6wCdgIfysy9Uf9PcQVwOvA8sC4z7xtE3JIkSZI6k5mPAm9vUf5T4NT+RzR6xrHBqEqcQ0ha2NXAaXPKNgB3ZOZq4I6yDfBeYHX5Wg9c2acYJUmSJElaFBuEpAVk5jeBp+cUrwU2l+ebgfc3lV+TdXcDyxuTzUmSJEmSVCU2CEmLN5GZuwHK41GlfCXweNNxu0qZJEmSJEmV4hxCUvdEi7JseWDEeurDypiYmKBWq3X8zWdmZrpynW5qjml6zexggykmDq9OLA3zxVS111Pql/kmY3RuAUmSRtcwTcY8KmwQkhbvqYhYkZm7y5CwPaV8F3BM03FHA0+2ukBmbgI2AUxOTubU1FTHQdVqNbpxnW5qjmldRf7AT6+Z5dJt1frTN19MO8+e6n8wkqSx5WIakjReqlUrGlO2hA6dW4BzgY3l8eam8gsiYgtwIrCvMbRMGiURsRN4DngBmM3MyfkqDIOKUeoFc1+90Opz4AB7w10NfB64pqmssZjGxojYULYvZP/FNE6kvpjGiX2NVpLUEecQkhYQEV8BvgW8KSJ2RcR51BuC3hMRjwDvKdsAW4FHgR3AF4A/HEDIUr+8KzOPy8zJsj3f6nvSqDH3NbJcTEOSxktHPYS8U6ZRl5kfmWfXqS2OTeD83kYkVdZaYKo83wzUqN9BHmv2AB0L5n4L5v5I2W8xjYg42GIa9o6WpCHRjSFj78rMnzRtz9etVGrL3A+RTiIqVU4CX4+IBP6+zIk1X4VBGiVLzv1eLCYA1V1QYHrNC4MOYz/DtKAADM2iAm0tpjFuuT9fTIPKv2HL/bmq9hpLo6YXcwh5p0ySRtvJmflkqfjeHhHfb/fEcVthb5g/hPfLkFUMlpz7vVhMAKq7oMCld/1s0GHsZ5gWFIDKLSrQ0WIa45b788U0qMU1hi3356rYe0Edsvdo9XT618G7xJI0ZjLzyfK4JyJuAk5g/grD3HPHaoW9qqyu12DFoDOd5L40xFxMQ5JGVKefCit1lxiqfad4PoO4WztMd4mr9npK4ywijgAOycznyvPfAv6S+SsM0kgw9zUOymIaU8DrImIX8OfUc/v6srDGY8CZ5fCt1Jec30F92fmP9T1gSVJHOmoQqtpdYqj2neL5DOIO8jDdJR70HWFJ+5kAbooIqP8P+XJmfi0i/oXWFQZpVJj76ptBLUXvYhqSNF6W3CLgnbKlc+ykpHYc7G/FICZcz8xHgbe3KP8pLSoM0qgYx9wfVKOENCzmvkem18xWbqiwtFTN+e3f/tHVSRcR75RJkiRJkiQNoSU3CI3jnTJJkiRJ0niIiGOAa4BfA34JbMrMKyLiEuD3gB+XQy/OzK2DiVJaumpNIiNJkiRJUjXMAtOZeV9EvAq4NyJuL/suz8zPDTC2ynGY2fCxQUhSx+ab68ax9Bp2zqEiSdL4yszdwO7y/LmI2A6sHGxUUvfYINQH257YZ6VYkiRJkoZURKwCjgfuAU4GLoiIjwLfod6LaO/gopOWxgYhVd7cO/TenZdURc1/q+wdJ0nDydWA1UpEvBK4EfhkZj4bEVcCnwKyPF4KfLzFeeuB9QATExPUarWOY5mZmenKdQ5mes3si88P9v0aMbU6p7msnyYOH9z3XsjcuPrxWi7EBiFJkiRJklqIiMOoNwZdm5lfBcjMp5r2fwG4tdW5mbkJ2AQwOTmZU1NTHcdTq9XoxnUOpvnG1s6zF/5+jZj2uxm27WflyWCaHKbXzHLptuo1d8yNq/G7HdT8S4f07TtJkiRJkjQkIiKAq4DtmXlZU/mKpsM+AHyv37FJ3VC9JjNJkiRJkgbvZOAcYFtEPFDKLgY+EhHHUR8ythP4/cGEJ3XGBqElcE4bjRvH00sv8f0gSdJ4yMy7gGixa2u/Y6kCl5XvvlafKxtl/fgd2yAkSZKktrT64GqlQJKk4eQcQpIkSZIkSWPGHkKSJGko2Dulmua+LvXldP2IKUlS1fnfWpIkSao4G0QlSd1mg1APHHinbECBSJIkSZIkteAcQpIkSZIkSWPGHkKSJEmSJKlt/VwaXfuPQurm79wGoTa0GrMtSZIkSeqdxdbDbJzojPXe8WODUBf4xpEkSVXkRMSSJGk+Nghp6Mz9cOsHW0ntmq8B378jkiRJi7dqw21Mr5llnZ0khpINQtKYs4ebJI0Xew1p3PhZR5Jas0EIe5wMO18/Sa0spgJgZUGSJA27Xk08rMHox+fTsWwQ8oO/xon5PrraeW39MCBJGkXbntjnEBWpTa4IpvmMZYOQJEkaDeM6L1Tj526et6GTn9mbB5I0Wg72d92e1AIbhKSh1vzH2cncNK68SyzV+YFdkrQQ/09orpFsEOo00X2jSJIkSZKqyvmC1A2H9OrCEXFaRPwgInZExIZefR+pasx9jStzX+PM/Ne4Mvc1rgaV+9ue2HdAB4ZVG26zU4OWpCc9hCLiUOBvgfcAu4B/iYhbMvPhXnw/qdkgVx0z9zWuzH2NM/Nfg9KqAujnHqn3zH1VQTd6ifVqyNgJwI7MfBQgIrYAa4FFv0EW29I5vWaWER0Jp+HQtdwHhy9qqAws96fXLOU7SF01sM890oD5t1/jqme536jYOyRM/dCrlpOVwONN27uAE3v0vaQqMfc1rsx9jTPzX+PK3Ne46lnue2NAB9PNHOlVg1C0KMv9DohYD6wvmzMR8YNufOM/htcBP+nGtbrFmNrTq5jiswc95L/q5rdrUZYHHNSD/B+n17QT4xbTQfLf3O+RKsYE1YxrQH/7u5n74Oee/RhTe8blc4+5P1jjFtOofu6Z83ON1Wu6VFWMCar3uadXDUK7gGOato8Gnmw+IDM3AZu6/Y0j4juZOdnt63bCmNpTxZiW4KC5D73J/yr+/oypPVWMaQnM/SZVjAmqGVcVY1oCP/c0Mab2VDGmJTD3mxhTe6oY0xL4uaeJMbWvanH1apWxfwFWR8SxEfEy4Czglh59L6lKzH2NK3Nf48z817gy9zWuzH2NhJ70EMrM2Yi4APgn4FDgi5n5UC++l1Ql5r7GlbmvcWb+a1yZ+xpX5r5GRc+W48rMrcDWXl1/AV3vktoFxtSeKsa0aOb+foypPVWMadHM/f1UMSaoZlxVjGnRzP/9GFN7qhjTopn7+zGm9lQxpkUz9/djTO2rVFyRecDcV5IkSZIkSRphvZpDSJIkSZIkSRU1Eg1CEXFMRNwZEdsj4qGI+MSgY2qIiEMj4v6IuHXQsQBExPKIuCEivl9+X//toGMCiIg/Ka/d9yLiKxHxikHHNAzM/cWpYv6b+0tn/rfP3B8t5n77qpj7YP4vlbm/OFXMf3N/6cz/9pn77RuJBiFgFpjOzDcDJwHnR8RbBhxTwyeA7YMOoskVwNcy878G3k4FYouIlcAfA5OZ+TbqE7OdNdiohoa5vziVyn9zv2Pmf/vM/dFi7revUrkP5n+HzP3FqVT+m/sdM//bZ+63aSQahDJzd2beV54/R/0FXznYqCAijgbOAP5h0LEARMSvAr8JXAWQmf+amc8MNqoXLQMOj4hlwK8ATw44nqFg7revwvlv7i+R+d8ec3/0mPvtqXDug/m/JOZ++yqc/+b+Epn/7TH3F2ckGoSaRcQq4HjgnsFGAsBfA38G/HLQgRRvAH4M/MfSpe8fIuKIQQeVmU8AnwMeA3YD+zLz64ONaviY+wdVufw397vH/F+QuT/CzP0FVS73wfzvFnP/oCqX/+Z+95j/CzL3F2GkGoQi4pXAjcAnM/PZAcfyPmBPZt47yDjmWAa8A7gyM48HfgZsGGxIEBGvAdYCxwK/DhwREf/zYKMaLuZ+WyqX/+Z+d5j/B2Xujyhz/6Aql/tg/neDud+WyuW/ud8d5v9BmfuLMDINQhFxGPU3xrWZ+dVBxwOcDPxOROwEtgCnRMT/PdiQ2AXsysxGS/IN1N8sg/Zu4EeZ+ePM/Dfgq8B/N+CYhoa537Yq5r+53yHzvy3m/ggy99tSxdwH878j5n7bqpj/5n6HzP+2mPuLMBINQhER1McIbs/MywYdD0BmXpSZR2fmKuoTRn0jMwfaCpiZ/wV4PCLeVIpOBR4eYEgNjwEnRcSvlNfyVKo1KVllmfvtq2j+m/sdMP/bjsncHzHmftsxVTH3wfxfMnO/fRXNf3O/A+Z/2zGZ+4uwbNABdMnJwDnAtoh4oJRdnJlbBxhTVf0RcG1EvAx4FPjYgOMhM++JiBuA+6jPnn8/sGmwUQ0Nc39xKpX/5n7HzP/2mfujxdxvX6VyH8z/Dpn7i1Op/Df3O2b+t8/cb1Nk5qBjkCRJkiRJUh+NxJAxSZIkSZIktc8GIUmSJEmSpDFjg5AkSZIkSdKYsUFIkiRJkiRpzNggJEmSJEmSNGZsEJIkSZIkSRozNghJkiRJkiSNGRuEJEmSJEmSxsz/D1Vlq6BPuEXiAAAAAElFTkSuQmCC",
             "text/plain": [
               "<Figure size 1440x288 with 6 Axes>"
             ]
@@ -1500,61 +1494,61 @@
             "needs_background": "light"
           }
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pYAItQoA_G_R"
-      },
-      "source": [
-        "Some are decent, but several of them tend to overestimate the good number of bins. As you have more data points, some of the formulae may overestimate the necessary number of bins. Particularly in our case, because of the precision issue, we shouldn't increase the number of bins too much."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "0jf4KJxB_G_S"
-      },
-      "source": [
-        "### Then, how should we choose the number of bins?"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "2duwuNV5_G_S"
-      },
-      "source": [
-        "So what's the conclusion? use Scott's rule or Sturges' formula? \n",
-        "\n",
-        "No, I think the take-away is that you **should understand how the inappropriate number of bins can mislead you** and you should **try multiple number of bins** to obtain the most accurate picture of the data. Although the 'default' may work in most cases, don't blindly trust it! Don't judge the distribution of a dataset based on a single histogram. Try multiple parameters to get the full picture!"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "jUB_C-vo_G_S"
-      },
-      "source": [
-        "## CDF (Cumulative distribution function)\n",
-        "\n",
-        "Drawing a CDF is easy. Because it's very common data visualization, histogram has an option called `cumulative`. "
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "KuT78TG5_G_T",
-        "outputId": "322ddcca-6288-4666-f841-c5722cce9cda"
-      },
+        "id": "pyK-B5KN_G_R",
+        "outputId": "1cc0db3e-afc2-441d-8676-a1211ed7ee4f"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Some are decent, but several of them tend to overestimate the good number of bins. As you have more data points, some of the formulae may overestimate the necessary number of bins. Particularly in our case, because of the precision issue, we shouldn't increase the number of bins too much."
+      ],
+      "metadata": {
+        "id": "pYAItQoA_G_R"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Then, how should we choose the number of bins?"
+      ],
+      "metadata": {
+        "id": "0jf4KJxB_G_S"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "So what's the conclusion? use Scott's rule or Sturges' formula? \n",
+        "\n",
+        "No, I think the take-away is that you **should understand how the inappropriate number of bins can mislead you** and you should **try multiple number of bins** to obtain the most accurate picture of the data. Although the 'default' may work in most cases, don't blindly trust it! Don't judge the distribution of a dataset based on a single histogram. Try multiple parameters to get the full picture!"
+      ],
+      "metadata": {
+        "id": "2duwuNV5_G_S"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## CDF (Cumulative distribution function)\n",
+        "\n",
+        "Drawing a CDF is easy. Because it's very common data visualization, histogram has an option called `cumulative`. "
+      ],
+      "metadata": {
+        "id": "jUB_C-vo_G_S"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "movies['IMDB_Rating'].hist(cumulative=True)"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1571,7 +1565,7 @@
         {
           "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX0AAAD4CAYAAAAAczaOAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAUoElEQVR4nO3dcayddZ3n8fdHUEGuAzg4Nx3obtlM14g0g3KD7JKYW5mBwkwG3YwbCIvgaGo2MNHdJms1meiMkjBZ0d3JOmY6lhVXxzusQmygI8MydFySRaCIlloNHewypWwZl4peZZ0p+90/zlP3UE577z2995xbf+9XcnLO+T3PeZ7PuWk/57m/85xzU1VIktrwsnEHkCSNjqUvSQ2x9CWpIZa+JDXE0pekhpw47gBHc8YZZ9SqVavGHWOgH//4x5xyyinjjjGQ2YZjtuGYbThLmW379u3fr6rXDlxYVcv2cv7559dydd999407whGZbThmG47ZhrOU2YCH6wi96vSOJDXE0pekhlj6ktQQS1+SGmLpS1JD5iz9JCcleTDJN5PsTPL73fjZSb6e5PEkf57kFd34K7v7u7vlq/q29cFu/LtJLl2qJyVJGmw+R/o/Bd5aVb8KnAesS3Ih8IfAJ6tqNXAAeHe3/ruBA1X1K8Anu/VIcg5wJfAGYB3wx0lOWMwnI0k6ujlLvzvtc7a7+/LuUsBbgS9147cCb+tuX9Hdp1t+cZJ04zNV9dOq+h6wG7hgUZ6FJGleUvP4Pv3uiHw78CvAp4B/DzzQHc2TZCXwF1V1bpLHgHVVtbdb9jfAm4GPdI/5fDe+uXvMlw7b13pgPcDk5OT5MzMzi/E8F93s7CwTExPjjjGQ2YZjtuGYbThLmW3t2rXbq2pq0LJ5fQ1DVb0AnJfkNOAO4PWDVuuuc4RlRxo/fF+bgE0AU1NTNT09PZ+II7dt2zbMtnBmG47ZhrMY2VZtvGtxwhxmw5oXuPn+Hx9x+Z6bfmNJ9rugs3eq6gfANuBC4LQkh140zgL2dbf3AisBuuWnAs/2jw94jCRpBOZz9s5ruyN8kpwM/BqwC7gP+O1utWuBr3S3t3T36Zb/VfddEFuAK7uze84GVgMPLtYTkSTNbT7TOyuAW7t5/ZcBt1XVnUm+Dcwk+RjwDWBzt/5m4L8k2U3vCP9KgKrameQ24NvAQeD6btpIko5q2CmWDWsOct0STc8cr+Ys/ar6FvDGAeNPMODsm6r6P8A7jrCtG4EbFx5TkrQY/ESuJDXE0pekhlj6ktQQS1+SGmLpS1JDLH1JaoilL0kNsfQlqSGWviQ1xNKXpIZY+pLUEEtfkhpi6UtSQyx9SWqIpS9JDbH0Jakhlr4kNcTSl6SGWPqS1BBLX5IaMucfRpekQ1ZtvOslYxvWHOS6AeNanjzSl6SGWPqS1BBLX5IaYulLUkPmLP0kK5Pcl2RXkp1J3teNfyTJU0ke7S6X9z3mg0l2J/lukkv7xtd1Y7uTbFyapyRJOpL5nL1zENhQVY8keTWwPck93bJPVtXH+1dOcg5wJfAG4JeB/5bkn3aLPwX8OrAXeCjJlqr69mI8EUnS3OYs/ap6Gni6u/2jJLuAM4/ykCuAmar6KfC9JLuBC7plu6vqCYAkM926lr4kjciC5vSTrALeCHy9G7ohybeS3JLk9G7sTOBv+x62txs70rgkaURSVfNbMZkA/hq4sapuTzIJfB8o4KPAiqr6nSSfAv5HVX2+e9xmYCu9F5hLq+o93fg1wAVV9buH7Wc9sB5gcnLy/JmZmUV4motvdnaWiYmJcccYyGzDMdvcdjz13EvGJk+G/c+PIcw8HM/Z1px56tDbXrt27faqmhq0bF6fyE3ycuDLwBeq6naAqtrft/xPgTu7u3uBlX0PPwvY190+0vjPVNUmYBPA1NRUTU9PzyfiyG3btg2zLZzZhrNcsg365O2GNQe5ecfy/HD/8Zxtz9XTS7Lf+Zy9E2AzsKuqPtE3vqJvtbcDj3W3twBXJnllkrOB1cCDwEPA6iRnJ3kFvTd7tyzO05Akzcd8XgIvAq4BdiR5tBv7EHBVkvPoTe/sAd4LUFU7k9xG7w3ag8D1VfUCQJIbgLuBE4BbqmrnIj4XSdIc5nP2zv1ABizaepTH3AjcOGB869EeJ0laWn4iV5IaYulLUkMsfUlqiKUvSQ2x9CWpIZa+JDXE0pekhlj6ktQQS1+SGmLpS1JDLH1JaoilL0kNsfQlqSGWviQ1xNKXpIZY+pLUEEtfkhpi6UtSQyx9SWqIpS9JDbH0Jakhlr4kNcTSl6SGWPqS1BBLX5IaYulLUkPmLP0kK5Pcl2RXkp1J3teNvybJPUke765P78aT5I+S7E7yrSRv6tvWtd36jye5dumeliRpkPkc6R8ENlTV64ELgeuTnANsBO6tqtXAvd19gMuA1d1lPfBp6L1IAB8G3gxcAHz40AuFJGk05iz9qnq6qh7pbv8I2AWcCVwB3Nqtdivwtu72FcDnqucB4LQkK4BLgXuq6tmqOgDcA6xb1GcjSTqqVNX8V05WAV8DzgWerKrT+pYdqKrTk9wJ3FRV93fj9wIfAKaBk6rqY9347wHPV9XHD9vHenq/ITA5OXn+zMzM0E9uKc3OzjIxMTHuGAOZbThmm9uOp557ydjkybD/+TGEmYfjOduaM08dettr167dXlVTg5adON+NJJkAvgy8v6p+mOSIqw4Yq6OMv3igahOwCWBqaqqmp6fnG3Gktm3bhtkWzmzDWS7Zrtt410vGNqw5yM075l0lI3U8Z9tz9fSS7HdeZ+8keTm9wv9CVd3eDe/vpm3orp/pxvcCK/sefhaw7yjjkqQRmc/ZOwE2A7uq6hN9i7YAh87AuRb4St/4O7uzeC4Enquqp4G7gUuSnN69gXtJNyZJGpH5/N5zEXANsCPJo93Yh4CbgNuSvBt4EnhHt2wrcDmwG/gJ8C6Aqno2yUeBh7r1/qCqnl2UZyFJmpc5S797Q/ZIE/gXD1i/gOuPsK1bgFsWElDSi60aMK8uzZefyJWkhlj6ktQQS1+SGmLpS1JDLH1JaoilL0kNsfQlqSGWviQ1xNKXpIZY+pLUEEtfkhpi6UtSQyx9SWqIpS9JDbH0Jakhlr4kNcTSl6SGWPqS1BBLX5IaYulLUkMsfUlqiKUvSQ2x9CWpIZa+JDXE0pekhlj6ktSQOUs/yS1JnknyWN/YR5I8leTR7nJ537IPJtmd5LtJLu0bX9eN7U6ycfGfiiRpLvM50v8ssG7A+Cer6rzushUgyTnAlcAbusf8cZITkpwAfAq4DDgHuKpbV5I0QifOtUJVfS3Jqnlu7wpgpqp+CnwvyW7ggm7Z7qp6AiDJTLfutxecWJI0tFTV3Cv1Sv/Oqjq3u/8R4Drgh8DDwIaqOpDkPwEPVNXnu/U2A3/RbWZdVb2nG78GeHNV3TBgX+uB9QCTk5Pnz8zMHMPTWzqzs7NMTEyMO8ZAZhvO8ZJtx1PPjTnNi02eDPufH3eKwY7nbGvOPHXoba9du3Z7VU0NWjbnkf4RfBr4KFDd9c3A7wAZsG4xeBpp4KtNVW0CNgFMTU3V9PT0kBGX1rZt2zDbwpltOP3Zrtt413jDHGbDmoPcvGPYKllax3O2PVdPL8l+h/ppVNX+Q7eT/ClwZ3d3L7Cyb9WzgH3d7SONS5JGZKhTNpOs6Lv7duDQmT1bgCuTvDLJ2cBq4EHgIWB1krOTvILem71bho8tSRrGnEf6Sb4ITANnJNkLfBiYTnIevSmaPcB7AapqZ5Lb6L1BexC4vqpe6LZzA3A3cAJwS1XtXPRnI0k6qvmcvXPVgOHNR1n/RuDGAeNbga0LSidJWlR+IleSGmLpS1JDLH1JaoilL0kNsfQlqSGWviQ1xNKXpIZY+pLUEEtfkhpi6UtSQyx9SWqIpS9JDbH0Jakhlr4kNcTSl6SGWPqS1BBLX5IaYulLUkPm/HOJkgZbtfGuke1rw5qDXDfC/ennl0f6ktQQS1+SGmLpS1JDLH1JaoilL0kNsfQlqSFzln6SW5I8k+SxvrHXJLknyePd9endeJL8UZLdSb6V5E19j7m2W//xJNcuzdORJB3NfI70PwusO2xsI3BvVa0G7u3uA1wGrO4u64FPQ+9FAvgw8GbgAuDDh14oJEmjM2fpV9XXgGcPG74CuLW7fSvwtr7xz1XPA8BpSVYAlwL3VNWzVXUAuIeXvpBIkpZYqmrulZJVwJ1VdW53/wdVdVrf8gNVdXqSO4Gbqur+bvxe4APANHBSVX2sG/894Pmq+viAfa2n91sCk5OT58/MzBzTE1wqs7OzTExMjDvGQGYbzkKz7XjquSVM82KTJ8P+50e2uwUx23DmyrbmzFOH3vbatWu3V9XUoGWL/TUMGTBWRxl/6WDVJmATwNTUVE1PTy9auMW0bds2zLZwP0/ZRvm1CBvWHOTmHcvzW1PMNpy5su25enpJ9jvs2Tv7u2kbuutnuvG9wMq+9c4C9h1lXJI0QsOW/hbg0Bk41wJf6Rt/Z3cWz4XAc1X1NHA3cEmS07s3cC/pxiRJIzTn7z1JvkhvTv6MJHvpnYVzE3BbkncDTwLv6FbfClwO7AZ+ArwLoKqeTfJR4KFuvT+oqsPfHJYkLbE5S7+qrjrCoosHrFvA9UfYzi3ALQtKJ0laVH4iV5IaYulLUkMsfUlqiKUvSQ2x9CWpIZa+JDXE0pekhlj6ktQQS1+SGmLpS1JDLH1JaoilL0kNsfQlqSGWviQ1xNKXpIZY+pLUEEtfkhpi6UtSQyx9SWqIpS9JDbH0Jakhlr4kNcTSl6SGWPqS1BBLX5IaYulLUkNOPJYHJ9kD/Ah4AThYVVNJXgP8ObAK2AP8y6o6kCTAfwQuB34CXFdVjxzL/qVVG+9atG1tWHOQ6xZxe9JytBhH+mur6ryqmurubwTurarVwL3dfYDLgNXdZT3w6UXYtyRpAZZieucK4Nbu9q3A2/rGP1c9DwCnJVmxBPuXJB1Bqmr4ByffAw4ABfxJVW1K8oOqOq1vnQNVdXqSO4Gbqur+bvxe4ANV9fBh21xP7zcBJicnz5+ZmRk631KanZ1lYmJi3DEGainbjqeeW7RtTZ4M+59ftM0tKrMN53jOtubMU4fe9tq1a7f3zb68yDHN6QMXVdW+JL8E3JPkO0dZNwPGXvKKU1WbgE0AU1NTNT09fYwRl8a2bdsw28ItdrbFnIPfsOYgN+841v8SS8Nswzmes+25enpJ9ntM0ztVta+7fga4A7gA2H9o2qa7fqZbfS+wsu/hZwH7jmX/kqSFGbr0k5yS5NWHbgOXAI8BW4Bru9WuBb7S3d4CvDM9FwLPVdXTQyeXJC3YsfzeMwnc0TsTkxOBP6uqryZ5CLgtybuBJ4F3dOtvpXe65m56p2y+6xj2LUkawtClX1VPAL86YPx/AxcPGC/g+mH3J0k6dn4iV5IaYulLUkMsfUlqiKUvSQ2x9CWpIZa+JDXE0pekhlj6ktQQS1+SGmLpS1JDLH1Jasjy/KJpHXfm+7dq/Tu00nh5pC9JDbH0Jakhlr4kNcTSl6SGWPqS1BBLX5IaYulLUkMsfUlqiB/O+jmzauNdfgBK0hF5pC9JDbH0Jakhlr4kNcTSl6SG+EbuEpjvN05K0qiN/Eg/ybok302yO8nGUe9fklo20tJPcgLwKeAy4BzgqiTnjDKDJLVs1NM7FwC7q+oJgCQzwBXAt5diZ0s5zeK58JKOR6mq0e0s+W1gXVW9p7t/DfDmqrqhb531wPru7uuA744s4MKcAXx/3CGOwGzDMdtwzDacpcz2j6vqtYMWjPpIPwPGXvSqU1WbgE2jiTO8JA9X1dS4cwxituGYbThmG864so36jdy9wMq++2cB+0acQZKaNerSfwhYneTsJK8ArgS2jDiDJDVrpNM7VXUwyQ3A3cAJwC1VtXOUGRbRcp6CMttwzDYcsw1nLNlG+kauJGm8/BoGSWqIpS9JDbH0FyjJyiT3JdmVZGeS94070yFJTkryYJJvdtl+f9yZ+iU5Ick3ktw57iyHS7InyY4kjyZ5eNx5+iU5LcmXknyn+3f3z8adCSDJ67qf16HLD5O8f9y5Dknyb7r/B48l+WKSk8ad6ZAk7+ty7Rz1z8w5/QVKsgJYUVWPJHk1sB14W1UtyaeKFyJJgFOqajbJy4H7gfdV1QNjjgZAkn8LTAG/UFW/Oe48/ZLsAaaqatl9kCfJrcB/r6rPdGe9vaqqfjDuXP26r1h5it6HLf/nMshzJr1//+dU1fNJbgO2VtVnx5sMkpwLzND7hoK/B74K/OuqenwU+/dIf4Gq6umqeqS7/SNgF3DmeFP1VM9sd/fl3WVZvKonOQv4DeAz485yPEnyC8BbgM0AVfX3y63wOxcDf7McCr/PicDJSU4EXsXy+UzQ64EHquonVXUQ+Gvg7aPauaV/DJKsAt4IfH28Sf6/bgrlUeAZ4J6qWi7Z/gPw74D/O+4gR1DAXybZ3n0VyHLxT4C/A/5zNzX2mSSnjDvUAFcCXxx3iEOq6ing48CTwNPAc1X1l+NN9TOPAW9J8otJXgVczos/tLqkLP0hJZkAvgy8v6p+OO48h1TVC1V1Hr1PO1/Q/So5Vkl+E3imqraPO8tRXFRVb6L3DbDXJ3nLuAN1TgTeBHy6qt4I/BhYVl9J3k05/RbwX8ed5ZAkp9P7MsezgV8GTknyr8abqqeqdgF/CNxDb2rnm8DBUe3f0h9CN1/+ZeALVXX7uPMM0k0BbAPWjTkKwEXAb3Xz5jPAW5N8fryRXqyq9nXXzwB30JtvXQ72Anv7fmP7Er0XgeXkMuCRqto/7iB9fg34XlX9XVX9A3A78M/HnOlnqmpzVb2pqt4CPAuMZD4fLP0F694s3QzsqqpPjDtPvySvTXJad/tkev/wvzPeVFBVH6yqs6pqFb1pgL+qqmVx1AWQ5JTuTXm6qZNL6P0KPnZV9b+Av03yum7oYpboq8iPwVUso6mdzpPAhUle1f2fvZje+2/LQpJf6q7/EfAvGOHPzz+XuHAXAdcAO7q5c4APVdXWMWY6ZAVwa3cmxcuA26pq2Z0euQxNAnf0uoETgT+rqq+ON9KL/C7whW4a5QngXWPO8zPdnPSvA+8dd5Z+VfX1JF8CHqE3dfINltdXMnw5yS8C/wBcX1UHRrVjT9mUpIY4vSNJDbH0Jakhlr4kNcTSl6SGWPqS1BBLX5IaYulLUkP+H2K0VZCMvxYHAAAAAElFTkSuQmCC\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX0AAAD4CAYAAAAAczaOAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAUoElEQVR4nO3dcayddZ3n8fdHUEGuAzg4Nx3obtlM14g0g3KD7JKYW5mBwkwG3YwbCIvgaGo2MNHdJms1meiMkjBZ0d3JOmY6lhVXxzusQmygI8MydFySRaCIlloNHewypWwZl4peZZ0p+90/zlP3UE577z2995xbf+9XcnLO+T3PeZ7PuWk/57m/85xzU1VIktrwsnEHkCSNjqUvSQ2x9CWpIZa+JDXE0pekhpw47gBHc8YZZ9SqVavGHWOgH//4x5xyyinjjjGQ2YZjtuGYbThLmW379u3fr6rXDlxYVcv2cv7559dydd999407whGZbThmG47ZhrOU2YCH6wi96vSOJDXE0pekhlj6ktQQS1+SGmLpS1JD5iz9JCcleTDJN5PsTPL73fjZSb6e5PEkf57kFd34K7v7u7vlq/q29cFu/LtJLl2qJyVJGmw+R/o/Bd5aVb8KnAesS3Ih8IfAJ6tqNXAAeHe3/ruBA1X1K8Anu/VIcg5wJfAGYB3wx0lOWMwnI0k6ujlLvzvtc7a7+/LuUsBbgS9147cCb+tuX9Hdp1t+cZJ04zNV9dOq+h6wG7hgUZ6FJGleUvP4Pv3uiHw78CvAp4B/DzzQHc2TZCXwF1V1bpLHgHVVtbdb9jfAm4GPdI/5fDe+uXvMlw7b13pgPcDk5OT5MzMzi/E8F93s7CwTExPjjjGQ2YZjtuGYbThLmW3t2rXbq2pq0LJ5fQ1DVb0AnJfkNOAO4PWDVuuuc4RlRxo/fF+bgE0AU1NTNT09PZ+II7dt2zbMtnBmG47ZhrMY2VZtvGtxwhxmw5oXuPn+Hx9x+Z6bfmNJ9rugs3eq6gfANuBC4LQkh140zgL2dbf3AisBuuWnAs/2jw94jCRpBOZz9s5ruyN8kpwM/BqwC7gP+O1utWuBr3S3t3T36Zb/VfddEFuAK7uze84GVgMPLtYTkSTNbT7TOyuAW7t5/ZcBt1XVnUm+Dcwk+RjwDWBzt/5m4L8k2U3vCP9KgKrameQ24NvAQeD6btpIko5q2CmWDWsOct0STc8cr+Ys/ar6FvDGAeNPMODsm6r6P8A7jrCtG4EbFx5TkrQY/ESuJDXE0pekhlj6ktQQS1+SGmLpS1JDLH1JaoilL0kNsfQlqSGWviQ1xNKXpIZY+pLUEEtfkhpi6UtSQyx9SWqIpS9JDbH0Jakhlr4kNcTSl6SGWPqS1BBLX5IaMucfRpekQ1ZtvOslYxvWHOS6AeNanjzSl6SGWPqS1BBLX5IaYulLUkPmLP0kK5Pcl2RXkp1J3teNfyTJU0ke7S6X9z3mg0l2J/lukkv7xtd1Y7uTbFyapyRJOpL5nL1zENhQVY8keTWwPck93bJPVtXH+1dOcg5wJfAG4JeB/5bkn3aLPwX8OrAXeCjJlqr69mI8EUnS3OYs/ap6Gni6u/2jJLuAM4/ykCuAmar6KfC9JLuBC7plu6vqCYAkM926lr4kjciC5vSTrALeCHy9G7ohybeS3JLk9G7sTOBv+x62txs70rgkaURSVfNbMZkA/hq4sapuTzIJfB8o4KPAiqr6nSSfAv5HVX2+e9xmYCu9F5hLq+o93fg1wAVV9buH7Wc9sB5gcnLy/JmZmUV4motvdnaWiYmJcccYyGzDMdvcdjz13EvGJk+G/c+PIcw8HM/Z1px56tDbXrt27faqmhq0bF6fyE3ycuDLwBeq6naAqtrft/xPgTu7u3uBlX0PPwvY190+0vjPVNUmYBPA1NRUTU9PzyfiyG3btg2zLZzZhrNcsg365O2GNQe5ecfy/HD/8Zxtz9XTS7Lf+Zy9E2AzsKuqPtE3vqJvtbcDj3W3twBXJnllkrOB1cCDwEPA6iRnJ3kFvTd7tyzO05Akzcd8XgIvAq4BdiR5tBv7EHBVkvPoTe/sAd4LUFU7k9xG7w3ag8D1VfUCQJIbgLuBE4BbqmrnIj4XSdIc5nP2zv1ABizaepTH3AjcOGB869EeJ0laWn4iV5IaYulLUkMsfUlqiKUvSQ2x9CWpIZa+JDXE0pekhlj6ktQQS1+SGmLpS1JDLH1JaoilL0kNsfQlqSGWviQ1xNKXpIZY+pLUEEtfkhpi6UtSQyx9SWqIpS9JDbH0Jakhlr4kNcTSl6SGWPqS1BBLX5IaYulLUkPmLP0kK5Pcl2RXkp1J3teNvybJPUke765P78aT5I+S7E7yrSRv6tvWtd36jye5dumeliRpkPkc6R8ENlTV64ELgeuTnANsBO6tqtXAvd19gMuA1d1lPfBp6L1IAB8G3gxcAHz40AuFJGk05iz9qnq6qh7pbv8I2AWcCVwB3Nqtdivwtu72FcDnqucB4LQkK4BLgXuq6tmqOgDcA6xb1GcjSTqqVNX8V05WAV8DzgWerKrT+pYdqKrTk9wJ3FRV93fj9wIfAKaBk6rqY9347wHPV9XHD9vHenq/ITA5OXn+zMzM0E9uKc3OzjIxMTHuGAOZbThmm9uOp557ydjkybD/+TGEmYfjOduaM08dettr167dXlVTg5adON+NJJkAvgy8v6p+mOSIqw4Yq6OMv3igahOwCWBqaqqmp6fnG3Gktm3bhtkWzmzDWS7Zrtt410vGNqw5yM075l0lI3U8Z9tz9fSS7HdeZ+8keTm9wv9CVd3eDe/vpm3orp/pxvcCK/sefhaw7yjjkqQRmc/ZOwE2A7uq6hN9i7YAh87AuRb4St/4O7uzeC4Enquqp4G7gUuSnN69gXtJNyZJGpH5/N5zEXANsCPJo93Yh4CbgNuSvBt4EnhHt2wrcDmwG/gJ8C6Aqno2yUeBh7r1/qCqnl2UZyFJmpc5S797Q/ZIE/gXD1i/gOuPsK1bgFsWElDSi60aMK8uzZefyJWkhlj6ktQQS1+SGmLpS1JDLH1JaoilL0kNsfQlqSGWviQ1xNKXpIZY+pLUEEtfkhpi6UtSQyx9SWqIpS9JDbH0Jakhlr4kNcTSl6SGWPqS1BBLX5IaYulLUkMsfUlqiKUvSQ2x9CWpIZa+JDXE0pekhlj6ktSQOUs/yS1JnknyWN/YR5I8leTR7nJ537IPJtmd5LtJLu0bX9eN7U6ycfGfiiRpLvM50v8ssG7A+Cer6rzushUgyTnAlcAbusf8cZITkpwAfAq4DDgHuKpbV5I0QifOtUJVfS3Jqnlu7wpgpqp+CnwvyW7ggm7Z7qp6AiDJTLfutxecWJI0tFTV3Cv1Sv/Oqjq3u/8R4Drgh8DDwIaqOpDkPwEPVNXnu/U2A3/RbWZdVb2nG78GeHNV3TBgX+uB9QCTk5Pnz8zMHMPTWzqzs7NMTEyMO8ZAZhvO8ZJtx1PPjTnNi02eDPufH3eKwY7nbGvOPHXoba9du3Z7VU0NWjbnkf4RfBr4KFDd9c3A7wAZsG4xeBpp4KtNVW0CNgFMTU3V9PT0kBGX1rZt2zDbwpltOP3Zrtt413jDHGbDmoPcvGPYKllax3O2PVdPL8l+h/ppVNX+Q7eT/ClwZ3d3L7Cyb9WzgH3d7SONS5JGZKhTNpOs6Lv7duDQmT1bgCuTvDLJ2cBq4EHgIWB1krOTvILem71bho8tSRrGnEf6Sb4ITANnJNkLfBiYTnIevSmaPcB7AapqZ5Lb6L1BexC4vqpe6LZzA3A3cAJwS1XtXPRnI0k6qvmcvXPVgOHNR1n/RuDGAeNbga0LSidJWlR+IleSGmLpS1JDLH1JaoilL0kNsfQlqSGWviQ1xNKXpIZY+pLUEEtfkhpi6UtSQyx9SWqIpS9JDbH0Jakhlr4kNcTSl6SGWPqS1BBLX5IaYulLUkPm/HOJkgZbtfGuke1rw5qDXDfC/ennl0f6ktQQS1+SGmLpS1JDLH1JaoilL0kNsfQlqSFzln6SW5I8k+SxvrHXJLknyePd9endeJL8UZLdSb6V5E19j7m2W//xJNcuzdORJB3NfI70PwusO2xsI3BvVa0G7u3uA1wGrO4u64FPQ+9FAvgw8GbgAuDDh14oJEmjM2fpV9XXgGcPG74CuLW7fSvwtr7xz1XPA8BpSVYAlwL3VNWzVXUAuIeXvpBIkpZYqmrulZJVwJ1VdW53/wdVdVrf8gNVdXqSO4Gbqur+bvxe4APANHBSVX2sG/894Pmq+viAfa2n91sCk5OT58/MzBzTE1wqs7OzTExMjDvGQGYbzkKz7XjquSVM82KTJ8P+50e2uwUx23DmyrbmzFOH3vbatWu3V9XUoGWL/TUMGTBWRxl/6WDVJmATwNTUVE1PTy9auMW0bds2zLZwP0/ZRvm1CBvWHOTmHcvzW1PMNpy5su25enpJ9jvs2Tv7u2kbuutnuvG9wMq+9c4C9h1lXJI0QsOW/hbg0Bk41wJf6Rt/Z3cWz4XAc1X1NHA3cEmS07s3cC/pxiRJIzTn7z1JvkhvTv6MJHvpnYVzE3BbkncDTwLv6FbfClwO7AZ+ArwLoKqeTfJR4KFuvT+oqsPfHJYkLbE5S7+qrjrCoosHrFvA9UfYzi3ALQtKJ0laVH4iV5IaYulLUkMsfUlqiKUvSQ2x9CWpIZa+JDXE0pekhlj6ktQQS1+SGmLpS1JDLH1JaoilL0kNsfQlqSGWviQ1xNKXpIZY+pLUEEtfkhpi6UtSQyx9SWqIpS9JDbH0Jakhlr4kNcTSl6SGWPqS1BBLX5IaYulLUkNOPJYHJ9kD/Ah4AThYVVNJXgP8ObAK2AP8y6o6kCTAfwQuB34CXFdVjxzL/qVVG+9atG1tWHOQ6xZxe9JytBhH+mur6ryqmurubwTurarVwL3dfYDLgNXdZT3w6UXYtyRpAZZieucK4Nbu9q3A2/rGP1c9DwCnJVmxBPuXJB1Bqmr4ByffAw4ABfxJVW1K8oOqOq1vnQNVdXqSO4Gbqur+bvxe4ANV9fBh21xP7zcBJicnz5+ZmRk631KanZ1lYmJi3DEGainbjqeeW7RtTZ4M+59ftM0tKrMN53jOtubMU4fe9tq1a7f3zb68yDHN6QMXVdW+JL8E3JPkO0dZNwPGXvKKU1WbgE0AU1NTNT09fYwRl8a2bdsw28ItdrbFnIPfsOYgN+841v8SS8Nswzmes+25enpJ9ntM0ztVta+7fga4A7gA2H9o2qa7fqZbfS+wsu/hZwH7jmX/kqSFGbr0k5yS5NWHbgOXAI8BW4Bru9WuBb7S3d4CvDM9FwLPVdXTQyeXJC3YsfzeMwnc0TsTkxOBP6uqryZ5CLgtybuBJ4F3dOtvpXe65m56p2y+6xj2LUkawtClX1VPAL86YPx/AxcPGC/g+mH3J0k6dn4iV5IaYulLUkMsfUlqiKUvSQ2x9CWpIZa+JDXE0pekhlj6ktQQS1+SGmLpS1JDLH1Jasjy/KJpHXfm+7dq/Tu00nh5pC9JDbH0Jakhlr4kNcTSl6SGWPqS1BBLX5IaYulLUkMsfUlqiB/O+jmzauNdfgBK0hF5pC9JDbH0Jakhlr4kNcTSl6SG+EbuEpjvN05K0qiN/Eg/ybok302yO8nGUe9fklo20tJPcgLwKeAy4BzgqiTnjDKDJLVs1NM7FwC7q+oJgCQzwBXAt5diZ0s5zeK58JKOR6mq0e0s+W1gXVW9p7t/DfDmqrqhb531wPru7uuA744s4MKcAXx/3CGOwGzDMdtwzDacpcz2j6vqtYMWjPpIPwPGXvSqU1WbgE2jiTO8JA9X1dS4cwxituGYbThmG864so36jdy9wMq++2cB+0acQZKaNerSfwhYneTsJK8ArgS2jDiDJDVrpNM7VXUwyQ3A3cAJwC1VtXOUGRbRcp6CMttwzDYcsw1nLNlG+kauJGm8/BoGSWqIpS9JDbH0FyjJyiT3JdmVZGeS94070yFJTkryYJJvdtl+f9yZ+iU5Ick3ktw57iyHS7InyY4kjyZ5eNx5+iU5LcmXknyn+3f3z8adCSDJ67qf16HLD5O8f9y5Dknyb7r/B48l+WKSk8ad6ZAk7+ty7Rz1z8w5/QVKsgJYUVWPJHk1sB14W1UtyaeKFyJJgFOqajbJy4H7gfdV1QNjjgZAkn8LTAG/UFW/Oe48/ZLsAaaqatl9kCfJrcB/r6rPdGe9vaqqfjDuXP26r1h5it6HLf/nMshzJr1//+dU1fNJbgO2VtVnx5sMkpwLzND7hoK/B74K/OuqenwU+/dIf4Gq6umqeqS7/SNgF3DmeFP1VM9sd/fl3WVZvKonOQv4DeAz485yPEnyC8BbgM0AVfX3y63wOxcDf7McCr/PicDJSU4EXsXy+UzQ64EHquonVXUQ+Gvg7aPauaV/DJKsAt4IfH28Sf6/bgrlUeAZ4J6qWi7Z/gPw74D/O+4gR1DAXybZ3n0VyHLxT4C/A/5zNzX2mSSnjDvUAFcCXxx3iEOq6ing48CTwNPAc1X1l+NN9TOPAW9J8otJXgVczos/tLqkLP0hJZkAvgy8v6p+OO48h1TVC1V1Hr1PO1/Q/So5Vkl+E3imqraPO8tRXFRVb6L3DbDXJ3nLuAN1TgTeBHy6qt4I/BhYVl9J3k05/RbwX8ed5ZAkp9P7MsezgV8GTknyr8abqqeqdgF/CNxDb2rnm8DBUe3f0h9CN1/+ZeALVXX7uPMM0k0BbAPWjTkKwEXAb3Xz5jPAW5N8fryRXqyq9nXXzwB30JtvXQ72Anv7fmP7Er0XgeXkMuCRqto/7iB9fg34XlX9XVX9A3A78M/HnOlnqmpzVb2pqt4CPAuMZD4fLP0F694s3QzsqqpPjDtPvySvTXJad/tkev/wvzPeVFBVH6yqs6pqFb1pgL+qqmVx1AWQ5JTuTXm6qZNL6P0KPnZV9b+Av03yum7oYpboq8iPwVUso6mdzpPAhUle1f2fvZje+2/LQpJf6q7/EfAvGOHPzz+XuHAXAdcAO7q5c4APVdXWMWY6ZAVwa3cmxcuA26pq2Z0euQxNAnf0uoETgT+rqq+ON9KL/C7whW4a5QngXWPO8zPdnPSvA+8dd5Z+VfX1JF8CHqE3dfINltdXMnw5yS8C/wBcX1UHRrVjT9mUpIY4vSNJDbH0Jakhlr4kNcTSl6SGWPqS1BBLX5IaYulLUkP+H2K0VZCMvxYHAAAAAElFTkSuQmCC",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
@@ -1581,30 +1575,30 @@
             "needs_background": "light"
           }
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "S1ucXKzI_G_T"
-      },
-      "source": [
-        "You can also combine with options such as `histtype` and `density`."
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "FGB1nZqz_G_T",
-        "outputId": "8a4624f2-2645-4241-eeed-fb27d627b64d"
-      },
+        "id": "KuT78TG5_G_T",
+        "outputId": "322ddcca-6288-4666-f841-c5722cce9cda"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "You can also combine with options such as `histtype` and `density`."
+      ],
+      "metadata": {
+        "id": "S1ucXKzI_G_T"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "movies['IMDB_Rating'].hist(histtype='step', cumulative=True, density=True)"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1621,7 +1615,7 @@
         {
           "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD4CAYAAAD8Zh1EAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAARaElEQVR4nO3df5DcdX3H8eebRDTkkDhGrzRBQqfomCGdwqWgTYdyBdsgDvQHWChmiiOm0zH+KLQltA5taf9Ibae/lGodpGqr3CBqJxMyRofctdoplgRUSJBpSiPmUPEHiR6mxei7f+z3yHLs3m42e/fd+/B8zOxkv/v93Pf7yt7d67772f3uRmYiSVr4Tqg7gCSpPyx0SSqEhS5JhbDQJakQFrokFWJxXTtevnx5rlq1qq7dz+rJJ59k6dKldcdoyWy9MVtvzNabucy2e/fub2XmS1quzMxaLiMjIzmoxsfH647Qltl6Y7bemK03c5kN2JVtetUpF0kqhIUuSYWw0CWpEBa6JBXCQpekQljoklSIjoUeEbdFxOMR8WCb9RERfxcR+yLiSxFxTv9jSpI66eYI/YPA+lnWXwycWV02Au89/liSpGPVsdAz89+A78wy5DLgw9Vr3u8BlkXEqf0KKEnqTmQXH3AREauAbZl5Vot124Atmfm5avlu4IbM3NVi7EYaR/EMDw+PjI2NHVf4uTI1NcXQ0FDdMVoyW2/M1puSsz389e/x1A9/1MdERw0vgW8cbr/+xEUn8IofO7mnbY+Oju7OzLUtV7Y7hbT5AqwCHmyz7i7g55qW7wZGOm3TU/97Y7bemK03JWc7/YZt/QnSQqdsx7Nv5vjU/wPAaU3LK4HH+rBdSdIx6Me7LW4FNkXEGHAecCgzv9aH7Up6Dli3ZSeTB2eZn2jj+jVHuGbzXT3vd8WyJT1/7aDqWOgRcTtwAbA8Ig4AfwQ8DyAz3wdsB14L7AO+D7xxrsJKKs/kwcPs33LJMX/dxMQE+6++oP+BFrCOhZ6ZV3VYn8Bb+pZIktQTzxSVpEJY6JJUCAtdkgphoUtSISx0SSqEhS5JhbDQJakQFrokFcJCl6RCWOiSVAgLXZIKYaFLUiEsdEkqhIUuSYWw0CWpEBa6JBXCQpekQljoklQIC12SCtHxM0UllW/dlp1MHjz8rNuvX3OEazbfNaf7XrFsyZxu/7nEQpfE5MHD7N9yybNun5iYYP/VF8x/IPXEKRdJKoSFLkmFsNAlqRAWuiQVwkKXpEJY6JJUCAtdkgphoUtSISx0SSqEhS5JhbDQJakQXRV6RKyPiIcjYl9EbG6x/mURMR4R90fElyLitf2PKkmaTcdCj4hFwC3AxcBq4KqIWD1j2DuBOzLzbOBK4O/7HVSSNLtujtDPBfZl5iOZ+RQwBlw2Y0wCL6yunwI81r+IkqRuRGbOPiDicmB9Zl5bLW8AzsvMTU1jTgU+DbwIWApclJm7W2xrI7ARYHh4eGRsbKxf/4++mpqaYmhoqO4YLZmtN2ab3QOTh1iz4pRn3T4I2dpZyNna3d/dGB0d3Z2Za1uuzMxZL8AVwK1NyxuAd88Ycx1wfXX91cBe4ITZtjsyMpKDanx8vO4IbZmtN2ab3ek3bGt5+yBka2chZ2t3f3cD2JVterWbKZcDwGlNyyt59pTKm4A7qj8Q/wG8AFjexbYlSX3STaHfC5wZEWdExIk0nvTcOmPMo8CFABHxShqF/s1+BpUkza5joWfmEWATsAN4iMarWfZExM0RcWk17HrgzRHxReB24JrqoYEkaZ509Zmimbkd2D7jtpuaru8F1vU3miTpWHimqCQVwkKXpEJY6JJUCAtdkgphoUtSISx0SSqEhS5JhbDQJakQFrokFcJCl6RCWOiSVAgLXZIKYaFLUiEsdEkqhIUuSYWw0CWpEBa6JBXCQpekQljoklQIC12SCmGhS1IhLHRJKoSFLkmFsNAlqRAWuiQVwkKXpEIsrjuApKPWbdnJ5MHD877fFcuWzPs+1X8WujRAJg8eZv+WS+qOoQXKKRdJKoSFLkmFsNAlqRAWuiQVoqtCj4j1EfFwROyLiM1txrw+IvZGxJ6I+Gh/Y0qSOun4KpeIWATcArwGOADcGxFbM3Nv05gzgRuBdZn5RES8dK4CS5Ja6+YI/VxgX2Y+kplPAWPAZTPGvBm4JTOfAMjMx/sbU5LUSTeFvgL4atPygeq2Zi8HXh4R/x4R90TE+n4FlCR1JzJz9gERVwC/lJnXVssbgHMz861NY7YBPwBeD6wEPguclZkHZ2xrI7ARYHh4eGRsbKyP/5X+mZqaYmhoqO4YLZmtNwsl2wOTh1iz4pSaEx21UO63QdMp2/F8n0dHR3dn5tqWKzNz1gvwamBH0/KNwI0zxrwPuKZp+W7gZ2bb7sjISA6q8fHxuiO0ZbbeLJRsp9+wrb4gLSyU+23QdMp2PN9nYFe26dVuplzuBc6MiDMi4kTgSmDrjDH/AowCRMRyGlMwjxzLXx1J0vHpWOiZeQTYBOwAHgLuyMw9EXFzRFxaDdsBfDsi9gLjwO9l5rfnKrQk6dm6enOuzNwObJ9x201N1xO4rrpIkmrgmaKSVAgLXZIKYaFLUiEsdEkqhIUuSYWw0CWpEBa6JBXCQpekQljoklQIC12SCmGhS1IhLHRJKoSFLkmFsNAlqRAWuiQVwkKXpEJY6JJUCAtdkgphoUtSISx0SSqEhS5JhbDQJakQFrokFcJCl6RCWOiSVAgLXZIKYaFLUiEsdEkqhIUuSYWw0CWpEBa6JBXCQpekQljoklSIrgo9ItZHxMMRsS8iNs8y7vKIyIhY27+IkqRudCz0iFgE3AJcDKwGroqI1S3GnQy8Dfh8v0NKkjrr5gj9XGBfZj6SmU8BY8BlLcb9KfAu4H/7mE+S1KXIzNkHRFwOrM/Ma6vlDcB5mbmpaczZwDsz89ciYgL43czc1WJbG4GNAMPDwyNjY2N9+4/009TUFENDQ3XHaMlsvVko2R6YPMSaFafUnOiohXK/DZpO2Y7n+zw6Oro7M1tPa2fmrBfgCuDWpuUNwLublk8AJoBV1fIEsLbTdkdGRnJQjY+P1x2hLbP1ZqFkO/2GbfUFaWGh3G+DplO24/k+A7uyTa92M+VyADitaXkl8FjT8snAWcBEROwHXgVs9YlRSZpfi7sYcy9wZkScAUwCVwK/Mb0yMw8By6eXZ5tykRaCdVt2Mnnw8Lzt7/o1R7hm810ArFi2ZN72q/J0LPTMPBIRm4AdwCLgtszcExE30zj03zrXIaX5NHnwMPu3XDJv+5uYmGD/1RfM2/5Urm6O0MnM7cD2Gbfd1GbsBccfS5J0rDxTVJIKYaFLUiEsdEkqhIUuSYWw0CWpEBa6JBXCQpekQljoklQIC12SCmGhS1IhLHRJKoSFLkmFsNAlqRAWuiQVwkKXpEJY6JJUCAtdkgphoUtSISx0SSqEhS5JhbDQJakQFrokFcJCl6RCWOiSVAgLXZIKYaFLUiEsdEkqhIUuSYWw0CWpEBa6JBXCQpekQljoklSIrgo9ItZHxMMRsS8iNrdYf11E7I2IL0XE3RFxev+jSpJm07HQI2IRcAtwMbAauCoiVs8Ydj+wNjN/CrgTeFe/g0qSZtfNEfq5wL7MfCQznwLGgMuaB2TmeGZ+v1q8B1jZ35iSpE4iM2cfEHE5sD4zr62WNwDnZeamNuPfA3w9M/+sxbqNwEaA4eHhkbGxseOMPzempqYYGhqqO0ZLZuvNsWR7YPIQa1acMseJjirlfptvCznb8fyMjY6O7s7MtS1XZuasF+AK4Nam5Q3Au9uMfQONI/Tnd9ruyMhIDqrx8fG6I7Rltt4cS7bTb9g2d0FaKOV+m28LOdvx/IwBu7JNry7u4g/CAeC0puWVwGMzB0XERcAfAj+fmf/X7V8bSVJ/dDOHfi9wZkScEREnAlcCW5sHRMTZwD8Al2bm4/2PKUnqpOMRemYeiYhNwA5gEXBbZu6JiJtpHPpvBf4CGAI+FhEAj2bmpXOYW88B67bsZPLg4b5s6/o1R7hm811djV2xbElf9inNt26mXMjM7cD2Gbfd1HT9oj7nkpg8eJj9Wy7py7YmJibYf/UFfdmWNKg8U1SSCmGhS1IhLHRJKoSFLkmFsNAlqRAWuiQVwkKXpEJY6JJUCAtdkgphoUtSISx0SSqEhS5JhbDQJakQFrokFcJCl6RCWOiSVAgLXZIKYaFLUiG6+gg6Pbd1+9mex/K5nd3wsz2lY2Ohq6NuP9vTz+2U6uWUiyQVwkKXpEJY6JJUCAtdkgphoUtSISx0SSqEhS5JhfB16AvE9Mk9/T55pxue4CMtDBb6AjF9co8n70hqxykXSSqEhS5JhbDQJakQzqEfo27febDffGJSUiddFXpErAf+FlgE3JqZW2asfz7wYWAE+Dbw65m5v79RB0O37zwoSfOt45RLRCwCbgEuBlYDV0XE6hnD3gQ8kZk/Cfw18Of9DipJml03R+jnAvsy8xGAiBgDLgP2No25DPjj6vqdwHsiIjIz+5j1aXM97THba72d+pA0qLop9BXAV5uWDwDntRuTmUci4hDwYuBbzYMiYiOwsVqcioiHewk9194Gy5mRfdpXgLhxfvPM0DbbADBbb8zWmwWdLXqfxzi93YpuCj1a3DbzyLubMWTm+4H3d7HPWkXErsxcW3eOVszWG7P1xmy9qStbNy9bPACc1rS8Enis3ZiIWAycAnynHwElSd3pptDvBc6MiDMi4kTgSmDrjDFbgd+srl8O7Jyr+XNJUmsdp1yqOfFNwA4aL1u8LTP3RMTNwK7M3Ap8APiniNhH48j8yrkMPQ8GeVrIbL0xW2/M1ptasoUH0pJUBk/9l6RCWOiSVAgLvRIRp0XEeEQ8FBF7IuLtdWeaFhEviIj/jIgvVtn+pO5MM0XEooi4PyK21Z2lWUTsj4gHIuILEbGr7jzNImJZRNwZEV+ufu5eXXcmgIh4RXV/TV++GxHvqDvXtIj4ner34MGIuD0iXlB3pmkR8fYq15467jPn0CsRcSpwambeFxEnA7uBX87MvR2+dM5FRABLM3MqIp4HfA54e2beU3O0p0XEdcBa4IWZ+bq680yLiP3A2swcuBNQIuJDwGcz89bqFWQnZebBunM1q976YxI4LzO/MgB5VtD4+V+dmYcj4g5ge2Z+sN5kEBFnAWM0zq5/CvgU8NuZ+V/zlcEj9Epmfi0z76uufw94iMYZsLXLhqlq8XnVZWD+EkfESuAS4Na6sywUEfFC4HwarxAjM58atDKvXAj89yCUeZPFwJLqnJeTePZ5MXV5JXBPZn4/M48A/wr8ynwGsNBbiIhVwNnA5+tNclQ1pfEF4HHgM5k5MNmAvwF+H/hR3UFaSODTEbG7euuJQfETwDeBf6ymqm6NiKV1h2rhSuD2ukNMy8xJ4C+BR4GvAYcy89P1pnrag8D5EfHiiDgJeC3PPClzzlnoM0TEEPBx4B2Z+d2680zLzB9m5k/TOFP33OrhXe0i4nXA45m5u+4sbazLzHNovFvoWyLi/LoDVRYD5wDvzcyzgSeBzfVGeqZqGuhS4GN1Z5kWES+i8WaAZwA/DiyNiDfUm6ohMx+i8U6zn6Ex3fJF4Mh8ZrDQm1Tz0x8HPpKZn6g7TyvVw/IJYH3NUaatAy6t5qrHgF+IiH+uN9JRmflY9e/jwCdpzG8OggPAgaZHWnfSKPhBcjFwX2Z+o+4gTS4C/iczv5mZPwA+AfxszZmelpkfyMxzMvN8GidZztv8OVjoT6ueePwA8FBm/lXdeZpFxEsiYll1fQmNH+ov15uqITNvzMyVmbmKxsPznZk5EEdMEbG0eoKbajrjF2k8LK5dZn4d+GpEvKK66UKe+ZbUg+AqBmi6pfIo8KqIOKn6nb2QxvNdAyEiXlr9+zLgV5nn+8+PoDtqHbABeKCaqwb4g8zcXmOmaacCH6pecXACcEdmDtTLAwfUMPDJxu89i4GPZuan6o30DG8FPlJNbTwCvLHmPE+r5oBfA/xW3VmaZebnI+JO4D4a0xn3M1hvAfDxiHgx8APgLZn5xHzu3JctSlIhnHKRpEJY6JJUCAtdkgphoUtSISx0SSqEhS5JhbDQJakQ/w9Rh+f+aYjUUQAAAABJRU5ErkJggg==\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD4CAYAAAD8Zh1EAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAARaElEQVR4nO3df5DcdX3H8eebRDTkkDhGrzRBQqfomCGdwqWgTYdyBdsgDvQHWChmiiOm0zH+KLQltA5taf9Ibae/lGodpGqr3CBqJxMyRofctdoplgRUSJBpSiPmUPEHiR6mxei7f+z3yHLs3m42e/fd+/B8zOxkv/v93Pf7yt7d67772f3uRmYiSVr4Tqg7gCSpPyx0SSqEhS5JhbDQJakQFrokFWJxXTtevnx5rlq1qq7dz+rJJ59k6dKldcdoyWy9MVtvzNabucy2e/fub2XmS1quzMxaLiMjIzmoxsfH647Qltl6Y7bemK03c5kN2JVtetUpF0kqhIUuSYWw0CWpEBa6JBXCQpekQljoklSIjoUeEbdFxOMR8WCb9RERfxcR+yLiSxFxTv9jSpI66eYI/YPA+lnWXwycWV02Au89/liSpGPVsdAz89+A78wy5DLgw9Vr3u8BlkXEqf0KKEnqTmQXH3AREauAbZl5Vot124Atmfm5avlu4IbM3NVi7EYaR/EMDw+PjI2NHVf4uTI1NcXQ0FDdMVoyW2/M1puSsz389e/x1A9/1MdERw0vgW8cbr/+xEUn8IofO7mnbY+Oju7OzLUtV7Y7hbT5AqwCHmyz7i7g55qW7wZGOm3TU/97Y7bemK03JWc7/YZt/QnSQqdsx7Nv5vjU/wPAaU3LK4HH+rBdSdIx6Me7LW4FNkXEGHAecCgzv9aH7Up6Dli3ZSeTB2eZn2jj+jVHuGbzXT3vd8WyJT1/7aDqWOgRcTtwAbA8Ig4AfwQ8DyAz3wdsB14L7AO+D7xxrsJKKs/kwcPs33LJMX/dxMQE+6++oP+BFrCOhZ6ZV3VYn8Bb+pZIktQTzxSVpEJY6JJUCAtdkgphoUtSISx0SSqEhS5JhbDQJakQFrokFcJCl6RCWOiSVAgLXZIKYaFLUiEsdEkqhIUuSYWw0CWpEBa6JBXCQpekQljoklQIC12SCtHxM0UllW/dlp1MHjz8rNuvX3OEazbfNaf7XrFsyZxu/7nEQpfE5MHD7N9yybNun5iYYP/VF8x/IPXEKRdJKoSFLkmFsNAlqRAWuiQVwkKXpEJY6JJUCAtdkgphoUtSISx0SSqEhS5JhbDQJakQXRV6RKyPiIcjYl9EbG6x/mURMR4R90fElyLitf2PKkmaTcdCj4hFwC3AxcBq4KqIWD1j2DuBOzLzbOBK4O/7HVSSNLtujtDPBfZl5iOZ+RQwBlw2Y0wCL6yunwI81r+IkqRuRGbOPiDicmB9Zl5bLW8AzsvMTU1jTgU+DbwIWApclJm7W2xrI7ARYHh4eGRsbKxf/4++mpqaYmhoqO4YLZmtN2ab3QOTh1iz4pRn3T4I2dpZyNna3d/dGB0d3Z2Za1uuzMxZL8AVwK1NyxuAd88Ycx1wfXX91cBe4ITZtjsyMpKDanx8vO4IbZmtN2ab3ek3bGt5+yBka2chZ2t3f3cD2JVterWbKZcDwGlNyyt59pTKm4A7qj8Q/wG8AFjexbYlSX3STaHfC5wZEWdExIk0nvTcOmPMo8CFABHxShqF/s1+BpUkza5joWfmEWATsAN4iMarWfZExM0RcWk17HrgzRHxReB24JrqoYEkaZ509Zmimbkd2D7jtpuaru8F1vU3miTpWHimqCQVwkKXpEJY6JJUCAtdkgphoUtSISx0SSqEhS5JhbDQJakQFrokFcJCl6RCWOiSVAgLXZIKYaFLUiEsdEkqhIUuSYWw0CWpEBa6JBXCQpekQljoklQIC12SCmGhS1IhLHRJKoSFLkmFsNAlqRAWuiQVwkKXpEIsrjuApKPWbdnJ5MHD877fFcuWzPs+1X8WujRAJg8eZv+WS+qOoQXKKRdJKoSFLkmFsNAlqRAWuiQVoqtCj4j1EfFwROyLiM1txrw+IvZGxJ6I+Gh/Y0qSOun4KpeIWATcArwGOADcGxFbM3Nv05gzgRuBdZn5RES8dK4CS5Ja6+YI/VxgX2Y+kplPAWPAZTPGvBm4JTOfAMjMx/sbU5LUSTeFvgL4atPygeq2Zi8HXh4R/x4R90TE+n4FlCR1JzJz9gERVwC/lJnXVssbgHMz861NY7YBPwBeD6wEPguclZkHZ2xrI7ARYHh4eGRsbKyP/5X+mZqaYmhoqO4YLZmtNwsl2wOTh1iz4pSaEx21UO63QdMp2/F8n0dHR3dn5tqWKzNz1gvwamBH0/KNwI0zxrwPuKZp+W7gZ2bb7sjISA6q8fHxuiO0ZbbeLJRsp9+wrb4gLSyU+23QdMp2PN9nYFe26dVuplzuBc6MiDMi4kTgSmDrjDH/AowCRMRyGlMwjxzLXx1J0vHpWOiZeQTYBOwAHgLuyMw9EXFzRFxaDdsBfDsi9gLjwO9l5rfnKrQk6dm6enOuzNwObJ9x201N1xO4rrpIkmrgmaKSVAgLXZIKYaFLUiEsdEkqhIUuSYWw0CWpEBa6JBXCQpekQljoklQIC12SCmGhS1IhLHRJKoSFLkmFsNAlqRAWuiQVwkKXpEJY6JJUCAtdkgphoUtSISx0SSqEhS5JhbDQJakQFrokFcJCl6RCWOiSVAgLXZIKYaFLUiEsdEkqhIUuSYWw0CWpEBa6JBXCQpekQljoklSIrgo9ItZHxMMRsS8iNs8y7vKIyIhY27+IkqRudCz0iFgE3AJcDKwGroqI1S3GnQy8Dfh8v0NKkjrr5gj9XGBfZj6SmU8BY8BlLcb9KfAu4H/7mE+S1KXIzNkHRFwOrM/Ma6vlDcB5mbmpaczZwDsz89ciYgL43czc1WJbG4GNAMPDwyNjY2N9+4/009TUFENDQ3XHaMlsvVko2R6YPMSaFafUnOiohXK/DZpO2Y7n+zw6Oro7M1tPa2fmrBfgCuDWpuUNwLublk8AJoBV1fIEsLbTdkdGRnJQjY+P1x2hLbP1ZqFkO/2GbfUFaWGh3G+DplO24/k+A7uyTa92M+VyADitaXkl8FjT8snAWcBEROwHXgVs9YlRSZpfi7sYcy9wZkScAUwCVwK/Mb0yMw8By6eXZ5tykRaCdVt2Mnnw8Lzt7/o1R7hm810ArFi2ZN72q/J0LPTMPBIRm4AdwCLgtszcExE30zj03zrXIaX5NHnwMPu3XDJv+5uYmGD/1RfM2/5Urm6O0MnM7cD2Gbfd1GbsBccfS5J0rDxTVJIKYaFLUiEsdEkqhIUuSYWw0CWpEBa6JBXCQpekQljoklQIC12SCmGhS1IhLHRJKoSFLkmFsNAlqRAWuiQVwkKXpEJY6JJUCAtdkgphoUtSISx0SSqEhS5JhbDQJakQFrokFcJCl6RCWOiSVAgLXZIKYaFLUiEsdEkqhIUuSYWw0CWpEBa6JBXCQpekQljoklSIrgo9ItZHxMMRsS8iNrdYf11E7I2IL0XE3RFxev+jSpJm07HQI2IRcAtwMbAauCoiVs8Ydj+wNjN/CrgTeFe/g0qSZtfNEfq5wL7MfCQznwLGgMuaB2TmeGZ+v1q8B1jZ35iSpE4iM2cfEHE5sD4zr62WNwDnZeamNuPfA3w9M/+sxbqNwEaA4eHhkbGxseOMPzempqYYGhqqO0ZLZuvNsWR7YPIQa1acMseJjirlfptvCznb8fyMjY6O7s7MtS1XZuasF+AK4Nam5Q3Au9uMfQONI/Tnd9ruyMhIDqrx8fG6I7Rltt4cS7bTb9g2d0FaKOV+m28LOdvx/IwBu7JNry7u4g/CAeC0puWVwGMzB0XERcAfAj+fmf/X7V8bSVJ/dDOHfi9wZkScEREnAlcCW5sHRMTZwD8Al2bm4/2PKUnqpOMRemYeiYhNwA5gEXBbZu6JiJtpHPpvBf4CGAI+FhEAj2bmpXOYW88B67bsZPLg4b5s6/o1R7hm811djV2xbElf9inNt26mXMjM7cD2Gbfd1HT9oj7nkpg8eJj9Wy7py7YmJibYf/UFfdmWNKg8U1SSCmGhS1IhLHRJKoSFLkmFsNAlqRAWuiQVwkKXpEJY6JJUCAtdkgphoUtSISx0SSqEhS5JhbDQJakQFrokFcJCl6RCWOiSVAgLXZIKYaFLUiG6+gg6Pbd1+9mex/K5nd3wsz2lY2Ohq6NuP9vTz+2U6uWUiyQVwkKXpEJY6JJUCAtdkgphoUtSISx0SSqEhS5JhfB16AvE9Mk9/T55pxue4CMtDBb6AjF9co8n70hqxykXSSqEhS5JhbDQJakQzqEfo27febDffGJSUiddFXpErAf+FlgE3JqZW2asfz7wYWAE+Dbw65m5v79RB0O37zwoSfOt45RLRCwCbgEuBlYDV0XE6hnD3gQ8kZk/Cfw18Of9DipJml03R+jnAvsy8xGAiBgDLgP2No25DPjj6vqdwHsiIjIz+5j1aXM97THba72d+pA0qLop9BXAV5uWDwDntRuTmUci4hDwYuBbzYMiYiOwsVqcioiHewk9194Gy5mRfdpXgLhxfvPM0DbbADBbb8zWmwWdLXqfxzi93YpuCj1a3DbzyLubMWTm+4H3d7HPWkXErsxcW3eOVszWG7P1xmy9qStbNy9bPACc1rS8Enis3ZiIWAycAnynHwElSd3pptDvBc6MiDMi4kTgSmDrjDFbgd+srl8O7Jyr+XNJUmsdp1yqOfFNwA4aL1u8LTP3RMTNwK7M3Ap8APiniNhH48j8yrkMPQ8GeVrIbL0xW2/M1ptasoUH0pJUBk/9l6RCWOiSVAgLvRIRp0XEeEQ8FBF7IuLtdWeaFhEviIj/jIgvVtn+pO5MM0XEooi4PyK21Z2lWUTsj4gHIuILEbGr7jzNImJZRNwZEV+ufu5eXXcmgIh4RXV/TV++GxHvqDvXtIj4ner34MGIuD0iXlB3pmkR8fYq15467jPn0CsRcSpwambeFxEnA7uBX87MvR2+dM5FRABLM3MqIp4HfA54e2beU3O0p0XEdcBa4IWZ+bq680yLiP3A2swcuBNQIuJDwGcz89bqFWQnZebBunM1q976YxI4LzO/MgB5VtD4+V+dmYcj4g5ge2Z+sN5kEBFnAWM0zq5/CvgU8NuZ+V/zlcEj9Epmfi0z76uufw94iMYZsLXLhqlq8XnVZWD+EkfESuAS4Na6sywUEfFC4HwarxAjM58atDKvXAj89yCUeZPFwJLqnJeTePZ5MXV5JXBPZn4/M48A/wr8ynwGsNBbiIhVwNnA5+tNclQ1pfEF4HHgM5k5MNmAvwF+H/hR3UFaSODTEbG7euuJQfETwDeBf6ymqm6NiKV1h2rhSuD2ukNMy8xJ4C+BR4GvAYcy89P1pnrag8D5EfHiiDgJeC3PPClzzlnoM0TEEPBx4B2Z+d2680zLzB9m5k/TOFP33OrhXe0i4nXA45m5u+4sbazLzHNovFvoWyLi/LoDVRYD5wDvzcyzgSeBzfVGeqZqGuhS4GN1Z5kWES+i8WaAZwA/DiyNiDfUm6ohMx+i8U6zn6Ex3fJF4Mh8ZrDQm1Tz0x8HPpKZn6g7TyvVw/IJYH3NUaatAy6t5qrHgF+IiH+uN9JRmflY9e/jwCdpzG8OggPAgaZHWnfSKPhBcjFwX2Z+o+4gTS4C/iczv5mZPwA+AfxszZmelpkfyMxzMvN8GidZztv8OVjoT6ueePwA8FBm/lXdeZpFxEsiYll1fQmNH+ov15uqITNvzMyVmbmKxsPznZk5EEdMEbG0eoKbajrjF2k8LK5dZn4d+GpEvKK66UKe+ZbUg+AqBmi6pfIo8KqIOKn6nb2QxvNdAyEiXlr9+zLgV5nn+8+PoDtqHbABeKCaqwb4g8zcXmOmaacCH6pecXACcEdmDtTLAwfUMPDJxu89i4GPZuan6o30DG8FPlJNbTwCvLHmPE+r5oBfA/xW3VmaZebnI+JO4D4a0xn3M1hvAfDxiHgx8APgLZn5xHzu3JctSlIhnHKRpEJY6JJUCAtdkgphoUtSISx0SSqEhS5JhbDQJakQ/w9Rh+f+aYjUUQAAAABJRU5ErkJggg==",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
@@ -1631,30 +1625,30 @@
             "needs_background": "light"
           }
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Nfm50nqF_G_T"
-      },
-      "source": [
-        "And increase the number of bins. "
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "ZrMVUVmW_G_U",
-        "outputId": "502f010c-1275-4675-8f3c-7cc2029fe4c8"
-      },
+        "id": "FGB1nZqz_G_T",
+        "outputId": "8a4624f2-2645-4241-eeed-fb27d627b64d"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "And increase the number of bins. "
+      ],
+      "metadata": {
+        "id": "Nfm50nqF_G_T"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "movies['IMDB_Rating'].hist(cumulative=True, density=True, bins=1000)"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1671,7 +1665,7 @@
         {
           "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD4CAYAAAD8Zh1EAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAARkElEQVR4nO3de4ycV33G8e8PhxTHCwZhWKW2walqEFa2auKVA40UdpvQOhTZvaTgNEQ1IriqMIXiXkKL0jbtH5Q2vYmU1gqUSyGrEKCyUouAwNtC1VDbCbCxTVRj3GAbEi7BdEPaxOXXP2ZsxuPxzux4Zt7Z4+9HWmXfeU9mnrXsZ8+e97yzkZlIkha+p1UdQJLUGxa6JBXCQpekQljoklQIC12SCnFBVS+8bNmyXLVqVVUvP6fHH3+cJUuWVB2jJbN1x2zdMVt3+plt796938rM57U8mZmVfKxduzaH1a5du6qOcFZm647ZumO27vQzG7Anz9KrLrlIUiEsdEkqhIUuSYWw0CWpEBa6JBXCQpekQrQt9Ih4b0Q8GhEPnuV8RMTfRMTBiPhSRFze+5iSpHY6maG/D1g/x/lrgdX1jy3Au889liRpvtoWemb+K/CdOYZsBD5Q3/N+H/DsiLi4VwElSZ2J7OAXXETEKuCezLy0xbl7gHdk5ufqx58Gfjcz97QYu4XaLJ7R0dG1U1NT5xS+X2ZnZxkZGak6Rktm647ZumO21maOHp/z/OhieOSJs58fW76069eenJzcm5njrc714r1cosVjLb9LZOZ2YDvA+Ph4TkxM9ODle296ehqzzZ/ZumO27gwy26qb/7npkbmrc9vYCW6bOfuYwzdMnHuoFnpR6EeAlQ3HK4BjPXheSRqIMwt7YepFoe8AtkbEFHAFcDwzv96D55WkviilwJu1LfSIuBOYAJZFxBHgD4CnA2Tm3wE7gVcCB4HvA6/rV1hJ0tm1LfTMvL7N+QTe2LNEktRjpc7Im1X2Cy4kqV/OlwJv5q3/klQIC12SCuGSi6QF73xdYmnmDF2SCuEMXdKCNHP0OJudmZ/GGbokFcJCl6RCuOQiaUFovvC5bayiIEPMGbokFcJCl6RCWOiSVAjX0CUNJW8Wmj9n6JJUCAtdkgphoUtSIVxDlzQUXDM/d87QJakQFrokFcIlF0mVcIml95yhS1IhLHRJKoSFLkmFsNAlqRAWuiQVwl0ukgbCXS395wxdkgphoUtSISx0SSqEa+iS+sI188Fzhi5JhbDQJakQHRV6RKyPiIci4mBE3Nzi/AsiYldEPBARX4qIV/Y+qiRpLm0LPSIWAbcD1wJrgOsjYk3TsLcDd2XmZcAm4G97HVSSNLdOZujrgIOZeSgznwSmgI1NYxJ4Vv3zpcCx3kWUJHUiMnPuARHXAesz86b68Y3AFZm5tWHMxcAngecAS4BrMnNvi+faAmwBGB0dXTs1NdWrr6OnZmdnGRkZqTpGS2brjtm6M59sM0eP9znN6UYXwyNPDPQlO9Yu29jypV0/9+Tk5N7MHG91rpNti9HisebvAtcD78vM2yLiZcAHI+LSzPzBaf9T5nZgO8D4+HhOTEx08PKDNz09jdnmz2zdKSXb5gFvU9w2doLbZoZz53W7bIdvmOjL63ay5HIEWNlwvIIzl1ReD9wFkJn/DjwDWNaLgJKkznRS6LuB1RFxSURcSO2i546mMQ8DVwNExEuoFfo3exlUkjS3toWemSeArcC9wAFqu1n2RcStEbGhPmwb8IaI+CJwJ7A52y3OS5J6qqMFqMzcCexseuyWhs/3A1f2NpokaT6G84qCpKHne7UMH2/9l6RCWOiSVAgLXZIKYaFLUiEsdEkqhLtcJHXEXS3Dzxm6JBXCQpekQljoklQIC12SCmGhS1IhLHRJKoTbFiWd1czR4wP/TUTqnjN0SSqEhS5JhbDQJakQFrokFcKLopJOaX6/lm1jFQVRV5yhS1IhLHRJKoSFLkmFsNAlqRAWuiQVwkKXpEJY6JJUCPehS+cxf09oWZyhS1IhLHRJKoSFLkmFsNAlqRAWuiQVoqNCj4j1EfFQRByMiJvPMubVEbE/IvZFxId7G1OS1E7bbYsRsQi4HXgFcATYHRE7MnN/w5jVwNuAKzPzsYh4fr8CS+qe2xTL1skMfR1wMDMPZeaTwBSwsWnMG4DbM/MxgMx8tLcxJUntdFLoy4GvNRwfqT/W6EXAiyLi3yLivohY36uAkqTORGbOPSDil4Gfzcyb6sc3Ausy800NY+4BngJeDawAPgtcmpnfbXquLcAWgNHR0bVTU1M9/FJ6Z3Z2lpGRkapjtGS27pitZubo8XmNH10MjzzRpzDnaCFnG1u+tOvnnpyc3JuZ463OdXLr/xFgZcPxCuBYizH3ZeZTwFcj4iFgNbC7cVBmbge2A4yPj+fExERHX8CgTU9PY7b5M1t3Bplt8zzX0LeNneC2meF8h5CFnO3wDRN9ed1Ollx2A6sj4pKIuBDYBOxoGvNPwCRARCyjtgRzqJdBJUlza1vomXkC2ArcCxwA7srMfRFxa0RsqA+7F/h2ROwHdgG/nZnf7ldoSdKZOvp5JTN3AjubHrul4fME3lr/kCRVYDgXoCT1hPvOzy/e+i9JhbDQJakQFrokFcJCl6RCWOiSVAgLXZIK4bZFqSBuUzy/OUOXpEJY6JJUCAtdkgphoUtSIbwoKi1gXgRVI2foklQIC12SCmGhS1IhLHRJKoSFLkmFsNAlqRBuW5QWELcpai7O0CWpEBa6JBXCQpekQljoklQIC12SCmGhS1Ih3LYoDTG3KWo+nKFLUiEsdEkqhIUuSYWw0CWpEBa6JBXCXS7SkHFni7rV0Qw9ItZHxEMRcTAibp5j3HURkREx3ruIkqROtC30iFgE3A5cC6wBro+INS3GPRP4DeDzvQ4pSWqvkxn6OuBgZh7KzCeBKWBji3F/DLwT+J8e5pMkdSgyc+4BEdcB6zPzpvrxjcAVmbm1YcxlwNsz85ciYhr4rczc0+K5tgBbAEZHR9dOTU317AvppdnZWUZGRqqO0ZLZurOQss0cPV5hmtONLoZHnqg6RWsLOdvY8qVdP/fk5OTezGy5rN3JRdFo8dip7wIR8TTgL4HN7Z4oM7cD2wHGx8dzYmKig5cfvOnpacw2f2brTnO2zUN0UXTb2AlumxnOvRMLOdvhGyb68rqdLLkcAVY2HK8AjjUcPxO4FJiOiMPAS4EdXhiVpMHq5NvbbmB1RFwCHAU2Ab9y8mRmHgeWnTyea8lF0plmjh4fqlm5Fq62M/TMPAFsBe4FDgB3Zea+iLg1Ijb0O6AkqTMdLUBl5k5gZ9Njt5xl7MS5x5IkzZe3/ktSISx0SSqEhS5JhbDQJakQw7krXypY87spbhurKIiK4wxdkgphoUtSISx0SSqEhS5JhfCiqNRn/ko5DYozdEkqhIUuSYWw0CWpEBa6JBXCQpekQrjLReoxd7WoKs7QJakQFrokFcJCl6RCWOiSVAgvikrnyIugGhbO0CWpEBa6JBXCQpekQljoklQIL4pK8+RFUA0rZ+iSVAgLXZIKYaFLUiEsdEkqhBdFpTa8CKqFwhm6JBWio0KPiPUR8VBEHIyIm1ucf2tE7I+IL0XEpyPihb2PKkmaS9tCj4hFwO3AtcAa4PqIWNM07AFgPDN/ArgbeGevg0qS5tbJGvo64GBmHgKIiClgI7D/5IDM3NUw/j7gtb0MKQ2Sa+ZaqCIz5x4QcR2wPjNvqh/fCFyRmVvPMv5dwDcy809anNsCbAEYHR1dOzU1dY7x+2N2dpaRkZGqY7Rktu7MJ9vM0eN9TnO60cXwyBMDfcmOma077bKNLV/a9XNPTk7uzczxVuc6maFHi8dafheIiNcC48DLW53PzO3AdoDx8fGcmJjo4OUHb3p6GrPNXynZNg94hr5t7AS3zQznhjOzdaddtsM3TPTldTv50zgCrGw4XgEcax4UEdcAvw+8PDP/tzfxJEmd6mSXy25gdURcEhEXApuAHY0DIuIy4O+BDZn5aO9jSpLaaTtDz8wTEbEVuBdYBLw3M/dFxK3AnszcAfwZMAJ8JCIAHs7MDX3MLfWUF0JVgo4WoDJzJ7Cz6bFbGj6/pse5JEnz5J2iklSI4bxELPWZSywqkTN0SSqEhS5JhXDJReeFmaPHB37DkDRoztAlqRAWuiQVwiUXFal5F8u2sYqCSAPkDF2SCmGhS1IhXHJREbxRSHKGLknFcIauBckZuXQmZ+iSVAgLXZIKYaFLUiFcQ9eC4Jq51J4zdEkqhDN0DSVn5NL8OUOXpEI4Q9dQcEYunTsLXZWwwKXec8lFkgrhDF194yxcGixn6JJUCGfo6hl/EbNULQtdXfPXvEnDxULXWbkGLi0sFvp5zMKWymKhn0cscKls7nKRpEI4Qy+YM3Lp/GKhD7kzd5KccGugpJY6KvSIWA/8NbAIuCMz39F0/keADwBrgW8Dr8nMw72NWgZnzZL6pW2hR8Qi4HbgFcARYHdE7MjM/Q3DXg88lpk/HhGbgD8FXtOPwMPOwpZUlU5m6OuAg5l5CCAipoCNQGOhbwT+sP753cC7IiIyM3uYtWvzLVmXNSQtRNGucyPiOmB9Zt5UP74RuCIztzaMebA+5kj9+Cv1Md9qeq4twJb64YuBh3r1hfTYMuBbbUdVw2zdMVt3zNadfmZ7YWY+r9WJTmbo0eKx5u8CnYwhM7cD2zt4zUpFxJ7MHK86Rytm647ZumO27lSVrZN96EeAlQ3HK4BjZxsTERcAS4Hv9CKgJKkznRT6bmB1RFwSERcCm4AdTWN2AL9a//w64DPDsn4uSeeLtksumXkiIrYC91LbtvjezNwXEbcCezJzB/Ae4IMRcZDazHxTP0MPwDAvC5mtO2brjtm6U0m2thdFJUkLg+/lIkmFsNAlqRAWel1ErIyIXRFxICL2RcSbq850UkQ8IyL+IyK+WM/2R1VnahYRiyLigYi4p+osjSLicETMRMQXImJP1XkaRcSzI+LuiPhy/e/dy6rOBBARL67/eZ38+F5EvKXqXCdFxG/W/x08GBF3RsQzqs50UkS8uZ5rXxV/Zq6h10XExcDFmXl/RDwT2Av8fNNbHFQiIgJYkpmzEfF04HPAmzPzvoqjnRIRbwXGgWdl5quqznNSRBwGxptvchsGEfF+4LOZeUd9B9lFmfndqnM1qr/1x1FqNwr+1xDkWU7t7/+azHwiIu4Cdmbm+6pNBhFxKTBF7e76J4FPAL+emf85qAzO0Osy8+uZeX/98/8GDgDLq01VkzWz9cOn1z+G5jtxRKwAfg64o+osC0VEPAu4itoOMTLzyWEr87qrga8MQ5k3uABYXL/n5SLOvC+mKi8B7svM72fmCeBfgF8YZAALvYWIWAVcBny+2iQ/VF/S+ALwKPCpzByabMBfAb8D/KDqIC0k8MmI2Ft/64lh8WPAN4F/qC9V3RERS6oO1cIm4M6qQ5yUmUeBPwceBr4OHM/MT1ab6pQHgasi4rkRcRHwSk6/KbPvLPQmETECfBR4S2Z+r+o8J2Xm/2XmT1K7U3dd/ce7ykXEq4BHM3Nv1VnO4srMvBy4FnhjRFxVdaC6C4DLgXdn5mXA48DN1UY6XX0ZaAPwkaqznBQRz6H2ZoCXAD8KLImI11abqiYzD1B7p9lPUVtu+SJwYpAZLPQG9fXpjwIfysyPVZ2nlfqP5dPA+oqjnHQlsKG+Vj0F/HRE/GO1kX4oM4/V//so8HFq65vD4AhwpOEnrbupFfwwuRa4PzMfqTpIg2uAr2bmNzPzKeBjwE9VnOmUzHxPZl6emVdRu8lyYOvnYKGfUr/w+B7gQGb+RdV5GkXE8yLi2fXPF1P7S/3lalPVZObbMnNFZq6i9uP5ZzJzKGZMEbGkfoGb+nLGz1D7sbhymfkN4GsR8eL6Q1dz+ltSD4PrGaLllrqHgZdGxEX1f7NXU7veNRQi4vn1/74A+EUG/Ofnr6D7oSuBG4GZ+lo1wO9l5s4KM510MfD++o6DpwF3ZeZQbQ8cUqPAx2v/7rkA+HBmfqLaSKd5E/Ch+tLGIeB1Fec5pb4G/Arg16rO0igzPx8RdwP3U1vOeIDheguAj0bEc4GngDdm5mODfHG3LUpSIVxykaRCWOiSVAgLXZIKYaFLUiEsdEkqhIUuSYWw0CWpEP8PDVTm+TsAbYkAAAAASUVORK5CYII=\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD4CAYAAAD8Zh1EAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAARkElEQVR4nO3de4ycV33G8e8PhxTHCwZhWKW2walqEFa2auKVA40UdpvQOhTZvaTgNEQ1IriqMIXiXkKL0jbtH5Q2vYmU1gqUSyGrEKCyUouAwNtC1VDbCbCxTVRj3GAbEi7BdEPaxOXXP2ZsxuPxzux4Zt7Z4+9HWmXfeU9mnrXsZ8+e97yzkZlIkha+p1UdQJLUGxa6JBXCQpekQljoklQIC12SCnFBVS+8bNmyXLVqVVUvP6fHH3+cJUuWVB2jJbN1x2zdMVt3+plt796938rM57U8mZmVfKxduzaH1a5du6qOcFZm647ZumO27vQzG7Anz9KrLrlIUiEsdEkqhIUuSYWw0CWpEBa6JBXCQpekQrQt9Ih4b0Q8GhEPnuV8RMTfRMTBiPhSRFze+5iSpHY6maG/D1g/x/lrgdX1jy3Au889liRpvtoWemb+K/CdOYZsBD5Q3/N+H/DsiLi4VwElSZ2J7OAXXETEKuCezLy0xbl7gHdk5ufqx58Gfjcz97QYu4XaLJ7R0dG1U1NT5xS+X2ZnZxkZGak6Rktm647ZumO21maOHp/z/OhieOSJs58fW76069eenJzcm5njrc714r1cosVjLb9LZOZ2YDvA+Ph4TkxM9ODle296ehqzzZ/ZumO27gwy26qb/7npkbmrc9vYCW6bOfuYwzdMnHuoFnpR6EeAlQ3HK4BjPXheSRqIMwt7YepFoe8AtkbEFHAFcDwzv96D55WkviilwJu1LfSIuBOYAJZFxBHgD4CnA2Tm3wE7gVcCB4HvA6/rV1hJ0tm1LfTMvL7N+QTe2LNEktRjpc7Im1X2Cy4kqV/OlwJv5q3/klQIC12SCuGSi6QF73xdYmnmDF2SCuEMXdKCNHP0OJudmZ/GGbokFcJCl6RCuOQiaUFovvC5bayiIEPMGbokFcJCl6RCWOiSVAjX0CUNJW8Wmj9n6JJUCAtdkgphoUtSIVxDlzQUXDM/d87QJakQFrokFcIlF0mVcIml95yhS1IhLHRJKoSFLkmFsNAlqRAWuiQVwl0ukgbCXS395wxdkgphoUtSISx0SSqEa+iS+sI188Fzhi5JhbDQJakQHRV6RKyPiIci4mBE3Nzi/AsiYldEPBARX4qIV/Y+qiRpLm0LPSIWAbcD1wJrgOsjYk3TsLcDd2XmZcAm4G97HVSSNLdOZujrgIOZeSgznwSmgI1NYxJ4Vv3zpcCx3kWUJHUiMnPuARHXAesz86b68Y3AFZm5tWHMxcAngecAS4BrMnNvi+faAmwBGB0dXTs1NdWrr6OnZmdnGRkZqTpGS2brjtm6M59sM0eP9znN6UYXwyNPDPQlO9Yu29jypV0/9+Tk5N7MHG91rpNti9HisebvAtcD78vM2yLiZcAHI+LSzPzBaf9T5nZgO8D4+HhOTEx08PKDNz09jdnmz2zdKSXb5gFvU9w2doLbZoZz53W7bIdvmOjL63ay5HIEWNlwvIIzl1ReD9wFkJn/DjwDWNaLgJKkznRS6LuB1RFxSURcSO2i546mMQ8DVwNExEuoFfo3exlUkjS3toWemSeArcC9wAFqu1n2RcStEbGhPmwb8IaI+CJwJ7A52y3OS5J6qqMFqMzcCexseuyWhs/3A1f2NpokaT6G84qCpKHne7UMH2/9l6RCWOiSVAgLXZIKYaFLUiEsdEkqhLtcJHXEXS3Dzxm6JBXCQpekQljoklQIC12SCmGhS1IhLHRJKoTbFiWd1czR4wP/TUTqnjN0SSqEhS5JhbDQJakQFrokFcKLopJOaX6/lm1jFQVRV5yhS1IhLHRJKoSFLkmFsNAlqRAWuiQVwkKXpEJY6JJUCPehS+cxf09oWZyhS1IhLHRJKoSFLkmFsNAlqRAWuiQVoqNCj4j1EfFQRByMiJvPMubVEbE/IvZFxId7G1OS1E7bbYsRsQi4HXgFcATYHRE7MnN/w5jVwNuAKzPzsYh4fr8CS+qe2xTL1skMfR1wMDMPZeaTwBSwsWnMG4DbM/MxgMx8tLcxJUntdFLoy4GvNRwfqT/W6EXAiyLi3yLivohY36uAkqTORGbOPSDil4Gfzcyb6sc3Ausy800NY+4BngJeDawAPgtcmpnfbXquLcAWgNHR0bVTU1M9/FJ6Z3Z2lpGRkapjtGS27pitZubo8XmNH10MjzzRpzDnaCFnG1u+tOvnnpyc3JuZ463OdXLr/xFgZcPxCuBYizH3ZeZTwFcj4iFgNbC7cVBmbge2A4yPj+fExERHX8CgTU9PY7b5M1t3Bplt8zzX0LeNneC2meF8h5CFnO3wDRN9ed1Ollx2A6sj4pKIuBDYBOxoGvNPwCRARCyjtgRzqJdBJUlza1vomXkC2ArcCxwA7srMfRFxa0RsqA+7F/h2ROwHdgG/nZnf7ldoSdKZOvp5JTN3AjubHrul4fME3lr/kCRVYDgXoCT1hPvOzy/e+i9JhbDQJakQFrokFcJCl6RCWOiSVAgLXZIK4bZFqSBuUzy/OUOXpEJY6JJUCAtdkgphoUtSIbwoKi1gXgRVI2foklQIC12SCmGhS1IhLHRJKoSFLkmFsNAlqRBuW5QWELcpai7O0CWpEBa6JBXCQpekQljoklQIC12SCmGhS1Ih3LYoDTG3KWo+nKFLUiEsdEkqhIUuSYWw0CWpEBa6JBXCXS7SkHFni7rV0Qw9ItZHxEMRcTAibp5j3HURkREx3ruIkqROtC30iFgE3A5cC6wBro+INS3GPRP4DeDzvQ4pSWqvkxn6OuBgZh7KzCeBKWBji3F/DLwT+J8e5pMkdSgyc+4BEdcB6zPzpvrxjcAVmbm1YcxlwNsz85ciYhr4rczc0+K5tgBbAEZHR9dOTU317AvppdnZWUZGRqqO0ZLZurOQss0cPV5hmtONLoZHnqg6RWsLOdvY8qVdP/fk5OTezGy5rN3JRdFo8dip7wIR8TTgL4HN7Z4oM7cD2wHGx8dzYmKig5cfvOnpacw2f2brTnO2zUN0UXTb2AlumxnOvRMLOdvhGyb68rqdLLkcAVY2HK8AjjUcPxO4FJiOiMPAS4EdXhiVpMHq5NvbbmB1RFwCHAU2Ab9y8mRmHgeWnTyea8lF0plmjh4fqlm5Fq62M/TMPAFsBe4FDgB3Zea+iLg1Ijb0O6AkqTMdLUBl5k5gZ9Njt5xl7MS5x5IkzZe3/ktSISx0SSqEhS5JhbDQJakQw7krXypY87spbhurKIiK4wxdkgphoUtSISx0SSqEhS5JhfCiqNRn/ko5DYozdEkqhIUuSYWw0CWpEBa6JBXCQpekQrjLReoxd7WoKs7QJakQFrokFcJCl6RCWOiSVAgvikrnyIugGhbO0CWpEBa6JBXCQpekQljoklQIL4pK8+RFUA0rZ+iSVAgLXZIKYaFLUiEsdEkqhBdFpTa8CKqFwhm6JBWio0KPiPUR8VBEHIyIm1ucf2tE7I+IL0XEpyPihb2PKkmaS9tCj4hFwO3AtcAa4PqIWNM07AFgPDN/ArgbeGevg0qS5tbJGvo64GBmHgKIiClgI7D/5IDM3NUw/j7gtb0MKQ2Sa+ZaqCIz5x4QcR2wPjNvqh/fCFyRmVvPMv5dwDcy809anNsCbAEYHR1dOzU1dY7x+2N2dpaRkZGqY7Rktu7MJ9vM0eN9TnO60cXwyBMDfcmOma077bKNLV/a9XNPTk7uzczxVuc6maFHi8dafheIiNcC48DLW53PzO3AdoDx8fGcmJjo4OUHb3p6GrPNXynZNg94hr5t7AS3zQznhjOzdaddtsM3TPTldTv50zgCrGw4XgEcax4UEdcAvw+8PDP/tzfxJEmd6mSXy25gdURcEhEXApuAHY0DIuIy4O+BDZn5aO9jSpLaaTtDz8wTEbEVuBdYBLw3M/dFxK3AnszcAfwZMAJ8JCIAHs7MDX3MLfWUF0JVgo4WoDJzJ7Cz6bFbGj6/pse5JEnz5J2iklSI4bxELPWZSywqkTN0SSqEhS5JhXDJReeFmaPHB37DkDRoztAlqRAWuiQVwiUXFal5F8u2sYqCSAPkDF2SCmGhS1IhXHJREbxRSHKGLknFcIauBckZuXQmZ+iSVAgLXZIKYaFLUiFcQ9eC4Jq51J4zdEkqhDN0DSVn5NL8OUOXpEI4Q9dQcEYunTsLXZWwwKXec8lFkgrhDF194yxcGixn6JJUCGfo6hl/EbNULQtdXfPXvEnDxULXWbkGLi0sFvp5zMKWymKhn0cscKls7nKRpEI4Qy+YM3Lp/GKhD7kzd5KccGugpJY6KvSIWA/8NbAIuCMz39F0/keADwBrgW8Dr8nMw72NWgZnzZL6pW2hR8Qi4HbgFcARYHdE7MjM/Q3DXg88lpk/HhGbgD8FXtOPwMPOwpZUlU5m6OuAg5l5CCAipoCNQGOhbwT+sP753cC7IiIyM3uYtWvzLVmXNSQtRNGucyPiOmB9Zt5UP74RuCIztzaMebA+5kj9+Cv1Md9qeq4twJb64YuBh3r1hfTYMuBbbUdVw2zdMVt3zNadfmZ7YWY+r9WJTmbo0eKx5u8CnYwhM7cD2zt4zUpFxJ7MHK86Rytm647ZumO27lSVrZN96EeAlQ3HK4BjZxsTERcAS4Hv9CKgJKkznRT6bmB1RFwSERcCm4AdTWN2AL9a//w64DPDsn4uSeeLtksumXkiIrYC91LbtvjezNwXEbcCezJzB/Ae4IMRcZDazHxTP0MPwDAvC5mtO2brjtm6U0m2thdFJUkLg+/lIkmFsNAlqRAWel1ErIyIXRFxICL2RcSbq850UkQ8IyL+IyK+WM/2R1VnahYRiyLigYi4p+osjSLicETMRMQXImJP1XkaRcSzI+LuiPhy/e/dy6rOBBARL67/eZ38+F5EvKXqXCdFxG/W/x08GBF3RsQzqs50UkS8uZ5rXxV/Zq6h10XExcDFmXl/RDwT2Av8fNNbHFQiIgJYkpmzEfF04HPAmzPzvoqjnRIRbwXGgWdl5quqznNSRBwGxptvchsGEfF+4LOZeUd9B9lFmfndqnM1qr/1x1FqNwr+1xDkWU7t7/+azHwiIu4Cdmbm+6pNBhFxKTBF7e76J4FPAL+emf85qAzO0Osy8+uZeX/98/8GDgDLq01VkzWz9cOn1z+G5jtxRKwAfg64o+osC0VEPAu4itoOMTLzyWEr87qrga8MQ5k3uABYXL/n5SLOvC+mKi8B7svM72fmCeBfgF8YZAALvYWIWAVcBny+2iQ/VF/S+ALwKPCpzByabMBfAb8D/KDqIC0k8MmI2Ft/64lh8WPAN4F/qC9V3RERS6oO1cIm4M6qQ5yUmUeBPwceBr4OHM/MT1ab6pQHgasi4rkRcRHwSk6/KbPvLPQmETECfBR4S2Z+r+o8J2Xm/2XmT1K7U3dd/ce7ykXEq4BHM3Nv1VnO4srMvBy4FnhjRFxVdaC6C4DLgXdn5mXA48DN1UY6XX0ZaAPwkaqznBQRz6H2ZoCXAD8KLImI11abqiYzD1B7p9lPUVtu+SJwYpAZLPQG9fXpjwIfysyPVZ2nlfqP5dPA+oqjnHQlsKG+Vj0F/HRE/GO1kX4oM4/V//so8HFq65vD4AhwpOEnrbupFfwwuRa4PzMfqTpIg2uAr2bmNzPzKeBjwE9VnOmUzHxPZl6emVdRu8lyYOvnYKGfUr/w+B7gQGb+RdV5GkXE8yLi2fXPF1P7S/3lalPVZObbMnNFZq6i9uP5ZzJzKGZMEbGkfoGb+nLGz1D7sbhymfkN4GsR8eL6Q1dz+ltSD4PrGaLllrqHgZdGxEX1f7NXU7veNRQi4vn1/74A+EUG/Ofnr6D7oSuBG4GZ+lo1wO9l5s4KM510MfD++o6DpwF3ZeZQbQ8cUqPAx2v/7rkA+HBmfqLaSKd5E/Ch+tLGIeB1Fec5pb4G/Arg16rO0igzPx8RdwP3U1vOeIDheguAj0bEc4GngDdm5mODfHG3LUpSIVxykaRCWOiSVAgLXZIKYaFLUiEsdEkqhIUuSYWw0CWpEP8PDVTm+TsAbYkAAAAASUVORK5CYII=",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
@@ -1681,31 +1675,31 @@
             "needs_background": "light"
           }
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "JrEXxI1Z_G_U"
-      },
-      "source": [
-        "This method works fine. By increasing the number of bins, you can get a CDF in the resolution that you want. But let's also try it manually to better understand what's going on. First, we should sort all the values. "
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "CVqSQmmU_G_U",
-        "outputId": "6592daa4-0685-458d-ef00-83705f92b711"
-      },
+        "id": "ZrMVUVmW_G_U",
+        "outputId": "502f010c-1275-4675-8f3c-7cc2029fe4c8"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "This method works fine. By increasing the number of bins, you can get a CDF in the resolution that you want. But let's also try it manually to better understand what's going on. First, we should sort all the values. "
+      ],
+      "metadata": {
+        "id": "JrEXxI1Z_G_U"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "rating_sorted = movies['IMDB_Rating'].sort_values()\n",
         "rating_sorted.head()"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1724,31 +1718,31 @@
           },
           "execution_count": 49
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ucOJmOOZ_G_V"
-      },
-      "source": [
-        "We need to know the number of data points, "
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "zlkvZ-wx_G_V",
-        "outputId": "70f5b6d8-4af8-4f48-e4eb-beba3279f2f9"
-      },
+        "id": "CVqSQmmU_G_U",
+        "outputId": "6592daa4-0685-458d-ef00-83705f92b711"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We need to know the number of data points, "
+      ],
+      "metadata": {
+        "id": "ucOJmOOZ_G_V"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "N = len(rating_sorted)\n",
         "N"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1762,31 +1756,31 @@
           },
           "execution_count": 50
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "_iqJaMbJ_G_V"
-      },
-      "source": [
-        "And I think this may be useful for you. "
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "JSAwidf8_G_V",
-        "outputId": "d72141bb-7cc6-43c9-c128-29d14e9f0ea0"
-      },
+        "id": "zlkvZ-wx_G_V",
+        "outputId": "70f5b6d8-4af8-4f48-e4eb-beba3279f2f9"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "And I think this may be useful for you. "
+      ],
+      "metadata": {
+        "id": "_iqJaMbJ_G_V"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "n = 50\n",
         "np.linspace(1/n, 1.0, num=n)"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1804,35 +1798,35 @@
           },
           "execution_count": 51
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "HVnvIXbH_G_W"
-      },
-      "source": [
-        "**Q: now you're ready to draw a proper CDF. Draw the CDF plot of this data.** "
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "zRw7i6Mc_G_W",
-        "outputId": "a0b7cb88-1f5e-404b-c5d0-f96bfb3211a1"
-      },
+        "id": "JSAwidf8_G_V",
+        "outputId": "d72141bb-7cc6-43c9-c128-29d14e9f0ea0"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "**Q: now you're ready to draw a proper CDF. Draw the CDF plot of this data.** "
+      ],
+      "metadata": {
+        "id": "HVnvIXbH_G_W"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "# Implement"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEGCAYAAABo25JHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nO3deZxddX3/8dfnLnPvLJlsM9mXSSAsAQnLEBAUQYwNWKVqxbhVqz9T/YmKWlv92Yflh33051Jr7a+pPwNS0YqouKU1BbSAG4tZWCSBQEhCMgnZt5nJ3P3z++PeiTeTSSbLnDl35ryfj0ceufecc5M3IZn3nO/3nO8xd0dERKIrFnYAEREJl4pARCTiVAQiIhGnIhARiTgVgYhIxCXCDnCyWlpavK2tLewYIiLDyqpVq3a7e2t/+4ZdEbS1tbFy5cqwY4iIDCtm9uKx9mloSEQk4lQEIiIRpyIQEYk4FYGISMSpCEREIi6wIjCzO8xsp5k9fYz9Zmb/bGbrzewpM7s4qCwiInJsQZ4RfBNYeJz91wFzKj8WA18LMIuIiBxDYPcRuPuvzKztOIfcAHzLy+tgP2pmY8xssru/FFQmEZFasbsry3PbO8kVSxSKTr5YIlcska+8LhRL5Cqv84US+ZJz7TkTmDd9zKBnCfOGsqnAlqr3HZVtRxWBmS2mfNbAjBkzhiSciMjp2Ned45ENe8jki2TyJX6wagu7u7Jk8yWyhRIHevIn/WtObE6NuCKwfrb1+5Qcd18KLAVob2/Xk3REJHTuzrPbO+nKFsjmSzy2cQ8rNu2lUHQyhSJPbz3Y7+cWXTqdVCJGOhlnYnOaedPHUBePkUwYyXiMZKzqdTxGXTxGIm4kYoZZf182T1+YRdABTK96Pw3YFlIWEZHjKhRLPLRuFwd68mQKRX60eiurXtx31HFXnDGe5vok153fwLSx9bzz8pmkEnHSyRjN6SSxWDBfzE9HmEWwDLjJzO4GLgMOaH5ARGrVwy/s4X986+h1zpa+6xLGNtaRSsSYMqaelqZUCOlOT2BFYGbfBa4GWsysA/hbIAng7v8PWA5cD6wHDgF/HlQWEZGT1ZnJ87HvPcme7iyZfIl93TkAvvHuds6fOpp0Ik5DKk4yPvxvxwryqqG3DbDfgQ8F9fuLiJys3zy/m637D5HJl9i4u5tfPLOD86Y0M3VMPWe0NtLSlOIVc1pIJeJhRx1Uw24ZahGRIOzuyvLObzx2xLZUIsaXb5zHOZOaQ0o1NFQEIhJZ3dkCe7pyZApFtu7rAeDT153Dmy+ZRjoZJ52IkRgBQz8DURGISCSVSs5VX3yQPZWx/17DdcL3dKgIRCQyenJFth/MkC0U6c4W2dOdY+F5k3jdBZNJJ+M0pRJc2jY27JhDTkUgIpFxw5Lf8NyOriO2zZ81jtfPmxJSotqgIhCRyNjdleMVZ7bw9stmkE7GaKhLcPGM6J0B9KUiEJFImdXSyPUvmxx2jJqiIhCREeu2X23gvjXbyRZKZPJF9h/KDfyhCFIRiMiI9cPVHezqzHLBtNGkk3FeNnU0b75kWtixao6KQERGtPa2sXz9Xe1hx6hpKgIRGTHWbe/kl8/tJJsvkSkU2dmZZeb4hrBj1TwVgYiMGF+491keeHYnAPGYkU7EuGDa4D/IZaRREYjIiJEvlpg3bTT3fPCKEbEq6FDRn5SIjCixmKkETpLOCERkWCsUS2QKJbL5ItlCKew4w5KKQESGrX99aD1fvHfdEdsumzUupDTDl4pARIatF3Z2Myqd4MOvPvPwc4EvmakiOFkqAhEZdtydbKFEvliiOZ1k8VVnhB1pWFMRiMiw8dMntvLXP3yKTP4PcwFtuk/gtKkIRGTYeHZ7J7lCiY9eO4dUMkY6EWfe9NFhxxr2VAQiMqwkYjE+tuCssGOMKLrYVkQk4lQEIjIsuDulkocdY0TS0JCI1KyH1+/mpu8+Tle2QK5ys1h9Mh5yqpFHRSAiNWvdjk72dud4zxVtjK5PkkrGOHdSc9ixRhwVgYjUvJtfM4cxDXVhxxixNEcgIhJxOiMQkZqRK5T4+dodHOjJk8kXefiFPWFHigQVgYjUjF8+t4sP3bX6iG2TmtPU12mCOEgqAhGpGb1XBt31/suYO7mZdDJOXTxGLGYhJxvZVAQiUnNamlKaHB5CgU4Wm9lCM1tnZuvN7FP97J9hZg+a2eNm9pSZXR9kHhEROVpgZwRmFgeWAAuADmCFmS1z97VVh/0N8H13/5qZzQWWA21BZRKR2nMoV6AzUyCTL/LSgZ6w40RSkEND84H17r4BwMzuBm4AqovAgd67Q0YD2wLMIyI1ZuPubl77lV+SLx65dITuHh5aQRbBVGBL1fsO4LI+x9wC3G9mHwYagdf09wuZ2WJgMcCMGTMGPaiIhGN3V5Z80XnvlbM4b0ozqWSMCaPSTB+nZwwMpSCLoL9p/r4rRr0N+Ka7f9nMXg5828zOd/cjnkDt7kuBpQDt7e1adUpkhHn1ORN4xZyWsGNEVpCTxR3A9Kr30zh66Od9wPcB3P0RIA3ob4OIyBAKsghWAHPMbJaZ1QGLgGV9jtkMXAtgZudSLoJdAWYSEZE+AhsacveCmd0E3AfEgTvcfY2Z3QqsdPdlwCeA28zsY5SHjd7j7hr6ERmh3J07H97ESwcyZPJFtu7XVUK1INAbytx9OeVLQqu3fbbq9VrgyiAziEjt6NjXwy3/sZa6eIz6ujipRIxzJo1iVmtj2NEiTXcWi8iQKVVO+D//5pfxpounhZxGemkZahGRiFMRiIhEnIpARCTiNEcgIoEplZwP/Psq1u/qIpsvcShXACBmWla6lqgIRCQw2UKJ+9fu4NzJzVw0fSzpZIymdIKrzmoNO5pUURGISOBuuHAKH3jVGWHHkGPQHIGISMSpCEREIk5FICIScZojEJFBtaszy+a9h8jmixzM5MOOIydARSAig+pPlvz2qMXkRtcnQ0ojJ0JFICKD6mAmz2vnTuS9r5hFOhmnoS7OnAlNYceS41ARiMigmzq2nstnjw87hpwgTRaLiEScikBEJOI0NCQip+WO32zkwXU7yeSLZPIlurOFsCPJSdIZgYiclu889iJPbz1AIhajpamOPzpvEq+fNyXsWHISdEYgIqftijNbWPL2i8OOIadIZwQiIhGnIhARiTgVgYhIxKkIREQiTpPFInJSfvrEVn7y+FYy+RKZQpEt+3o4Z3Jz2LHkNOiMQEROyt2/28LvNu6lWHKaUgmumtPCn148LexYchp0RiAiJ+28KaP5/gdeHnYMGSQ6IxARiTgVgYhIxKkIREQiTkUgIhJxgU4Wm9lC4KtAHLjd3T/fzzE3ArcADjzp7m8PMpOInJx/f/RFljy4/vDqoj35IpfPHhd2LBlEgRWBmcWBJcACoANYYWbL3H1t1TFzgE8DV7r7PjObEFQeETk1KzbtpTNT4E0XTyWViJFOxrn67NawY8kgCvKMYD6w3t03AJjZ3cANwNqqY94PLHH3fQDuvjPAPCJyilqa6rj1hvPDjiEBCXKOYCqwpep9R2VbtbOAs8zst2b2aGUo6ShmttjMVprZyl27dgUUV0QkmoIsAutnm/d5nwDmAFcDbwNuN7MxR33Ifam7t7t7e2urTklFRAZTkEXQAUyvej8N2NbPMT9197y7bwTWUS4GEREZIkEWwQpgjpnNMrM6YBGwrM8xPwGuATCzFspDRRsCzCQiIn0ENlns7gUzuwm4j/Llo3e4+xozuxVY6e7LKvtea2ZrgSLwSXffE1QmERnYs9sPcufDm+jJFckWSqzevI/6ZDzsWBKgQO8jcPflwPI+2z5b9dqBj1d+iEgN+NHqrXz3d1uYMa6BdDLGxOY0V5+tK7tHMq0+KiJHcHca6uL86q+uCTuKDBEtMSEiEnEqAhGRiFMRiIhEnIpARA5zd0p9b/uUEU+TxSIR95vnd3Pz957gUK5AJl+k5DAqrS8NUaL/2yIR98xLB9ndleXdL5/JqHSSdDLG3CnNYceSIXTcIjCzb7r7eyqv3+3udw5JKhEZcp9ceA5NKX1vGEUDzRHMq3r90SCDiIhIOAYqAk0biYiMcAOdB04zs3+mvKR07+vD3P0jgSUTkUAUiiUe3bCXzkyeTKHIEx37w44kIRuoCD5Z9XplkEFEZGg88OxOFn971RHbxjYkqYvravKoOm4RaHJYZOTpyRcBuP3P2jljQhPpZIwx9XXUJVQEUTXg/3kze7eZrTaz7sqPlWb2Z0MRTkSCM7u1kVktjUweXU99nZaZjrKBLh/9M+BmystEr6Y8V3Ax8CUzw92/FXxEEREJ0kBnBP8TeKO7P+juB9x9v7s/ALy5sk9ERIa5gYqg2d039d1Y2aZbD0VERoCBrhrqOcV9IlIjDmby3Pofa9nbnSOTL7L9QCbsSFJjBiqCc83sqX62GzA7gDwiMsie3nqAe1Z1MLulkXGNdUwZU89FM8YybWxD2NGkRgxUBPOAicCWPttnAtsCSSQigfj7N72My2ePDzuG1KCB5gi+Ahx09xerfwCHKvtERGSYG6gI2tz9qKEhd18JtAWSSEREhtRARZA+zr76wQwiIiLhGGiOYIWZvd/db6veaGbvA1Yd4zMiEqJSybnjtxvZcTBDtlBiy95DYUeSGjdQEdwM/NjM3sEfvvC3A3XAG4MMJiKnZtOebv7uZ89QF4/RkIqTTsSZO7mZWS2NYUeTGjXQonM7gCvM7Brg/Mrmn1XuLhaRGtT78Pl/uHEeb5g3JdwwMiyc0HPp3P1B4MGAs4iISAi07qyISMSpCEREIu6EhoZEpLbdt2Y7L+7pJpMvsf2g1hKSk6MiEBnmurMF/qLq0ZOJmDG2IclsXSUkJyjQIjCzhcBXgThwu7t//hjH/SnwA+DSyl3LInKCil6+TOivF57D+185i4SePSwnKbC/MWYWB5YA1wFzgbeZ2dx+jhsFfAR4LKgsIlGQjJtKQE5JkH9r5gPr3X2Du+eAu4Eb+jnuc8AXAQ1sioiEIMgimMqRy1d3VLYdZmYXAdPd/T+P9wuZ2WIzW2lmK3ft2jX4SUVEIizIIrB+tvnhnWYxyktZf2KgX8jdl7p7u7u3t7a2DmJEEREJcrK4A5he9X4aRz7MZhTlZSseMjOAScAyM3uDJoxFju+v7nmSxzfvJ1Mo0pMrAVD5dyRy0oIsghXAHDObBWwFFgFv793p7geAlt73ZvYQ8JcqAZGBLXtyG1PG1NM+cxzpZIyGugTXnT8p7FgyTAVWBO5eMLObgPsoXz56h7uvMbNbgZXuviyo31skChacO5FPX39u2DFkBAj0PgJ3Xw4s77Pts8c49uogs4iISP900bGISMSpCEREIk5rDYkMA79Yu4PfbdpLJl8kmy+RK5TCjiQjiIpAZBj4u5+tZcu+HkalE6QTcWaOb6S9bVzYsWSEUBGIDAMlhzfMm8JX3nph2FFkBNIcgYhIxKkIREQiTkNDIjVo4+5uVmzaS7ZQIpsvcqAnH3YkGcFUBCI16DM//j0Pv7DniG164pgERUUgUoNyhRLtM8fytXdeQioZI52IU5fQSK4EQ0UgUqNSyRito1Jhx5AI0LcYIiIRpzMCkRrg7uztzpGpTA4fyhVJJfV9mgwNFYFIDfj75c9w2683HrHtNedOCCmNRI2KQKQGbN3fQ+uoFJ9YcBbpZJx0MsaF08eGHUsiQkUgUiPG1CdZNH9G2DEkgjQIKSIScTojEAlRoVgiUyiRK3jYUSTCVAQiIbjrsc387bKnyRf/UABzJzeHmEiiTEUgEoLndnRiZnx8wRzSyRjpZJyLZ2hyWMKhIhAJSX0yzkeunRN2DBFNFouIRJ2KQEQk4jQ0JDIEVmzayy3L1nAoVySTL7LvUI50Mh52LBFARSAyJH63cS9rth3kdRdMpiEZJ6U7h6WGqAhEhtA/3jiPVEJnAlJbNEcgIhJxOiMQCcCBQ3m+9cgmDmbyZAslntiyP+xIIsekIhAJwAPrdvDlnz9HKhGjvi5OOhHnlXNaSMZ0Ei61R0UgEoBiqfzzLz7+KqaPawg3jMgAAv32xMwWmtk6M1tvZp/qZ//HzWytmT1lZv9tZjODzCMiIkcL7IzAzOLAEmAB0AGsMLNl7r626rDHgXZ3P2RmHwS+CLw1qEwiQenJFfn6r15g/6E8mXyR53d2hR1J5IQFOTQ0H1jv7hsAzOxu4AbgcBG4+4NVxz8KvDPAPCKBWfXiPv7pF8/TlErQUBcnnYwzf9Y4Wkelwo4mMqAgi2AqsKXqfQdw2XGOfx/wX/3tMLPFwGKAGTP0BCepPSUvLyd953sv5ZKZ40JOI3JygpwjsH629fv0DTN7J9AOfKm//e6+1N3b3b29tbV1ECOKiEiQZwQdwPSq99OAbX0PMrPXAJ8BXuXu2QDziAyqlw70sLszR6ZQZM22g2HHETllQRbBCmCOmc0CtgKLgLdXH2BmFwFfBxa6+84As4gMqm37e7jyCw/gfc5xR6WT4QQSOQ2BFYG7F8zsJuA+IA7c4e5rzOxWYKW7L6M8FNQE/MDMADa7+xuCyiQyWA5m8rjDB68+gyvOGE86GWdcYx1ntDaFHU3kpAV6Q5m7LweW99n22arXrwny9xcZTM/t6GTr/h6y+SIbdx8C4IKpo3nlHM1byfCmO4tFTkBXtsB1X/01xdKRY0Hjm3R5qAx/KgKRE5ArlCiWnPe/chZvvGgaqWSM5nRS9wnIiKAiEDmGJ7bsZ/3OLrKFIvu6cwBMG9vA3CnNIScTGVwqApFjeMdtj9KdKx5+HzOYPq4+xEQiwVARiBxDtlDiXZfP5MOvPpNUIk66Lqani8mIpCIQqbjrsc08smEPmXyRbKFEoeQ01yeY0JwOO5pIoFQEIhX/8sDzdGYKTB1bTzoZ54ozxnPN2RPCjiUSOBWBSJWF50/iS2+ZF3YMkSGlIpDI+ukTW7n36e2Hh4J2d+XCjiQSChWBRNYdv93E+h2dzG5tIpWIMX/WOK6/YHLYsUSGnIpAIsPd2d2VI1soksmXyOSKtLeN4873zg87mkioVAQSGbcsW8Odj7x4xLZZLY0hpRGpHSoCiYxtBzJMak7z8QVnkUrGSCfjXDRjTNixREKnIpARy93Z2ZmlJ1ckUyhysCfP2MY6brx0+sAfFokQFYGMWP/3gfX848+fO2LbJTPHhpRGpHapCGTE2nEwQ1Mqwa03nEc6GSeViGnBOJF+qAhkxFixaS//Z/kzHMoVyeSL7OzM0lCX4E0XTws7mkhNUxHIsOXuPLeji85MnmyhxA9WbmH15v0smDuR+soZwKVt48KOKVLzVAQybC3//XY+dNfqI7aNSidY+q5LqDwDW0ROgIpAho2dBzN8+ke/Z39Pnky+yK7OLABfXXQhk5rTpJNxpoypVwmInCQVgdS0nZ0Z9nbnyORLPPLCHv772Z3Mmz6GSc1p2sY3MnVsPa+/YAqxmL74i5wqFYHUDHfnH+5fR8e+HjL5Ii/uOcSz2zuPOu4rN85jdmtTCAlFRiYVgYTq2e0H2bS7m0y+xO6uLEsefIHxjXW0NKVIJ2PMndzMW9qn0Ta+kVQyRktTSiUgMshUBDKkfvL4VlZs2ku2UKInX+RnT7101DFfessFvPqciSGkE4kmFYEMOncnVyyRyZf44aoOVm3eRzZfIlso8uvndwMwZXR5cnfOhCYWzZ/B1We3kk7GaapLMLohGfJ/gUi0qAjktBzKFXhi83568uWlnb/638/x3I6uo447d3Iz6WSMl88ez1+8ajZX6xGQIjVDRSADcneyhRLZfImHntvJ0l9tIF/5jn/z3kP9fuaTf3Q2qUSMVDLOK89soU3LPYvULBWBHNevn9/Fe7+5gnzRj9i+8LxJh7/DH9OY5PrzJ5eXdk7EmTwmTSoRDymxiJwsFYEc4aUDPXzmx0+z/1CObKHEzs4s+aJz0zVnMraxjlQixpwJTVw2e3zYUUVkkKgIRrBSqTyks3V/T+WmrPJD2tfv7CIZt8P7fvr4VlLJOPlCic5sAShP5p47uZm28Y1MH9fAJ157lu7YFRmhVATDRCZfJJsvkSkUeelAht2dWTKVZ+8+1bGfmBmZfHnVzZ88sQ0zcB/41+114YwxnDVxFOlknNamFO+5ok1364pERKBFYGYLga8CceB2d/98n/0p4FvAJcAe4K3uvinITLWkdxL2UK7I+p1d5AolMvki63Z0suNg5vCE7LInt1EsDfxVfcKoFKlkjNmtjYxtqOOVc1pIJeIkYsak0WkmVy7ZrEvEmNicLk/mJmL6Tl8k4gIrAjOLA0uABUAHsMLMlrn72qrD3gfsc/czzWwR8AXgrUFlGoi7Uyw5hd4fxRL5olMolSgUnXyxRKFU/rlY8vK+qm2FyrH5olf2l/ft7c7xwLM7qU/GyeSLbNrTze6u3IB5WkeV766d1dKIAW+bP+PwhGxTOsGslkbSiTipZIzWppS+gxeRUxLkGcF8YL27bwAws7uBG4DqIrgBuKXy+h7gX8zM3E9mUOPEfG/FZr7+qw0U+nyR7vsFPEiTR6eZ1dLIBdPG0JnJc2nbOJrSicNX2Lxs6mjSlYeqT2xOM7peN1aJSPCCLIKpwJaq9x3AZcc6xt0LZnYAGA/srj7IzBYDiwFmzJhxSmHGNaY4d3IzyZgRj8VIxo1E3Egcfh0jGSv/HI9ZeVvVvkTMSMZjhz+TiJU/n4z3vo4d8Zl4n+Mb6uI0pjQlIyK1J8ivTP2NU/T9lvtEjsHdlwJLAdrb20/p2/YFcyeyYK7WrxER6SsW4K/dAUyvej8N2HasY8wsAYwG9gaYSURE+giyCFYAc8xslpnVAYuAZX2OWQa8u/L6T4EHgpgfEBGRYwtsaKgy5n8TcB/ly0fvcPc1ZnYrsNLdlwHfAL5tZuspnwksCiqPiIj0L9DZS3dfDizvs+2zVa8zwFuCzCAiIscX5NCQiIgMAyoCEZGIUxGIiEScikBEJOJsuF2taWa7gBfDznEMLfS5K7qGKNupUbZTo2ynJshsM929tb8dw64IapmZrXT39rBz9EfZTo2ynRplOzVhZdPQkIhIxKkIREQiTkUwuJaGHeA4lO3UKNupUbZTE0o2zRGIiESczghERCJORSAiEnEqgtNkZtPN7EEze8bM1pjZR8PO1MvM0mb2OzN7spLtf4edqS8zi5vZ42b2n2FnqWZmm8zs92b2hJmtDDtPNTMbY2b3mNmzlb93Lw87E4CZnV358+r9cdDMbg47Vy8z+1jl38HTZvZdM0uHnamXmX20kmtNGH9mmiM4TWY2GZjs7qvNbBSwCvgTd187wEcDZ2YGNLp7l5klgd8AH3X3R0OOdpiZfRxoB5rd/Y/DztPLzDYB7e5eczcemdmdwK/d/fbKsz4a3H1/2LmqmVkc2Apc5u6h3wBqZlMp//2f6+49ZvZ9YLm7fzPcZGBm5wN3U37Oew64F/iguz8/VBl0RnCa3P0ld19ded0JPEP5Wcyh87Kuyttk5UfNNL+ZTQNeB9wedpbhwsyagasoP8sDd8/VWglUXAu8UAslUCUB1FeehtjA0U9MDMu5wKPufsjdC8AvgTcOZQAVwSAyszbgIuCxcJP8QWXo5QlgJ/Bzd6+ZbMA/AX8FlMIO0g8H7jezVWa2OOwwVWYDu4B/qwyp3W5mjWGH6sci4Lthh+jl7luBfwA2Ay8BB9z9/nBTHfY0cJWZjTezBuB6jnzMb+BUBIPEzJqAHwI3u/vBsPP0cveiu19I+ZnR8yunoaEzsz8Gdrr7qrCzHMOV7n4xcB3wITO7KuxAFQngYuBr7n4R0A18KtxIR6oMV70B+EHYWXqZ2VjgBmAWMAVoNLN3hpuqzN2fAb4A/JzysNCTQGEoM6gIBkFl/P2HwHfc/Udh5+lPZfjgIWBhyFF6XQm8oTIWfzfwajP793Aj/YG7b6v8vBP4MeXx21rQAXRUndndQ7kYasl1wGp33xF2kCqvATa6+y53zwM/Aq4IOdNh7v4Nd7/Y3a+i/NjeIZsfABXBaatMyH4DeMbd/zHsPNXMrNXMxlRe11P+x/BsuKnK3P3T7j7N3dsoDyM84O418R2amTVWJv6pDLu8lvLpe+jcfTuwxczOrmy6Fgj9woQ+3kYNDQtVbAYuN7OGyr/ZaynP59UEM5tQ+XkG8CaG+M8v0GcWR8SVwLuA31fG4gH+V+V5zWGbDNxZuYIjBnzf3WvqMs0aNRH4cfnrBQngLne/N9xIR/gw8J3KEMwG4M9DznNYZYx7AfAXYWep5u6Pmdk9wGrKwy6PU1tLTfzQzMYDeeBD7r5vKH9zXT4qIhJxGhoSEYk4FYGISMSpCEREIk5FICIScSoCEZGIUxHIiGRmXZWf28zMzexzVftazCxvZv9SeX+LmW2trJj5vJn9yMzmVh3/kJmtq+x/5lhLTlQd96SZrTCzC08g582VSy573y/vvfdDZKioCCQKNgDVK5u+BVjT55ivuPuF7j4H+B7wgJm1Vu1/R2WpjiuBL1Su4e/PO9x9HvCvwJdOINvNlBdAA8Ddr6/RReRkBFMRSBT0AM+YWXvl/VuB7x/rYHf/HnA/8PZ+djdRXt+nOMDv+QhVq9Ca2dfMbGX1cyHM7COU17150MwerGzbVDljaaucfdxW+cz9lbvDMbNLzewpM3vEzL5kZjVx17MMXyoCiYq7gUWVpa+LDLwE8WrgnKr33zGzp4B1wOfcfaAiWAj8pOr9Z9y9HbgAeJWZXeDu/1zJcY27X9PPrzEHWOLu5wH7gTdXtv8b8AF3fzkDF5LIgLTEhETFvcDngB2Uh34GYn3ev8PdV1aGix42s3uPsdb+dyrrE8U5cjG4GytzCwnKS3/MBZ4aIMNGd+9dtmQV0FaZPxjl7g9Xtt/FkcNeIidNZwQSCe6eo/zF9BOUV4odyEX0syiZu++ifLZw2TE+9w7KSx3fBSwBMLNZwF8C17r7BcDPgBN5TGK26nWRcon0LSiR06YikCj5MvDX7r7neAeZ2Zsprzh61AqQlSt8LgJeONbnK8sc/w3l1S7PBZopzyscMLOJlJdp7tUJjDrR/4DKYmSdZnZ5ZdOiE/2syLFoaEgiw93XcPTVQr0+VnlQSSPlJadfXfnuv7hXMN4AAACPSURBVNd3zKwHSAHfHOiBOpXn4n4Z+Et3f5+ZPV75vTcAv606dCnwX2b20jHmCfrzPuA2M+um/IyJAyf4OZF+afVRkWHGzJp6n0VtZp8CJrv7R0OOJcOYzghEhp/XmdmnKf/7fRF4T7hxZLjTGYGISMRpslhEJOJUBCIiEaciEBGJOBWBiEjEqQhERCLu/wPTOH5IfxQcAAAAAABJRU5ErkJggg==\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEGCAYAAABo25JHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nO3deZxddX3/8dfnLnPvLJlsM9mXSSAsAQnLEBAUQYwNWKVqxbhVqz9T/YmKWlv92Yflh33051Jr7a+pPwNS0YqouKU1BbSAG4tZWCSBQEhCMgnZt5nJ3P3z++PeiTeTSSbLnDl35ryfj0ceufecc5M3IZn3nO/3nO8xd0dERKIrFnYAEREJl4pARCTiVAQiIhGnIhARiTgVgYhIxCXCDnCyWlpavK2tLewYIiLDyqpVq3a7e2t/+4ZdEbS1tbFy5cqwY4iIDCtm9uKx9mloSEQk4lQEIiIRpyIQEYk4FYGISMSpCEREIi6wIjCzO8xsp5k9fYz9Zmb/bGbrzewpM7s4qCwiInJsQZ4RfBNYeJz91wFzKj8WA18LMIuIiBxDYPcRuPuvzKztOIfcAHzLy+tgP2pmY8xssru/FFQmEZFasbsry3PbO8kVSxSKTr5YIlcska+8LhRL5Cqv84US+ZJz7TkTmDd9zKBnCfOGsqnAlqr3HZVtRxWBmS2mfNbAjBkzhiSciMjp2Ned45ENe8jki2TyJX6wagu7u7Jk8yWyhRIHevIn/WtObE6NuCKwfrb1+5Qcd18KLAVob2/Xk3REJHTuzrPbO+nKFsjmSzy2cQ8rNu2lUHQyhSJPbz3Y7+cWXTqdVCJGOhlnYnOaedPHUBePkUwYyXiMZKzqdTxGXTxGIm4kYoZZf182T1+YRdABTK96Pw3YFlIWEZHjKhRLPLRuFwd68mQKRX60eiurXtx31HFXnDGe5vok153fwLSx9bzz8pmkEnHSyRjN6SSxWDBfzE9HmEWwDLjJzO4GLgMOaH5ARGrVwy/s4X986+h1zpa+6xLGNtaRSsSYMqaelqZUCOlOT2BFYGbfBa4GWsysA/hbIAng7v8PWA5cD6wHDgF/HlQWEZGT1ZnJ87HvPcme7iyZfIl93TkAvvHuds6fOpp0Ik5DKk4yPvxvxwryqqG3DbDfgQ8F9fuLiJys3zy/m637D5HJl9i4u5tfPLOD86Y0M3VMPWe0NtLSlOIVc1pIJeJhRx1Uw24ZahGRIOzuyvLObzx2xLZUIsaXb5zHOZOaQ0o1NFQEIhJZ3dkCe7pyZApFtu7rAeDT153Dmy+ZRjoZJ52IkRgBQz8DURGISCSVSs5VX3yQPZWx/17DdcL3dKgIRCQyenJFth/MkC0U6c4W2dOdY+F5k3jdBZNJJ+M0pRJc2jY27JhDTkUgIpFxw5Lf8NyOriO2zZ81jtfPmxJSotqgIhCRyNjdleMVZ7bw9stmkE7GaKhLcPGM6J0B9KUiEJFImdXSyPUvmxx2jJqiIhCREeu2X23gvjXbyRZKZPJF9h/KDfyhCFIRiMiI9cPVHezqzHLBtNGkk3FeNnU0b75kWtixao6KQERGtPa2sXz9Xe1hx6hpKgIRGTHWbe/kl8/tJJsvkSkU2dmZZeb4hrBj1TwVgYiMGF+491keeHYnAPGYkU7EuGDa4D/IZaRREYjIiJEvlpg3bTT3fPCKEbEq6FDRn5SIjCixmKkETpLOCERkWCsUS2QKJbL5ItlCKew4w5KKQESGrX99aD1fvHfdEdsumzUupDTDl4pARIatF3Z2Myqd4MOvPvPwc4EvmakiOFkqAhEZdtydbKFEvliiOZ1k8VVnhB1pWFMRiMiw8dMntvLXP3yKTP4PcwFtuk/gtKkIRGTYeHZ7J7lCiY9eO4dUMkY6EWfe9NFhxxr2VAQiMqwkYjE+tuCssGOMKLrYVkQk4lQEIjIsuDulkocdY0TS0JCI1KyH1+/mpu8+Tle2QK5ys1h9Mh5yqpFHRSAiNWvdjk72dud4zxVtjK5PkkrGOHdSc9ixRhwVgYjUvJtfM4cxDXVhxxixNEcgIhJxOiMQkZqRK5T4+dodHOjJk8kXefiFPWFHigQVgYjUjF8+t4sP3bX6iG2TmtPU12mCOEgqAhGpGb1XBt31/suYO7mZdDJOXTxGLGYhJxvZVAQiUnNamlKaHB5CgU4Wm9lCM1tnZuvN7FP97J9hZg+a2eNm9pSZXR9kHhEROVpgZwRmFgeWAAuADmCFmS1z97VVh/0N8H13/5qZzQWWA21BZRKR2nMoV6AzUyCTL/LSgZ6w40RSkEND84H17r4BwMzuBm4AqovAgd67Q0YD2wLMIyI1ZuPubl77lV+SLx65dITuHh5aQRbBVGBL1fsO4LI+x9wC3G9mHwYagdf09wuZ2WJgMcCMGTMGPaiIhGN3V5Z80XnvlbM4b0ozqWSMCaPSTB+nZwwMpSCLoL9p/r4rRr0N+Ka7f9nMXg5828zOd/cjnkDt7kuBpQDt7e1adUpkhHn1ORN4xZyWsGNEVpCTxR3A9Kr30zh66Od9wPcB3P0RIA3ob4OIyBAKsghWAHPMbJaZ1QGLgGV9jtkMXAtgZudSLoJdAWYSEZE+AhsacveCmd0E3AfEgTvcfY2Z3QqsdPdlwCeA28zsY5SHjd7j7hr6ERmh3J07H97ESwcyZPJFtu7XVUK1INAbytx9OeVLQqu3fbbq9VrgyiAziEjt6NjXwy3/sZa6eIz6ujipRIxzJo1iVmtj2NEiTXcWi8iQKVVO+D//5pfxpounhZxGemkZahGRiFMRiIhEnIpARCTiNEcgIoEplZwP/Psq1u/qIpsvcShXACBmWla6lqgIRCQw2UKJ+9fu4NzJzVw0fSzpZIymdIKrzmoNO5pUURGISOBuuHAKH3jVGWHHkGPQHIGISMSpCEREIk5FICIScZojEJFBtaszy+a9h8jmixzM5MOOIydARSAig+pPlvz2qMXkRtcnQ0ojJ0JFICKD6mAmz2vnTuS9r5hFOhmnoS7OnAlNYceS41ARiMigmzq2nstnjw87hpwgTRaLiEScikBEJOI0NCQip+WO32zkwXU7yeSLZPIlurOFsCPJSdIZgYiclu889iJPbz1AIhajpamOPzpvEq+fNyXsWHISdEYgIqftijNbWPL2i8OOIadIZwQiIhGnIhARiTgVgYhIxKkIREQiTpPFInJSfvrEVn7y+FYy+RKZQpEt+3o4Z3Jz2LHkNOiMQEROyt2/28LvNu6lWHKaUgmumtPCn148LexYchp0RiAiJ+28KaP5/gdeHnYMGSQ6IxARiTgVgYhIxKkIREQiTkUgIhJxgU4Wm9lC4KtAHLjd3T/fzzE3ArcADjzp7m8PMpOInJx/f/RFljy4/vDqoj35IpfPHhd2LBlEgRWBmcWBJcACoANYYWbL3H1t1TFzgE8DV7r7PjObEFQeETk1KzbtpTNT4E0XTyWViJFOxrn67NawY8kgCvKMYD6w3t03AJjZ3cANwNqqY94PLHH3fQDuvjPAPCJyilqa6rj1hvPDjiEBCXKOYCqwpep9R2VbtbOAs8zst2b2aGUo6ShmttjMVprZyl27dgUUV0QkmoIsAutnm/d5nwDmAFcDbwNuN7MxR33Ifam7t7t7e2urTklFRAZTkEXQAUyvej8N2NbPMT9197y7bwTWUS4GEREZIkEWwQpgjpnNMrM6YBGwrM8xPwGuATCzFspDRRsCzCQiIn0ENlns7gUzuwm4j/Llo3e4+xozuxVY6e7LKvtea2ZrgSLwSXffE1QmERnYs9sPcufDm+jJFckWSqzevI/6ZDzsWBKgQO8jcPflwPI+2z5b9dqBj1d+iEgN+NHqrXz3d1uYMa6BdDLGxOY0V5+tK7tHMq0+KiJHcHca6uL86q+uCTuKDBEtMSEiEnEqAhGRiFMRiIhEnIpARA5zd0p9b/uUEU+TxSIR95vnd3Pz957gUK5AJl+k5DAqrS8NUaL/2yIR98xLB9ndleXdL5/JqHSSdDLG3CnNYceSIXTcIjCzb7r7eyqv3+3udw5JKhEZcp9ceA5NKX1vGEUDzRHMq3r90SCDiIhIOAYqAk0biYiMcAOdB04zs3+mvKR07+vD3P0jgSUTkUAUiiUe3bCXzkyeTKHIEx37w44kIRuoCD5Z9XplkEFEZGg88OxOFn971RHbxjYkqYvravKoOm4RaHJYZOTpyRcBuP3P2jljQhPpZIwx9XXUJVQEUTXg/3kze7eZrTaz7sqPlWb2Z0MRTkSCM7u1kVktjUweXU99nZaZjrKBLh/9M+BmystEr6Y8V3Ax8CUzw92/FXxEEREJ0kBnBP8TeKO7P+juB9x9v7s/ALy5sk9ERIa5gYqg2d039d1Y2aZbD0VERoCBrhrqOcV9IlIjDmby3Pofa9nbnSOTL7L9QCbsSFJjBiqCc83sqX62GzA7gDwiMsie3nqAe1Z1MLulkXGNdUwZU89FM8YybWxD2NGkRgxUBPOAicCWPttnAtsCSSQigfj7N72My2ePDzuG1KCB5gi+Ahx09xerfwCHKvtERGSYG6gI2tz9qKEhd18JtAWSSEREhtRARZA+zr76wQwiIiLhGGiOYIWZvd/db6veaGbvA1Yd4zMiEqJSybnjtxvZcTBDtlBiy95DYUeSGjdQEdwM/NjM3sEfvvC3A3XAG4MMJiKnZtOebv7uZ89QF4/RkIqTTsSZO7mZWS2NYUeTGjXQonM7gCvM7Brg/Mrmn1XuLhaRGtT78Pl/uHEeb5g3JdwwMiyc0HPp3P1B4MGAs4iISAi07qyISMSpCEREIu6EhoZEpLbdt2Y7L+7pJpMvsf2g1hKSk6MiEBnmurMF/qLq0ZOJmDG2IclsXSUkJyjQIjCzhcBXgThwu7t//hjH/SnwA+DSyl3LInKCil6+TOivF57D+185i4SePSwnKbC/MWYWB5YA1wFzgbeZ2dx+jhsFfAR4LKgsIlGQjJtKQE5JkH9r5gPr3X2Du+eAu4Eb+jnuc8AXAQ1sioiEIMgimMqRy1d3VLYdZmYXAdPd/T+P9wuZ2WIzW2lmK3ft2jX4SUVEIizIIrB+tvnhnWYxyktZf2KgX8jdl7p7u7u3t7a2DmJEEREJcrK4A5he9X4aRz7MZhTlZSseMjOAScAyM3uDJoxFju+v7nmSxzfvJ1Mo0pMrAVD5dyRy0oIsghXAHDObBWwFFgFv793p7geAlt73ZvYQ8JcqAZGBLXtyG1PG1NM+cxzpZIyGugTXnT8p7FgyTAVWBO5eMLObgPsoXz56h7uvMbNbgZXuviyo31skChacO5FPX39u2DFkBAj0PgJ3Xw4s77Pts8c49uogs4iISP900bGISMSpCEREIk5rDYkMA79Yu4PfbdpLJl8kmy+RK5TCjiQjiIpAZBj4u5+tZcu+HkalE6QTcWaOb6S9bVzYsWSEUBGIDAMlhzfMm8JX3nph2FFkBNIcgYhIxKkIREQiTkNDIjVo4+5uVmzaS7ZQIpsvcqAnH3YkGcFUBCI16DM//j0Pv7DniG164pgERUUgUoNyhRLtM8fytXdeQioZI52IU5fQSK4EQ0UgUqNSyRito1Jhx5AI0LcYIiIRpzMCkRrg7uztzpGpTA4fyhVJJfV9mgwNFYFIDfj75c9w2683HrHtNedOCCmNRI2KQKQGbN3fQ+uoFJ9YcBbpZJx0MsaF08eGHUsiQkUgUiPG1CdZNH9G2DEkgjQIKSIScTojEAlRoVgiUyiRK3jYUSTCVAQiIbjrsc387bKnyRf/UABzJzeHmEiiTEUgEoLndnRiZnx8wRzSyRjpZJyLZ2hyWMKhIhAJSX0yzkeunRN2DBFNFouIRJ2KQEQk4jQ0JDIEVmzayy3L1nAoVySTL7LvUI50Mh52LBFARSAyJH63cS9rth3kdRdMpiEZJ6U7h6WGqAhEhtA/3jiPVEJnAlJbNEcgIhJxOiMQCcCBQ3m+9cgmDmbyZAslntiyP+xIIsekIhAJwAPrdvDlnz9HKhGjvi5OOhHnlXNaSMZ0Ei61R0UgEoBiqfzzLz7+KqaPawg3jMgAAv32xMwWmtk6M1tvZp/qZ//HzWytmT1lZv9tZjODzCMiIkcL7IzAzOLAEmAB0AGsMLNl7r626rDHgXZ3P2RmHwS+CLw1qEwiQenJFfn6r15g/6E8mXyR53d2hR1J5IQFOTQ0H1jv7hsAzOxu4AbgcBG4+4NVxz8KvDPAPCKBWfXiPv7pF8/TlErQUBcnnYwzf9Y4Wkelwo4mMqAgi2AqsKXqfQdw2XGOfx/wX/3tMLPFwGKAGTP0BCepPSUvLyd953sv5ZKZ40JOI3JygpwjsH629fv0DTN7J9AOfKm//e6+1N3b3b29tbV1ECOKiEiQZwQdwPSq99OAbX0PMrPXAJ8BXuXu2QDziAyqlw70sLszR6ZQZM22g2HHETllQRbBCmCOmc0CtgKLgLdXH2BmFwFfBxa6+84As4gMqm37e7jyCw/gfc5xR6WT4QQSOQ2BFYG7F8zsJuA+IA7c4e5rzOxWYKW7L6M8FNQE/MDMADa7+xuCyiQyWA5m8rjDB68+gyvOGE86GWdcYx1ntDaFHU3kpAV6Q5m7LweW99n22arXrwny9xcZTM/t6GTr/h6y+SIbdx8C4IKpo3nlHM1byfCmO4tFTkBXtsB1X/01xdKRY0Hjm3R5qAx/KgKRE5ArlCiWnPe/chZvvGgaqWSM5nRS9wnIiKAiEDmGJ7bsZ/3OLrKFIvu6cwBMG9vA3CnNIScTGVwqApFjeMdtj9KdKx5+HzOYPq4+xEQiwVARiBxDtlDiXZfP5MOvPpNUIk66Lqani8mIpCIQqbjrsc08smEPmXyRbKFEoeQ01yeY0JwOO5pIoFQEIhX/8sDzdGYKTB1bTzoZ54ozxnPN2RPCjiUSOBWBSJWF50/iS2+ZF3YMkSGlIpDI+ukTW7n36e2Hh4J2d+XCjiQSChWBRNYdv93E+h2dzG5tIpWIMX/WOK6/YHLYsUSGnIpAIsPd2d2VI1soksmXyOSKtLeN4873zg87mkioVAQSGbcsW8Odj7x4xLZZLY0hpRGpHSoCiYxtBzJMak7z8QVnkUrGSCfjXDRjTNixREKnIpARy93Z2ZmlJ1ckUyhysCfP2MY6brx0+sAfFokQFYGMWP/3gfX848+fO2LbJTPHhpRGpHapCGTE2nEwQ1Mqwa03nEc6GSeViGnBOJF+qAhkxFixaS//Z/kzHMoVyeSL7OzM0lCX4E0XTws7mkhNUxHIsOXuPLeji85MnmyhxA9WbmH15v0smDuR+soZwKVt48KOKVLzVAQybC3//XY+dNfqI7aNSidY+q5LqDwDW0ROgIpAho2dBzN8+ke/Z39Pnky+yK7OLABfXXQhk5rTpJNxpoypVwmInCQVgdS0nZ0Z9nbnyORLPPLCHv772Z3Mmz6GSc1p2sY3MnVsPa+/YAqxmL74i5wqFYHUDHfnH+5fR8e+HjL5Ii/uOcSz2zuPOu4rN85jdmtTCAlFRiYVgYTq2e0H2bS7m0y+xO6uLEsefIHxjXW0NKVIJ2PMndzMW9qn0Ta+kVQyRktTSiUgMshUBDKkfvL4VlZs2ku2UKInX+RnT7101DFfessFvPqciSGkE4kmFYEMOncnVyyRyZf44aoOVm3eRzZfIlso8uvndwMwZXR5cnfOhCYWzZ/B1We3kk7GaapLMLohGfJ/gUi0qAjktBzKFXhi83568uWlnb/638/x3I6uo447d3Iz6WSMl88ez1+8ajZX6xGQIjVDRSADcneyhRLZfImHntvJ0l9tIF/5jn/z3kP9fuaTf3Q2qUSMVDLOK89soU3LPYvULBWBHNevn9/Fe7+5gnzRj9i+8LxJh7/DH9OY5PrzJ5eXdk7EmTwmTSoRDymxiJwsFYEc4aUDPXzmx0+z/1CObKHEzs4s+aJz0zVnMraxjlQixpwJTVw2e3zYUUVkkKgIRrBSqTyks3V/T+WmrPJD2tfv7CIZt8P7fvr4VlLJOPlCic5sAShP5p47uZm28Y1MH9fAJ157lu7YFRmhVATDRCZfJJsvkSkUeelAht2dWTKVZ+8+1bGfmBmZfHnVzZ88sQ0zcB/41+114YwxnDVxFOlknNamFO+5ok1364pERKBFYGYLga8CceB2d/98n/0p4FvAJcAe4K3uvinITLWkdxL2UK7I+p1d5AolMvki63Z0suNg5vCE7LInt1EsDfxVfcKoFKlkjNmtjYxtqOOVc1pIJeIkYsak0WkmVy7ZrEvEmNicLk/mJmL6Tl8k4gIrAjOLA0uABUAHsMLMlrn72qrD3gfsc/czzWwR8AXgrUFlGoi7Uyw5hd4fxRL5olMolSgUnXyxRKFU/rlY8vK+qm2FyrH5olf2l/ft7c7xwLM7qU/GyeSLbNrTze6u3IB5WkeV766d1dKIAW+bP+PwhGxTOsGslkbSiTipZIzWppS+gxeRUxLkGcF8YL27bwAws7uBG4DqIrgBuKXy+h7gX8zM3E9mUOPEfG/FZr7+qw0U+nyR7vsFPEiTR6eZ1dLIBdPG0JnJc2nbOJrSicNX2Lxs6mjSlYeqT2xOM7peN1aJSPCCLIKpwJaq9x3AZcc6xt0LZnYAGA/srj7IzBYDiwFmzJhxSmHGNaY4d3IzyZgRj8VIxo1E3Egcfh0jGSv/HI9ZeVvVvkTMSMZjhz+TiJU/n4z3vo4d8Zl4n+Mb6uI0pjQlIyK1J8ivTP2NU/T9lvtEjsHdlwJLAdrb20/p2/YFcyeyYK7WrxER6SsW4K/dAUyvej8N2HasY8wsAYwG9gaYSURE+giyCFYAc8xslpnVAYuAZX2OWQa8u/L6T4EHgpgfEBGRYwtsaKgy5n8TcB/ly0fvcPc1ZnYrsNLdlwHfAL5tZuspnwksCiqPiIj0L9DZS3dfDizvs+2zVa8zwFuCzCAiIscX5NCQiIgMAyoCEZGIUxGIiEScikBEJOJsuF2taWa7gBfDznEMLfS5K7qGKNupUbZTo2ynJshsM929tb8dw64IapmZrXT39rBz9EfZTo2ynRplOzVhZdPQkIhIxKkIREQiTkUwuJaGHeA4lO3UKNupUbZTE0o2zRGIiESczghERCJORSAiEnEqgtNkZtPN7EEze8bM1pjZR8PO1MvM0mb2OzN7spLtf4edqS8zi5vZ42b2n2FnqWZmm8zs92b2hJmtDDtPNTMbY2b3mNmzlb93Lw87E4CZnV358+r9cdDMbg47Vy8z+1jl38HTZvZdM0uHnamXmX20kmtNGH9mmiM4TWY2GZjs7qvNbBSwCvgTd187wEcDZ2YGNLp7l5klgd8AH3X3R0OOdpiZfRxoB5rd/Y/DztPLzDYB7e5eczcemdmdwK/d/fbKsz4a3H1/2LmqmVkc2Apc5u6h3wBqZlMp//2f6+49ZvZ9YLm7fzPcZGBm5wN3U37Oew64F/iguz8/VBl0RnCa3P0ld19ded0JPEP5Wcyh87Kuyttk5UfNNL+ZTQNeB9wedpbhwsyagasoP8sDd8/VWglUXAu8UAslUCUB1FeehtjA0U9MDMu5wKPufsjdC8AvgTcOZQAVwSAyszbgIuCxcJP8QWXo5QlgJ/Bzd6+ZbMA/AX8FlMIO0g8H7jezVWa2OOwwVWYDu4B/qwyp3W5mjWGH6sci4Lthh+jl7luBfwA2Ay8BB9z9/nBTHfY0cJWZjTezBuB6jnzMb+BUBIPEzJqAHwI3u/vBsPP0cveiu19I+ZnR8yunoaEzsz8Gdrr7qrCzHMOV7n4xcB3wITO7KuxAFQngYuBr7n4R0A18KtxIR6oMV70B+EHYWXqZ2VjgBmAWMAVoNLN3hpuqzN2fAb4A/JzysNCTQGEoM6gIBkFl/P2HwHfc/Udh5+lPZfjgIWBhyFF6XQm8oTIWfzfwajP793Aj/YG7b6v8vBP4MeXx21rQAXRUndndQ7kYasl1wGp33xF2kCqvATa6+y53zwM/Aq4IOdNh7v4Nd7/Y3a+i/NjeIZsfABXBaatMyH4DeMbd/zHsPNXMrNXMxlRe11P+x/BsuKnK3P3T7j7N3dsoDyM84O418R2amTVWJv6pDLu8lvLpe+jcfTuwxczOrmy6Fgj9woQ+3kYNDQtVbAYuN7OGyr/ZaynP59UEM5tQ+XkG8CaG+M8v0GcWR8SVwLuA31fG4gH+V+V5zWGbDNxZuYIjBnzf3WvqMs0aNRH4cfnrBQngLne/N9xIR/gw8J3KEMwG4M9DznNYZYx7AfAXYWep5u6Pmdk9wGrKwy6PU1tLTfzQzMYDeeBD7r5vKH9zXT4qIhJxGhoSEYk4FYGISMSpCEREIk5FICIScSoCEZGIUxHIiGRmXZWf28zMzexzVftazCxvZv9SeX+LmW2trJj5vJn9yMzmVh3/kJmtq+x/5lhLTlQd96SZrTCzC08g582VSy573y/vvfdDZKioCCQKNgDVK5u+BVjT55ivuPuF7j4H+B7wgJm1Vu1/R2WpjiuBL1Su4e/PO9x9HvCvwJdOINvNlBdAA8Ddr6/RReRkBFMRSBT0AM+YWXvl/VuB7x/rYHf/HnA/8PZ+djdRXt+nOMDv+QhVq9Ca2dfMbGX1cyHM7COU17150MwerGzbVDljaaucfdxW+cz9lbvDMbNLzewpM3vEzL5kZjVx17MMXyoCiYq7gUWVpa+LDLwE8WrgnKr33zGzp4B1wOfcfaAiWAj8pOr9Z9y9HbgAeJWZXeDu/1zJcY27X9PPrzEHWOLu5wH7gTdXtv8b8AF3fzkDF5LIgLTEhETFvcDngB2Uh34GYn3ev8PdV1aGix42s3uPsdb+dyrrE8U5cjG4GytzCwnKS3/MBZ4aIMNGd+9dtmQV0FaZPxjl7g9Xtt/FkcNeIidNZwQSCe6eo/zF9BOUV4odyEX0syiZu++ifLZw2TE+9w7KSx3fBSwBMLNZwF8C17r7BcDPgBN5TGK26nWRcon0LSiR06YikCj5MvDX7r7neAeZ2Zsprzh61AqQlSt8LgJeONbnK8sc/w3l1S7PBZopzyscMLOJlJdp7tUJjDrR/4DKYmSdZnZ5ZdOiE/2syLFoaEgiw93XcPTVQr0+VnlQSSPlJadfXfnuv7hXMN4AAACPSURBVNd3zKwHSAHfHOiBOpXn4n4Z+Et3f5+ZPV75vTcAv606dCnwX2b20jHmCfrzPuA2M+um/IyJAyf4OZF+afVRkWHGzJp6n0VtZp8CJrv7R0OOJcOYzghEhp/XmdmnKf/7fRF4T7hxZLjTGYGISMRpslhEJOJUBCIiEaciEBGJOBWBiEjEqQhERCLu/wPTOH5IfxQcAAAAAABJRU5ErkJggg==",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
@@ -1842,32 +1836,32 @@
             "needs_background": "light"
           }
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "f8SdTs86_G_W"
-      },
-      "source": [
-        "## A bit more histogram with altair\n",
-        "\n",
-        "As you may remember, you can get a pandas dataframe from `vega_datasets` package and use it to create visualizations. But, if you use `altair`, you can simply pass the URL instead of the actual data. "
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "xk7zzU7j_G_X",
-        "outputId": "ea8d77bb-ca3c-430d-8cf0-d93cc127d53e"
-      },
+        "id": "zRw7i6Mc_G_W",
+        "outputId": "a0b7cb88-1f5e-404b-c5d0-f96bfb3211a1"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## A bit more histogram with altair\n",
+        "\n",
+        "As you may remember, you can get a pandas dataframe from `vega_datasets` package and use it to create visualizations. But, if you use `altair`, you can simply pass the URL instead of the actual data. "
+      ],
+      "metadata": {
+        "id": "f8SdTs86_G_W"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "vega_datasets.data.movies.url"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1881,50 +1875,50 @@
           },
           "execution_count": 53
         }
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "yd9bwymv_G_X"
-      },
+        "id": "xk7zzU7j_G_X",
+        "outputId": "ea8d77bb-ca3c-430d-8cf0-d93cc127d53e"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "# Choose based on your environment\n",
         "#alt.renderers.enable('notebook')\n",
         "#alt.renderers.enable('jupyterlab')\n",
         "#alt.renderers.enable('default')"
       ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "iin4Nh4__G_Y"
-      },
-      "source": [
-        "As mentioned before, in `altair` histogram is not special. It is just a plot that use bars (`mark_bar()`) where X axis is defined by `IMDB_Rating` with bins (`bin=True`), and Y axis is defined by `count()` aggregation function. "
-      ]
-    },
-    {
-      "cell_type": "code",
+      "outputs": [],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "8ydZKh85_G_Y",
-        "outputId": "5fa2974e-95c7-4995-9181-618f8b060bc6"
-      },
+        "id": "yd9bwymv_G_X"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "As mentioned before, in `altair` histogram is not special. It is just a plot that use bars (`mark_bar()`) where X axis is defined by `IMDB_Rating` with bins (`bin=True`), and Y axis is defined by `count()` aggregation function. "
+      ],
+      "metadata": {
+        "id": "iin4Nh4__G_Y"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "alt.Chart(vega_datasets.data.movies.url).mark_bar().encode(\n",
         "    alt.X(\"IMDB_Rating:Q\",  bin=True),\n",
         "    alt.Y('count()')\n",
         ")"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1970,33 +1964,33 @@
           },
           "execution_count": 56
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "kcVjz-lH_G_Y"
-      },
-      "source": [
-        "Have you noted that it is `IMDB_Rating:Q` not `IMDB_Rating`? This is a shorthand for"
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "Ml1DzJ2B_G_Z",
-        "outputId": "e6da7c73-b7c1-468b-8a70-38fb3605fafc"
-      },
+        "id": "8ydZKh85_G_Y",
+        "outputId": "5fa2974e-95c7-4995-9181-618f8b060bc6"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Have you noted that it is `IMDB_Rating:Q` not `IMDB_Rating`? This is a shorthand for"
+      ],
+      "metadata": {
+        "id": "kcVjz-lH_G_Y"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "alt.Chart(vega_datasets.data.movies.url).mark_bar().encode(\n",
         "    alt.X('IMDB_Rating', type='quantitative', bin=True),\n",
         "    alt.Y(aggregate='count', type='quantitative')\n",
         ")"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -2042,35 +2036,36 @@
           },
           "execution_count": 57
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "MXxEHGfq_G_Z"
-      },
-      "source": [
-        "In altair, you want to specify the data types using one of the four categories: quantitative, ordinal, nominal, and temporal. https://altair-viz.github.io/user_guide/encoding.html#data-types"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "HRJ4yICd_G_Z"
-      },
-      "source": [
-        "Although you can adjust the bins in `altair`, it does not encourage you to set the bins directly. For instance, although there is `step` parameter that directly sets the bin size, there are parameters such as `maxbins` (maximum number of bins) or `minstep` (minimum allowable step size), or `nice` (attemps to make the bin boundaries more human-friendly), that encourage you not to specify the bins directly. "
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "bQNAzAYV_G_a",
-        "outputId": "57623a8a-4140-4b2c-9eb8-8e2e67c5fb0d"
-      },
+        "id": "Ml1DzJ2B_G_Z",
+        "outputId": "e6da7c73-b7c1-468b-8a70-38fb3605fafc"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "In altair, you want to specify the data types using one of the four categories: quantitative, ordinal, nominal, and temporal. https://altair-viz.github.io/user_guide/encoding.html#data-types"
+      ],
+      "metadata": {
+        "id": "MXxEHGfq_G_Z"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Although you can adjust the bins in `altair`, it does not encourage you to set the bins directly. For instance, although there is `step` parameter that directly sets the bin size, there are parameters such as `maxbins` (maximum number of bins) or `minstep` (minimum allowable step size), or `nice` (attemps to make the bin boundaries more human-friendly), that encourage you not to specify the bins directly. "
+      ],
+      "metadata": {
+        "id": "HRJ4yICd_G_Z"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "from altair import Bin\n",
         "\n",
@@ -2079,7 +2074,6 @@
         "    alt.Y('count()')\n",
         ")"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -2127,24 +2121,24 @@
           },
           "execution_count": 58
         }
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "yxUmNvoq_G_a",
-        "outputId": "94ab02b4-9f6e-4096-db27-569968b244c8"
-      },
+        "id": "bQNAzAYV_G_a",
+        "outputId": "57623a8a-4140-4b2c-9eb8-8e2e67c5fb0d"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "alt.Chart(vega_datasets.data.movies.url).mark_bar().encode(\n",
         "    alt.X(\"IMDB_Rating:Q\",  bin=Bin(nice=True, maxbins=20)),\n",
         "    alt.Y('count()')\n",
         ")"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -2193,24 +2187,29 @@
           },
           "execution_count": 59
         }
-      ]
+      ],
+      "metadata": {
+        "jupyter": {
+          "outputs_hidden": false
+        },
+        "id": "yxUmNvoq_G_a",
+        "outputId": "94ab02b4-9f6e-4096-db27-569968b244c8"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "Ebeq7q_o_G_a"
-      },
       "source": [
         "### Composing charts in altair\n",
         "\n",
         "`altair` has a very nice way to compose multiple plots. Two histograms side by side? just do the following."
-      ]
+      ],
+      "metadata": {
+        "id": "Ebeq7q_o_G_a"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "id": "HKWFq9uH_G_b"
-      },
+      "execution_count": null,
       "source": [
         "chart1 = alt.Chart(vega_datasets.data.movies.url).mark_bar().encode(\n",
         "    alt.X(\"IMDB_Rating:Q\",  bin=Bin(step=0.1)),\n",
@@ -2227,22 +2226,17 @@
         "    height=150\n",
         ")"
       ],
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "metadata": {
+        "id": "HKWFq9uH_G_b"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "jupyter": {
-          "outputs_hidden": false
-        },
-        "id": "CKFX__1v_G_b",
-        "outputId": "3f00466a-6694-42c5-88f9-7dcc010aed5f"
-      },
+      "execution_count": null,
       "source": [
         "chart1 | chart2"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -2318,21 +2312,21 @@
           },
           "execution_count": 62
         }
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "6EddLDKT_G_b",
-        "outputId": "59f1f72f-db26-4a8e-f637-90cfa59c0e4b"
-      },
+        "id": "CKFX__1v_G_b",
+        "outputId": "3f00466a-6694-42c5-88f9-7dcc010aed5f"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "alt.hconcat(chart1, chart2)"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -2408,30 +2402,30 @@
           },
           "execution_count": 63
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "U9RjftBC_G_b"
-      },
-      "source": [
-        "Vertical commposition? "
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "Tv0T5fgc_G_c",
-        "outputId": "87b974b2-acb3-4186-d1da-5d3e89042241"
-      },
+        "id": "6EddLDKT_G_b",
+        "outputId": "59f1f72f-db26-4a8e-f637-90cfa59c0e4b"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Vertical commposition? "
+      ],
+      "metadata": {
+        "id": "U9RjftBC_G_b"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "alt.vconcat(chart1, chart2)"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -2507,21 +2501,21 @@
           },
           "execution_count": 71
         }
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "metadata": {
         "jupyter": {
           "outputs_hidden": false
         },
-        "id": "qNsN6uZt_G_c",
-        "outputId": "3a400b07-a3a3-4b10-cb2a-78a63f520103"
-      },
+        "id": "Tv0T5fgc_G_c",
+        "outputId": "87b974b2-acb3-4186-d1da-5d3e89042241"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "source": [
         "chart1 & chart2"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -2597,33 +2591,37 @@
           },
           "execution_count": 72
         }
-      ]
+      ],
+      "metadata": {
+        "jupyter": {
+          "outputs_hidden": false
+        },
+        "id": "qNsN6uZt_G_c",
+        "outputId": "3a400b07-a3a3-4b10-cb2a-78a63f520103"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "q64PqDaq_G_c"
-      },
       "source": [
         "Shall we avoid some repetitions? You can define a *base* empty chart first and then assign encodings later when you put together multiple charts together. Here is an example: https://altair-viz.github.io/user_guide/compound_charts.html#repeated-charts\n",
         "\n"
-      ]
+      ],
+      "metadata": {
+        "id": "q64PqDaq_G_c"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "8sacUYEF_G_d"
-      },
       "source": [
         "Use base chart to produce the chart above:"
-      ]
+      ],
+      "metadata": {
+        "id": "8sacUYEF_G_d"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "id": "8p4KLnHb_G_d",
-        "outputId": "6881b905-1fb6-4909-ffd4-80829ffe8326"
-      },
+      "execution_count": null,
       "source": [
         "base = alt.Chart().mark_bar().encode(\n",
         "    alt.X(\"IMDB_Rating:Q\",  bin=Bin(nice=True, maxbins=20)),\n",
@@ -2641,7 +2639,6 @@
         "\n",
         "chart"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -2722,30 +2719,27 @@
           },
           "execution_count": 75
         }
-      ]
+      ],
+      "metadata": {
+        "id": "8p4KLnHb_G_d",
+        "outputId": "6881b905-1fb6-4909-ffd4-80829ffe8326"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "fNks8h5J_G_d"
-      },
       "source": [
         "**Q: Using the base chart approach to create a 2x2 chart where the top row shows the two histograms of `IMDB_Rating` with `maxbins`=10 and 50 respectively, and the bottom row shows another two histograms of `IMDB_Votes` with `maxbins`=10 and 50.**"
-      ]
+      ],
+      "metadata": {
+        "id": "fNks8h5J_G_d"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "jupyter": {
-          "outputs_hidden": false
-        },
-        "id": "kQcK-33e_G_d",
-        "outputId": "37ac36d3-4a86-416c-f2e6-6b525b5651d9"
-      },
+      "execution_count": null,
       "source": [
         "# TODO\n"
       ],
-      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -2861,7 +2855,14 @@
           },
           "execution_count": 76
         }
-      ]
+      ],
+      "metadata": {
+        "jupyter": {
+          "outputs_hidden": false
+        },
+        "id": "kQcK-33e_G_d",
+        "outputId": "37ac36d3-4a86-416c-f2e6-6b525b5651d9"
+      }
     }
   ]
 }

--- a/m08-histogram/m08-lab.ipynb
+++ b/m08-histogram/m08-lab.ipynb
@@ -1401,14 +1401,17 @@
         "movies['IMDB_Rating'].hist(bins=nbins)\n",
         "\n",
         "# Freedman-Diaconis\n",
-        "iqr = np.percentile(movies['IMDB_Rating'], 75) - np.percentile(movies['IMDB_Rating'], 25)\n",
-        "width = 2*iqr/np.power(N, 1/3)\n",
-        "nbins = int((max(movies['IMDB_Rating']) - min(movies['IMDB_Rating'])) / width)\n",
+        "# TODO: If below code gives ValueError with NaN, then there are still missing values in IMDB_Rating and you must remove it.\n",
+        "try:\n",
+        "    iqr = np.percentile(movies['IMDB_Rating'], 75) - np.percentile(movies['IMDB_Rating'], 25)\n",
+        "    width = 2*iqr/np.power(N, 1/3)\n",
+        "    nbins = int((max(movies['IMDB_Rating']) - min(movies['IMDB_Rating'])) / width)\n",
         "\n",
-        "plt.subplot(1,3,3)\n",
-        "plt.title(\"F-D, {} bins\".format(nbins))\n",
-        "movies['IMDB_Rating'].hist(bins=nbins)\n",
-        "\n"
+        "    plt.subplot(1,3,3)\n",
+        "    plt.title(\"F-D, {} bins\".format(nbins))\n",
+        "    movies['IMDB_Rating'].hist(bins=nbins)\n",
+        "except ValueError as e:\n",
+        "    print(\"Resulted in ValueError:\", str(e))"
       ],
       "outputs": [
         {

--- a/m08-histogram/m08-lab.ipynb
+++ b/m08-histogram/m08-lab.ipynb
@@ -522,7 +522,10 @@
       "cell_type": "code",
       "execution_count": null,
       "source": [
-        "plt.hist(movies['IMDB_Rating'])"
+        "try:\n",
+        "    plt.hist(movies['IMDB_Rating'])\n",
+        "except KeyError as e:\n",
+        "    print(\"movies has given KeyError: \", str(e))"
       ],
       "outputs": [
         {


### PR DESCRIPTION
Professor @yy, I have changed `m08-histogram/m08-lab.ipynb` in order to resolve workflow failures for it. Below are the reasons:

- Added dummy value placeholders for `n_raw`, `bins_raw`, `patches`.
- In Movies dataset in `vega_datasets` package, the key is `"IMDB_Rating"` for 0.9.0 version and higher. But the key is `"IMDB Rating"` for lower than 0.9.0 versions.
- Although `np.histogram()` and `plt.hist()` does same but internal implementation is not same. `np.histogram()` uses `np.max()` internally which doesn't handle `NaN` values whereas `plt.hist()` uses `np.nanmax()` internally which handles missing values. Same is true for `np.min()`->`np.nanmin()` as well. Because of that `np.histogram()` was failing

All Errors for `m08-histogram` are resolved.