### PR TITLE
GitHub Workflow to check broken links

### DIFF
--- a/.github/workflows/test_links.yml
+++ b/.github/workflows/test_links.yml
@@ -5,12 +5,12 @@ on:
     branches:
     - master
     paths:
-    - '**/*.md'
+    - '**/**.md'
   pull_request:
     branches:
     - master
     paths:
-    - '**/*.md'
+    - '**/**.md'
   schedule:
   # Run every Monday at 9AM EST (1PM UTC)
   - cron: "0 13 * * 1"

--- a/.github/workflows/test_links.yml
+++ b/.github/workflows/test_links.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - test_links
     paths:
     - '**/**.md'
   pull_request:

--- a/.github/workflows/test_links.yml
+++ b/.github/workflows/test_links.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - master
-    - test_links
     paths:
     - '**/**.md'
   pull_request:

--- a/.github/workflows/test_links.yml
+++ b/.github/workflows/test_links.yml
@@ -1,0 +1,20 @@
+name: check_link_broken
+
+on:
+  push
+  pull_request:
+    branches:
+    - master
+    paths:
+    - '**/*.md'
+  schedule:
+  # Run every Monday at 9AM EST (1PM UTC)
+  - cron: "0 13 * * 1"
+
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/test_links.yml
+++ b/.github/workflows/test_links.yml
@@ -2,14 +2,14 @@ name: check_link_broken
 
 on:
   push
-  pull_request:
-    branches:
-    - master
-    paths:
-    - '**/*.md'
-  schedule:
-  # Run every Monday at 9AM EST (1PM UTC)
-  - cron: "0 13 * * 1"
+  # pull_request:
+  #   branches:
+  #   - master
+  #   paths:
+  #   - '**/*.md'
+  # schedule:
+  # # Run every Monday at 9AM EST (1PM UTC)
+  # - cron: "0 13 * * 1"
 
 
 jobs:

--- a/.github/workflows/test_links.yml
+++ b/.github/workflows/test_links.yml
@@ -1,15 +1,19 @@
 name: check_link_broken
 
 on:
-  push
-  # pull_request:
-  #   branches:
-  #   - master
-  #   paths:
-  #   - '**/*.md'
-  # schedule:
-  # # Run every Monday at 9AM EST (1PM UTC)
-  # - cron: "0 13 * * 1"
+  push:
+    branches:
+    - master
+    paths:
+    - '**/*.md'
+  pull_request:
+    branches:
+    - master
+    paths:
+    - '**/*.md'
+  schedule:
+  # Run every Monday at 9AM EST (1PM UTC)
+  - cron: "0 13 * * 1"
 
 
 jobs:

--- a/m01-intro/class.md
+++ b/m01-intro/class.md
@@ -1,5 +1,5 @@
 # Why Visualizations?
-# Test commit
+
 # Further readings
 
 - [Self assessment questions](http://bit.ly/dvizselfassess)

--- a/m01-intro/class.md
+++ b/m01-intro/class.md
@@ -1,5 +1,5 @@
 # Why Visualizations?
-
+# Test Commit
 # Further readings
 
 - [Self assessment questions](http://bit.ly/dvizselfassess)

--- a/m01-intro/class.md
+++ b/m01-intro/class.md
@@ -1,5 +1,5 @@
 # Why Visualizations?
-# Test Commit
+
 # Further readings
 
 - [Self assessment questions](http://bit.ly/dvizselfassess)

--- a/m01-intro/class.md
+++ b/m01-intro/class.md
@@ -1,5 +1,5 @@
 # Why Visualizations?
-
+# Test commit
 # Further readings
 
 - [Self assessment questions](http://bit.ly/dvizselfassess)


### PR DESCRIPTION
Professor @yy, I have configured a new workflow for checking for the broken links in the repository. This PR will address the issue #54.

```
on:
  push:
    branches:
    - master
    paths:
    - '**/**.md'
  pull_request:
    branches:
    - master
    paths:
    - '**/**.md'
  schedule:
  # Run every Monday at 9AM EST (1PM UTC)
  - cron: "0 13 * * 1"
```

Based on the above workflow code, you can see that it will not be an overhead for the repository. The workflow will only run when:
- Anyone pushes to the `master` branch and the commit contains edit in any `.md` file.
- Pull request is raised (to the `master` branch) and the changed file includes at least one `.md` file.
- This workflow is scheduled to run every Monday 9AM EST (1PM UTC). It will help us in case nobody pushes any code to the repository for very long time.

