### PR TITLE
Change parameter in assignment instructions

### DIFF
--- a/m09-estimation/m09-lab.ipynb
+++ b/m09-estimation/m09-lab.ipynb
@@ -2070,7 +2070,7 @@
       ],
       "source": [
         "cmap = \"Reds\"\n",
-        "shade = True         # what happens if you change this?\n",
+        "fill = True         # what happens if you change this?\n",
         "thresh = 0           # what happens if you change this?\n",
         "\n",
         "# TODO: implement \n"


### PR DESCRIPTION
The assignment suggested varying the "shade" parameter, but "shade" is deprecated in seaborn. The equivalent parameter is now "fill", so I changed this in the instruction code. 